### PR TITLE
fix python version bug

### DIFF
--- a/paconvert/transformer/tensor_requires_grad_transformer.py
+++ b/paconvert/transformer/tensor_requires_grad_transformer.py
@@ -39,20 +39,21 @@ class TensorRequiresGradTransformer(BaseTransformer):
 
     def visit_Assign(self, node):
         # left value
-        if(isinstance(node.targets[0], ast.Attribute)):
-            if node.targets[0].attr == 'requires_grad':
-                node.targets[0].attr = 'stop_gradient'
-                node = ast.Assign(targets=[node.targets[0]], value = ast.UnaryOp(ast.Not(), operand = node.value))
+        if (isinstance(node, (ast.Assign))):
+            if(isinstance(node.targets[0], ast.Attribute)):
+                if node.targets[0].attr == 'requires_grad':
+                    node.targets[0].attr = 'stop_gradient'
+                    node = ast.Assign(targets=[node.targets[0]], value = ast.UnaryOp(ast.Not(), operand = node.value))
 
-        elif(isinstance(node.targets[0], ast.Tuple)):
-            for j in range(len(node.targets[0].dims)):
-                if (isinstance(node.targets[0].elts[j], ast.Attribute) and  (node.targets[0].elts[j].attr == 'requires_grad')):
-                    new_node = ast.Name(id='temp', ctx=ast.Load())
-                    node.targets[0].elts[j].attr ='stop_gradient'
-                    assign_node = ast.Assign(targets=[node.targets[0].elts[j]], value = ast.UnaryOp(ast.Not(), operand = new_node))
-                    node.targets[0].elts[j] = new_node
-                    index = self.parent_node.body.index(node)
-                    self.insert_nodes_list.append((self.parent_node, index, assign_node))
+            elif(isinstance(node.targets[0], ast.Tuple)):
+                for j in range(len(node.targets[0].dims)):
+                    if (isinstance(node.targets[0].elts[j], ast.Attribute) and  (node.targets[0].elts[j].attr == 'requires_grad')):
+                        new_node = ast.Name(id='temp', ctx=ast.Load())
+                        node.targets[0].elts[j].attr ='stop_gradient'
+                        assign_node = ast.Assign(targets=[node.targets[0].elts[j]], value = ast.UnaryOp(ast.Not(), operand = new_node))
+                        node.targets[0].elts[j] = new_node
+                        index = self.parent_node.body.index(node)
+                        self.insert_nodes_list.append((self.parent_node, index, assign_node))
     
         return node
 

--- a/paconvert/transformer/tensor_requires_grad_transformer.py
+++ b/paconvert/transformer/tensor_requires_grad_transformer.py
@@ -46,7 +46,7 @@ class TensorRequiresGradTransformer(BaseTransformer):
                     node = ast.Assign(targets=[node.targets[0]], value = ast.UnaryOp(ast.Not(), operand = node.value))
 
             elif(isinstance(node.targets[0], ast.Tuple)):
-                for j in range(len(node.targets[0].dims)):
+                for j in range(len(node.targets[0].elts)):
                     if (isinstance(node.targets[0].elts[j], ast.Attribute) and  (node.targets[0].elts[j].attr == 'requires_grad')):
                         new_node = ast.Name(id='temp', ctx=ast.Load())
                         node.targets[0].elts[j].attr ='stop_gradient'


### PR DESCRIPTION
1. 这里3.8版本的python 对应的astor是visit_Assign遍历的不只是赋值语句节点还有其它类型以及这里astor的ast.Tuple没有dims属性，这是和3.9以上版本不一致的地方，对着修改就行
2. 其它
这里说一下上面paddle_api不是多余的
![image](https://user-images.githubusercontent.com/129241980/231124571-dec42689-02c2-425a-afbc-70b04c344908.png)
可以看到
![image](https://user-images.githubusercontent.com/129241980/231124686-c2e674c2-fcbb-4dc0-89ab-f405ece3e72e.png)
