### PR TITLE
[pre-commit] update pre-commit `json format check` rule to sort APIs

### DIFF
--- a/paconvert/api_alias_mapping.json
+++ b/paconvert/api_alias_mapping.json
@@ -1,11 +1,11 @@
 {
   "torch.nn.modules.GroupNorm": "torch.nn.GroupNorm",
-  "torch.nn.parameter.Parameter": "torch.nn.Parameter",
   "torch.nn.modules.activation.ReLU": "torch.nn.ReLU",
   "torch.nn.modules.conv.Conv2d": "torch.nn.Conv2d",
-  "torch.utils.data.sampler.BatchSampler": "torch.utils.data.BatchSampler",
   "torch.nn.modules.module.Module": "torch.nn.Module",
+  "torch.nn.parameter.Parameter": "torch.nn.Parameter",
+  "torch.utils.data.sampler.BatchSampler": "torch.utils.data.BatchSampler",
   "torch.utils.data.sampler.RandomSampler": "torch.utils.data.RandomSampler",
-  "torch.utils.data.sampler.SequentialSampler": "torch.utils.data.SequentialSampler",
-  "torch.utils.data.sampler.Sampler": "torch.utils.data.Sampler"
+  "torch.utils.data.sampler.Sampler": "torch.utils.data.Sampler",
+  "torch.utils.data.sampler.SequentialSampler": "torch.utils.data.SequentialSampler"
 }

--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -1,241 +1,2370 @@
 {
-  "torch.nn.functional.log_softmax": {
-    "paddle_api": "paddle.nn.functional.log_softmax",
+  "torch.FloatTensor": {
+    "Matcher": "TensorMatcher",
+    "paddle_api": "paddle.Tensor"
+  },
+  "torch.Generator": {
+    "Matcher": "GeneratorMatcher",
     "args_list": [
-      "input",
+      "device"
+    ]
+  },
+  "torch.IntTensor": {
+    "Matcher": "TensorMatcher",
+    "paddle_api": "paddle.Tensor"
+  },
+  "torch.LongTensor": {
+    "Matcher": "TensorMatcher",
+    "paddle_api": "paddle.Tensor"
+  },
+  "torch.Size": {
+    "Matcher": "SizeMatcher",
+    "paddle_api": "list",
+    "args_list": []
+  },
+  "torch.Tensor": {
+    "Matcher": "TensorMatcher",
+    "paddle_api": "paddle.Tensor"
+  },
+  "torch.Tensor.abs": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.abs_": {},
+  "torch.Tensor.absolute": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.abs"
+  },
+  "torch.Tensor.absolute_": {},
+  "torch.Tensor.acos": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.acos"
+  },
+  "torch.Tensor.acos_": {},
+  "torch.Tensor.acosh": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.acosh"
+  },
+  "torch.Tensor.acosh_": {},
+  "torch.Tensor.add": {
+    "Matcher": "TensorAddMatcher",
+    "args_list": [
+      "other",
+      "alpha"
+    ]
+  },
+  "torch.Tensor.add_": {},
+  "torch.Tensor.addbmm": {
+    "Matcher": "AddBmmMatcher",
+    "args_list": [
+      "batch1",
+      "batch2",
+      "beta",
+      "alpha"
+    ]
+  },
+  "torch.Tensor.addbmm_": {},
+  "torch.Tensor.addcdiv": {
+    "Matcher": "AddCDivMatcher",
+    "args_list": [
+      "tensor1",
+      "tensor2",
+      "value"
+    ]
+  },
+  "torch.Tensor.addcdiv_": {},
+  "torch.Tensor.addcmul": {
+    "Matcher": "AddCMulMatcher",
+    "args_list": [
+      "tensor1",
+      "tensor2",
+      "value"
+    ]
+  },
+  "torch.Tensor.addcmul_": {},
+  "torch.Tensor.addmm": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.addmm",
+    "args_list": [
+      "mat1",
+      "mat2",
+      "alpha",
+      "beta"
+    ],
+    "kwargs_change": {
+      "mat1": "x",
+      "mat2": "y"
+    }
+  },
+  "torch.Tensor.addmm_": {},
+  "torch.Tensor.addmv": {
+    "Matcher": "AddMRMatcher",
+    "paddle_api": "paddle.mm",
+    "args_list": [
+      "mat",
+      "vec",
+      "beta",
+      "alpha"
+    ]
+  },
+  "torch.Tensor.addmv_": {},
+  "torch.Tensor.addr": {
+    "Matcher": "AddMRMatcher",
+    "paddle_api": "paddle.outer",
+    "args_list": [
+      "vec1",
+      "vec2",
+      "beta",
+      "alpha"
+    ]
+  },
+  "torch.Tensor.addr_": {},
+  "torch.Tensor.adjoint": {
+    "Matcher": "AdjointMatcher"
+  },
+  "torch.Tensor.align_as": {},
+  "torch.Tensor.align_to": {},
+  "torch.Tensor.all": {
+    "Matcher": "TensorToBoolMatcher",
+    "paddle_api": "paddle.Tensor.all",
+    "args_list": [
       "dim",
-      "dtype",
-      "_stacklevel"
+      "keepdim"
     ],
     "kwargs_change": {
-      "input": "x",
-      "dim": "axis",
-      "_stacklevel": ""
+      "dim": "axis"
     }
   },
-  "torch.backends.cudnn.deterministic": {
-    "Matcher": "DeleteMatcher"
-  },
-  "torch.backends.cudnn.benchmark": {
-    "Matcher": "DeleteMatcher"
-  },
-  "torch.permute": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.transpose",
+  "torch.Tensor.allclose": {
+    "Matcher": "AllcloseMatcher",
+    "paddle_api": "paddle.Tensor.allclose",
     "args_list": [
-      "input",
-      "dims"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dims": "perm"
-    }
-  },
-  "torch.nn.Identity": {
-    "Matcher": "IdentityMatcher",
-    "paddle_api": "paddle.nn.Identity"
-  },
-  "torch.linalg.eigvals": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.linalg.eigvals",
-    "args_list": [
-      "input",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.linalg.matmul": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.matmul",
-    "args_list": [
-      "input",
       "other",
-      "out"
+      "rtol",
+      "atol",
+      "equal_nan"
     ],
     "kwargs_change": {
-      "input": "x",
       "other": "y"
     }
   },
-  "torch.clamp": {
+  "torch.Tensor.amax": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.clip",
+    "paddle_api": "paddle.Tensor.amax",
     "args_list": [
-      "input",
-      "min",
-      "max",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.clamp_min": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.clip",
-    "args_list": [
-      "input",
-      "min",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.max": {
-    "Matcher": "MaxMinMatcher",
-    "paddle_api": "paddle.maximum",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "other": "y"
-    }
-  },
-  "torch.min": {
-    "Matcher": "MaxMinMatcher",
-    "paddle_api": "paddle.minimum",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "other": "y"
-    }
-  },
-  "torch.gather": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.take_along_axis",
-    "args_list": [
-      "input",
       "dim",
-      "index",
-      "sparse_grad",
-      "out"
+      "keepdim"
     ],
     "kwargs_change": {
-      "input": "arr",
-      "dim": "axis",
-      "index": "indices",
-      "sparse_grad": ""
+      "dim": "axis"
     }
   },
-  "torch.softmax": {
+  "torch.Tensor.amin": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.softmax",
+    "paddle_api": "paddle.Tensor.amin",
     "args_list": [
-      "input",
+      "dim",
+      "keepdim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.aminmax": {
+    "Matcher": "AMinMaxMatcher",
+    "args_list": [
+      "dim",
+      "keepdim"
+    ]
+  },
+  "torch.Tensor.angle": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.angle"
+  },
+  "torch.Tensor.any": {
+    "Matcher": "TensorToBoolMatcher",
+    "paddle_api": "paddle.Tensor.any",
+    "args_list": [
+      "dim",
+      "keepdim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.apply_": {},
+  "torch.Tensor.arccos": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.acos"
+  },
+  "torch.Tensor.arccos_": {},
+  "torch.Tensor.arccosh": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.acosh"
+  },
+  "torch.Tensor.arccosh_": {},
+  "torch.Tensor.arcsin": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.arcsin_": {},
+  "torch.Tensor.arcsinh": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.arcsinh_": {},
+  "torch.Tensor.arctan": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.arctan2": {
+    "Matcher": "TensorFunc2PaddleFunc",
+    "paddle_api": "paddle.atan2",
+    "args_list": [
+      "other"
+    ],
+    "kwargs_change": {
+      "other": "y"
+    }
+  },
+  "torch.Tensor.arctan2_": {},
+  "torch.Tensor.arctan_": {},
+  "torch.Tensor.arctanh": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.arctanh_": {},
+  "torch.Tensor.argmax": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.argmax",
+    "args_list": [
+      "dim",
+      "keepdim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.argmin": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.argmin",
+    "args_list": [
+      "dim",
+      "keepdim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.argsort": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.argsort",
+    "args_list": [
+      "dim",
+      "descending"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.argwhere": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.nonzero"
+  },
+  "torch.Tensor.as_strided": {},
+  "torch.Tensor.as_subclass": {},
+  "torch.Tensor.asin": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.asin"
+  },
+  "torch.Tensor.asin_": {},
+  "torch.Tensor.asinh": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.asinh"
+  },
+  "torch.Tensor.asinh_": {},
+  "torch.Tensor.atan": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.atan"
+  },
+  "torch.Tensor.atan2": {
+    "Matcher": "TensorFunc2PaddleFunc",
+    "paddle_api": "paddle.atan2",
+    "args_list": [
+      "other"
+    ],
+    "kwargs_change": {
+      "other": "y"
+    }
+  },
+  "torch.Tensor.atan2_": {},
+  "torch.Tensor.atan_": {},
+  "torch.Tensor.atanh": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.atanh"
+  },
+  "torch.Tensor.atanh_": {},
+  "torch.Tensor.backward": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.backward",
+    "args_list": [
+      "gradient",
+      "retain_graph",
+      "create_graph",
+      "input"
+    ],
+    "kwargs_change": {
+      "gradient": "grad_tensor"
+    },
+    "unsupport_args": [
+      "create_graph",
+      "input"
+    ]
+  },
+  "torch.Tensor.baddbmm": {
+    "Matcher": "AddMRMatcher",
+    "paddle_api": "paddle.bmm",
+    "args_list": [
+      "batch1",
+      "batch2",
+      "alpha",
+      "beta"
+    ]
+  },
+  "torch.Tensor.baddbmm_": {},
+  "torch.Tensor.bernoulli": {},
+  "torch.Tensor.bernoulli_": {
+    "Matcher": "TensorBernoulli_Matcher",
+    "args_list": [
+      "p",
+      "generator"
+    ]
+  },
+  "torch.Tensor.bfloat16": {
+    "Matcher": "TensorBF16Matcher",
+    "args_list": [
+      "memory_format"
+    ]
+  },
+  "torch.Tensor.bincount": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.bincount",
+    "args_list": [
+      "weights",
+      "minlength"
+    ]
+  },
+  "torch.Tensor.bitwise_and": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.bitwise_and",
+    "args_list": [
+      "other"
+    ],
+    "kwargs_change": {
+      "other": "y"
+    }
+  },
+  "torch.Tensor.bitwise_and_": {},
+  "torch.Tensor.bitwise_left_shift": {},
+  "torch.Tensor.bitwise_left_shift_": {},
+  "torch.Tensor.bitwise_not": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.bitwise_not"
+  },
+  "torch.Tensor.bitwise_not_": {},
+  "torch.Tensor.bitwise_or": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.bitwise_or",
+    "args_list": [
+      "other"
+    ],
+    "kwargs_change": {
+      "other": "y"
+    }
+  },
+  "torch.Tensor.bitwise_or_": {},
+  "torch.Tensor.bitwise_right_shift": {},
+  "torch.Tensor.bitwise_right_shift_": {},
+  "torch.Tensor.bitwise_xor": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.bitwise_xor",
+    "args_list": [
+      "other"
+    ],
+    "kwargs_change": {
+      "other": "y"
+    }
+  },
+  "torch.Tensor.bitwise_xor_": {},
+  "torch.Tensor.bmm": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.bmm",
+    "args_list": [
+      "mat2"
+    ],
+    "kwargs_change": {
+      "mat2": "y"
+    }
+  },
+  "torch.Tensor.bool": {
+    "Matcher": "TensorBoolMatcher",
+    "args_list": [
+      "memory_format"
+    ]
+  },
+  "torch.Tensor.broadcast_to": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.broadcast_to",
+    "args_list": [
+      "size"
+    ],
+    "kwargs_change": {
+      "size": "shape"
+    }
+  },
+  "torch.Tensor.byte": {
+    "Matcher": "TensorByteMatcher",
+    "args_list": [
+      "memory_format"
+    ]
+  },
+  "torch.Tensor.cauchy_": {},
+  "torch.Tensor.cdouble": {
+    "Matcher": "TensorCdoubleMatcher",
+    "args_list": [
+      "memory_format"
+    ]
+  },
+  "torch.Tensor.ceil": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.ceil_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.ceil_"
+  },
+  "torch.Tensor.cfloat": {
+    "Matcher": "TensorCfloatMatcher",
+    "args_list": [
+      "memory_format"
+    ]
+  },
+  "torch.Tensor.chalf": {},
+  "torch.Tensor.char": {
+    "Matcher": "TensorCharMatcher",
+    "args_list": [
+      "memory_format"
+    ]
+  },
+  "torch.Tensor.cholesky": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.cholesky",
+    "args_list": [
+      "upper"
+    ]
+  },
+  "torch.Tensor.cholesky_inverse": {
+    "Matcher": "CholeskyInverseMatcher",
+    "args_list": [
+      "upper"
+    ]
+  },
+  "torch.Tensor.cholesky_solve": {},
+  "torch.Tensor.chunk": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.chunk",
+    "args_list": [
+      "chunks",
+      "dim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.clamp": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.clip",
+    "args_list": [
+      "min",
+      "max"
+    ]
+  },
+  "torch.Tensor.clamp_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.clip_",
+    "args_list": [
+      "min",
+      "max"
+    ]
+  },
+  "torch.Tensor.clip": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.clip_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.clip_",
+    "args_list": [
+      "min",
+      "max"
+    ]
+  },
+  "torch.Tensor.clone": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.clone",
+    "args_list": [
+      "memory_format"
+    ]
+  },
+  "torch.Tensor.coalesce": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.coalesce"
+  },
+  "torch.Tensor.conj": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.conj_physical": {},
+  "torch.Tensor.conj_physical_": {},
+  "torch.Tensor.contiguous": {
+    "Matcher": "TensorSkipMatcher"
+  },
+  "torch.Tensor.copy_": {
+    "Matcher": "TensorCopyMatcher",
+    "args_list": [
+      "src",
+      "non_blocking"
+    ]
+  },
+  "torch.Tensor.copysign": {},
+  "torch.Tensor.copysign_": {},
+  "torch.Tensor.corrcoef": {},
+  "torch.Tensor.cos": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.cos"
+  },
+  "torch.Tensor.cos_": {},
+  "torch.Tensor.cosh": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.cosh"
+  },
+  "torch.Tensor.cosh_": {},
+  "torch.Tensor.count_nonzero": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.count_nonzero",
+    "args_list": [
+      "dim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.cov": {
+    "Matcher": "CovMatcher",
+    "args_list": [
+      "correction",
+      "fweight",
+      "aweight"
+    ]
+  },
+  "torch.Tensor.cpu": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.cpu"
+  },
+  "torch.Tensor.cross": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.cross",
+    "args_list": [
+      "other",
+      "dim"
+    ],
+    "kwargs_change": {
+      "other": "y",
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.cuda": {
+    "Matcher": "TensorSkipMatcher",
+    "args_list": [
+      "device",
+      "non_blocking",
+      "memory_format"
+    ]
+  },
+  "torch.Tensor.cummax": {},
+  "torch.Tensor.cummin": {},
+  "torch.Tensor.cumprod": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.cumprod_": {},
+  "torch.Tensor.cumsum": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.cumsum",
+    "args_list": [
       "dim",
       "dtype"
     ],
     "kwargs_change": {
-      "input": "x",
       "dim": "axis"
     }
   },
-  "torch.sort": {
-    "Matcher": "SortMatcher",
-    "paddle_api": "paddle.sort",
+  "torch.Tensor.cumsum_": {},
+  "torch.Tensor.data_ptr": {},
+  "torch.Tensor.deg2rad": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.dense_dim": {},
+  "torch.Tensor.dequantize": {},
+  "torch.Tensor.det": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.det"
+  },
+  "torch.Tensor.detach": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.detach"
+  },
+  "torch.Tensor.detach_": {},
+  "torch.Tensor.diag": {
+    "Matcher": "TensorDiagMatcher",
     "args_list": [
-      "input",
+      "diagonal"
+    ]
+  },
+  "torch.Tensor.diag_embed": {
+    "Matcher": "TensorFunc2PaddleFunc",
+    "paddle_api": "paddle.nn.functional.diag_embed",
+    "args_list": [
+      "offset",
+      "dim1",
+      "dim2"
+    ]
+  },
+  "torch.Tensor.diagflat": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.diagflat"
+  },
+  "torch.Tensor.diagonal": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.diagonal",
+    "args_list": [
+      "offset",
+      "dim1",
+      "dim2"
+    ],
+    "kwargs_change": {
+      "dim1": "axis1",
+      "dim2": "axis2"
+    }
+  },
+  "torch.Tensor.diagonal_scatter": {},
+  "torch.Tensor.diff": {
+    "Matcher": "DiffMatcher",
+    "paddle_api": "paddle.Tensor.diff",
+    "args_list": [
+      "n",
       "dim",
-      "descending",
-      "stable",
-      "out"
+      "prepend",
+      "append"
     ],
     "kwargs_change": {
-      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.digamma": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.digamma"
+  },
+  "torch.Tensor.digamma_": {},
+  "torch.Tensor.dim": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.dim"
+  },
+  "torch.Tensor.dist": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.dist",
+    "args_list": [
+      "other",
+      "p"
+    ],
+    "kwargs_change": {
+      "other": "y"
+    }
+  },
+  "torch.Tensor.div": {
+    "Matcher": "DivMatcher",
+    "args_list": [
+      "other",
+      "rounding_mode"
+    ]
+  },
+  "torch.Tensor.div_": {},
+  "torch.Tensor.divide": {
+    "Matcher": "DivMatcher",
+    "args_list": [
+      "other",
+      "rounding_mode"
+    ]
+  },
+  "torch.Tensor.divide_": {},
+  "torch.Tensor.dot": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.dot",
+    "args_list": [
+      "tensor"
+    ],
+    "kwargs_change": {
+      "tensor": "y"
+    }
+  },
+  "torch.Tensor.double": {
+    "Matcher": "TensorDoubleMatcher",
+    "args_list": [
+      "memory_format"
+    ]
+  },
+  "torch.Tensor.dsplit": {},
+  "torch.Tensor.eig": {},
+  "torch.Tensor.element_size": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.element_size"
+  },
+  "torch.Tensor.eq": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.equal",
+    "args_list": [
+      "other"
+    ],
+    "kwargs_change": {
+      "other": "y"
+    }
+  },
+  "torch.Tensor.eq_": {},
+  "torch.Tensor.equal": {
+    "Matcher": "EqualMatcher",
+    "paddle_api": "paddle.Tensor.equal_all",
+    "args_list": [
+      "other"
+    ],
+    "kwargs_change": {
+      "other": "y"
+    }
+  },
+  "torch.Tensor.erf": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.erf"
+  },
+  "torch.Tensor.erf_": {},
+  "torch.Tensor.erfc": {
+    "Matcher": "ErfCMatcher"
+  },
+  "torch.Tensor.erfc_": {},
+  "torch.Tensor.erfinv": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.erfinv"
+  },
+  "torch.Tensor.erfinv_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.erfinv_"
+  },
+  "torch.Tensor.exp": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.exp"
+  },
+  "torch.Tensor.exp_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.exp_"
+  },
+  "torch.Tensor.expand": {
+    "Matcher": "TensorExpandMatcher",
+    "paddle_api": "paddle.Tensor.expand"
+  },
+  "torch.Tensor.expand_as": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.expand_as",
+    "args_list": [
+      "other"
+    ],
+    "kwargs_change": {
+      "other": "y"
+    }
+  },
+  "torch.Tensor.expm1": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.expm1_": {},
+  "torch.Tensor.exponential_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.exponential_",
+    "args_list": [
+      "lambd",
+      "generator"
+    ],
+    "kwargs_change": {
+      "lambd": "lam"
+    }
+  },
+  "torch.Tensor.fill_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.fill_",
+    "args_list": [
+      "value"
+    ]
+  },
+  "torch.Tensor.fill_diagonal_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.fill_diagonal_",
+    "args_list": [
+      "fill_value",
+      "wrap"
+    ],
+    "kwargs_change": {
+      "fill_value": "value"
+    }
+  },
+  "torch.Tensor.fix": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.trunc"
+  },
+  "torch.Tensor.fix_": {},
+  "torch.Tensor.flatten": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.flatten",
+    "args_list": [
+      "start_dim",
+      "end_dim"
+    ],
+    "kwargs_change": {
+      "start_dim": "start_axis",
+      "end_dim": "stop_axis"
+    }
+  },
+  "torch.Tensor.flip": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.flip",
+    "args_list": [
+      "dims"
+    ],
+    "kwargs_change": {
+      "dims": "axis"
+    }
+  },
+  "torch.Tensor.fliplr": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.flip",
+    "paddle_default_kwargs": {
+      "axis": 1
+    }
+  },
+  "torch.Tensor.flipud": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.flip",
+    "paddle_default_kwargs": {
+      "axis": 0
+    }
+  },
+  "torch.Tensor.float": {
+    "Matcher": "TensorFloatMatcher",
+    "args_list": [
+      "memory_format"
+    ]
+  },
+  "torch.Tensor.float_power": {},
+  "torch.Tensor.float_power_": {},
+  "torch.Tensor.floor": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.floor_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.floor_"
+  },
+  "torch.Tensor.floor_divide": {
+    "Matcher": "Num2TensorBinaryMatcher",
+    "paddle_api": "paddle.Tensor.floor_divide",
+    "args_list": [
+      "other"
+    ]
+  },
+  "torch.Tensor.floor_divide_": {},
+  "torch.Tensor.fmax": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.fmax",
+    "args_list": [
+      "other"
+    ],
+    "kwargs_change": {
+      "other": "y"
+    }
+  },
+  "torch.Tensor.fmin": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.fmin",
+    "args_list": [
+      "other"
+    ],
+    "kwargs_change": {
+      "other": "y"
+    }
+  },
+  "torch.Tensor.fmod": {
+    "Matcher": "Num2TensorBinaryMatcher",
+    "paddle_api": "paddle.Tensor.mod",
+    "args_list": [
+      "other"
+    ],
+    "kwargs_change": {
+      "other": "y"
+    }
+  },
+  "torch.Tensor.fmod_": {},
+  "torch.Tensor.frac": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.frac"
+  },
+  "torch.Tensor.frac_": {},
+  "torch.Tensor.frexp": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.frexp"
+  },
+  "torch.Tensor.gather": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.take_along_axis",
+    "args_list": [
+      "dim",
+      "index"
+    ],
+    "kwargs_change": {
       "dim": "axis",
-      "stable": ""
+      "index": "indices"
     }
   },
-  "torch.sgn": {
+  "torch.Tensor.gcd": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.sgn",
+    "paddle_api": "paddle.Tensor.gcd",
     "args_list": [
-      "input",
-      "out"
+      "other"
     ],
     "kwargs_change": {
-      "input": "x"
+      "other": "y"
     }
   },
-  "torch.sub": {
-    "Matcher": "SubMatcher",
+  "torch.Tensor.gcd_": {},
+  "torch.Tensor.ge": {
+    "Matcher": "Num2TensorBinaryMatcher",
+    "paddle_api": "paddle.Tensor.greater_equal",
     "args_list": [
-      "input",
+      "other"
+    ]
+  },
+  "torch.Tensor.ge_": {},
+  "torch.Tensor.geometric_": {},
+  "torch.Tensor.geqrf": {},
+  "torch.Tensor.ger": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.outer",
+    "args_list": [
+      "vec2"
+    ],
+    "kwargs_change": {
+      "vec2": "y"
+    }
+  },
+  "torch.Tensor.get_device": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.device.get_device"
+  },
+  "torch.Tensor.greater": {
+    "Matcher": "Num2TensorBinaryMatcher",
+    "paddle_api": "paddle.Tensor.greater_than",
+    "args_list": [
+      "other"
+    ]
+  },
+  "torch.Tensor.greater_": {},
+  "torch.Tensor.greater_equal": {
+    "Matcher": "Num2TensorBinaryMatcher",
+    "paddle_api": "paddle.Tensor.greater_equal",
+    "args_list": [
+      "other"
+    ],
+    "kwargs_change": {
+      "other": "y"
+    }
+  },
+  "torch.Tensor.greater_equal_": {},
+  "torch.Tensor.gt": {
+    "Matcher": "Num2TensorBinaryMatcher",
+    "paddle_api": "paddle.Tensor.greater_than",
+    "args_list": [
+      "other"
+    ]
+  },
+  "torch.Tensor.gt_": {},
+  "torch.Tensor.half": {
+    "Matcher": "TensorFP16Matcher",
+    "args_list": [
+      "memory_format"
+    ]
+  },
+  "torch.Tensor.hardshrink": {
+    "Matcher": "TensorHardShrinkMatcher",
+    "args_list": [
+      "lambd"
+    ]
+  },
+  "torch.Tensor.heaviside": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.heaviside",
+    "args_list": [
+      "data"
+    ],
+    "kwargs_change": {
+      "data": "y"
+    }
+  },
+  "torch.Tensor.histc": {
+    "Matcher": "TensorHistcMatcher",
+    "args_list": [
+      "bins",
+      "min",
+      "max"
+    ]
+  },
+  "torch.Tensor.histogram": {},
+  "torch.Tensor.hsplit": {},
+  "torch.Tensor.hypot": {
+    "Matcher": "HypotMatcher",
+    "args_list": [
+      "other"
+    ]
+  },
+  "torch.Tensor.hypot_": {},
+  "torch.Tensor.i0": {},
+  "torch.Tensor.i0_": {},
+  "torch.Tensor.igamma": {},
+  "torch.Tensor.igamma_": {},
+  "torch.Tensor.igammac": {},
+  "torch.Tensor.igammac_": {},
+  "torch.Tensor.index_add": {
+    "Matcher": "IndexAddMatcher",
+    "paddle_api": "paddle.index_add",
+    "args_list": [
+      "dim",
+      "index",
+      "source",
+      "alpha"
+    ]
+  },
+  "torch.Tensor.index_add_": {
+    "Matcher": "IndexAddMatcher",
+    "paddle_api": "paddle.index_add_",
+    "args_list": [
+      "dim",
+      "index",
+      "source",
+      "alpha"
+    ]
+  },
+  "torch.Tensor.index_copy": {},
+  "torch.Tensor.index_copy_": {
+    "Matcher": "TensorIndexCopyMatcher",
+    "args_list": [
+      "dim",
+      "index",
+      "tensor"
+    ]
+  },
+  "torch.Tensor.index_fill": {},
+  "torch.Tensor.index_fill_": {},
+  "torch.Tensor.index_put": {},
+  "torch.Tensor.index_put_": {},
+  "torch.Tensor.index_reduce": {},
+  "torch.Tensor.index_reduce_": {},
+  "torch.Tensor.index_select": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.index_select",
+    "args_list": [
+      "dim",
+      "index"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.indices": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.indices"
+  },
+  "torch.Tensor.inner": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.inner",
+    "args_list": [
+      "other"
+    ],
+    "kwargs_change": {
+      "other": "y"
+    }
+  },
+  "torch.Tensor.int": {
+    "Matcher": "TensorIntMatcher",
+    "args_list": [
+      "memory_format"
+    ]
+  },
+  "torch.Tensor.int_repr": {},
+  "torch.Tensor.inverse": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.inverse"
+  },
+  "torch.Tensor.is_coalesced": {},
+  "torch.Tensor.is_complex": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.is_complex"
+  },
+  "torch.Tensor.is_conj": {},
+  "torch.Tensor.is_contiguous": {
+    "Matcher": "TensorIsContiguousMatcher"
+  },
+  "torch.Tensor.is_cuda": {},
+  "torch.Tensor.is_floating_point": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.is_floating_point"
+  },
+  "torch.Tensor.is_inference": {},
+  "torch.Tensor.is_meta": {},
+  "torch.Tensor.is_pinned": {},
+  "torch.Tensor.is_quantized": {},
+  "torch.Tensor.is_set_to": {},
+  "torch.Tensor.is_shared": {},
+  "torch.Tensor.is_signed": {},
+  "torch.Tensor.isclose": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.isclose",
+    "args_list": [
       "other",
-      "alpha",
-      "out"
-    ]
-  },
-  "torch.subtract": {
-    "Matcher": "SubMatcher",
-    "args_list": [
-      "input",
-      "other",
-      "alpha",
-      "out"
-    ]
-  },
-  "torch.msort": {
-    "Matcher": "MSortMatcher",
-    "args_list": [
-      "input",
-      "out"
-    ]
-  },
-  "torch.nn.ModuleList": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.LayerList",
-    "args_list": [
-      "modules"
+      "rtol",
+      "atol",
+      "equal_nan"
     ],
     "kwargs_change": {
-      "modules": "sublayers"
+      "other": "y"
     }
   },
-  "torch.nn.ModuleDict": {
+  "torch.Tensor.isfinite": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.LayerDict",
+    "paddle_api": "paddle.Tensor.isfinite"
+  },
+  "torch.Tensor.isinf": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.isinf"
+  },
+  "torch.Tensor.isnan": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.isnan"
+  },
+  "torch.Tensor.isneginf": {},
+  "torch.Tensor.isposinf": {},
+  "torch.Tensor.isreal": {},
+  "torch.Tensor.istft": {
+    "Matcher": "TensorFunc2PaddleFunc",
+    "paddle_api": "paddle.signal.istft",
     "args_list": [
-      "modules"
+      "n_fft",
+      "hop_length",
+      "win_length",
+      "window",
+      "center",
+      "normalized",
+      "onesided",
+      "length",
+      "return_complex"
+    ]
+  },
+  "torch.Tensor.item": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.kthvalue": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.kthvalue",
+    "args_list": [
+      "k",
+      "dim",
+      "keepdim"
     ],
     "kwargs_change": {
-      "modules": "sublayers"
+      "dim": "axis"
     }
   },
-  "torch.reshape": {
+  "torch.Tensor.lcm": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.reshape",
+    "paddle_api": "paddle.Tensor.lcm",
     "args_list": [
-      "input",
-      "shape"
+      "other"
     ],
     "kwargs_change": {
-      "input": "x"
+      "other": "y"
     }
   },
-  "torch.repeat_interleave": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.repeat_interleave",
+  "torch.Tensor.lcm_": {},
+  "torch.Tensor.ldexp": {
+    "Matcher": "LdExpMatcher",
     "args_list": [
-      "input",
+      "other"
+    ]
+  },
+  "torch.Tensor.ldexp_": {},
+  "torch.Tensor.le": {
+    "Matcher": "Num2TensorBinaryMatcher",
+    "paddle_api": "paddle.Tensor.less_equal",
+    "args_list": [
+      "other"
+    ]
+  },
+  "torch.Tensor.le_": {},
+  "torch.Tensor.lerp": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.lerp",
+    "args_list": [
+      "end",
+      "weight"
+    ],
+    "kwargs_change": {
+      "end": "y"
+    }
+  },
+  "torch.Tensor.lerp_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.lerp_",
+    "args_list": [
+      "end",
+      "weight"
+    ],
+    "kwargs_change": {
+      "end": "y"
+    }
+  },
+  "torch.Tensor.less": {
+    "Matcher": "Num2TensorBinaryMatcher",
+    "paddle_api": "paddle.Tensor.less_than",
+    "args_list": [
+      "other"
+    ]
+  },
+  "torch.Tensor.less_": {},
+  "torch.Tensor.less_equal": {
+    "Matcher": "Num2TensorBinaryMatcher",
+    "paddle_api": "paddle.Tensor.less_equal",
+    "args_list": [
+      "other"
+    ]
+  },
+  "torch.Tensor.less_equal_": {},
+  "torch.Tensor.lgamma": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.lgamma"
+  },
+  "torch.Tensor.lgamma_": {},
+  "torch.Tensor.log": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.log"
+  },
+  "torch.Tensor.log10": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.log10"
+  },
+  "torch.Tensor.log10_": {},
+  "torch.Tensor.log1p": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.log1p_": {},
+  "torch.Tensor.log2": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.log2"
+  },
+  "torch.Tensor.log2_": {},
+  "torch.Tensor.log_": {},
+  "torch.Tensor.log_normal_": {},
+  "torch.Tensor.logaddexp": {
+    "Matcher": "LogAddExpMatcher",
+    "args_list": [
+      "other"
+    ]
+  },
+  "torch.Tensor.logaddexp2": {
+    "Matcher": "LogAddExp2Matcher",
+    "args_list": [
+      "other"
+    ]
+  },
+  "torch.Tensor.logcumsumexp": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.logcumsumexp",
+    "args_list": [
+      "dim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.logdet": {
+    "Matcher": "LogDetMatcher",
+    "args_list": []
+  },
+  "torch.Tensor.logical_and": {
+    "Matcher": "TensorLogicalMatcher",
+    "paddle_api": "paddle.Tensor.logical_and",
+    "args_list": [
+      "other"
+    ]
+  },
+  "torch.Tensor.logical_and_": {},
+  "torch.Tensor.logical_not": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.logical_not"
+  },
+  "torch.Tensor.logical_not_": {},
+  "torch.Tensor.logical_or": {
+    "Matcher": "TensorLogicalMatcher",
+    "paddle_api": "paddle.Tensor.logical_or",
+    "args_list": [
+      "other"
+    ]
+  },
+  "torch.Tensor.logical_or_": {},
+  "torch.Tensor.logical_xor": {
+    "Matcher": "TensorLogicalMatcher",
+    "paddle_api": "paddle.Tensor.logical_xor",
+    "args_list": [
+      "other"
+    ]
+  },
+  "torch.Tensor.logical_xor_": {},
+  "torch.Tensor.logit": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.logit",
+    "args_list": [
+      "eps"
+    ]
+  },
+  "torch.Tensor.logit_": {},
+  "torch.Tensor.logsumexp": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.logsumexp",
+    "args_list": [
+      "dim",
+      "keepdim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.long": {
+    "Matcher": "TensorLongMatcher",
+    "args_list": [
+      "memory_format"
+    ]
+  },
+  "torch.Tensor.lstsq": {},
+  "torch.Tensor.lt": {
+    "Matcher": "Num2TensorBinaryMatcher",
+    "paddle_api": "paddle.Tensor.less_than",
+    "args_list": [
+      "other"
+    ]
+  },
+  "torch.Tensor.lt_": {},
+  "torch.Tensor.lu": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.lu",
+    "args_list": [
+      "pivot",
+      "get_infos"
+    ]
+  },
+  "torch.Tensor.lu_solve": {},
+  "torch.Tensor.map_": {},
+  "torch.Tensor.masked_fill": {
+    "Matcher": "TensorMaskedFillMatcher",
+    "args_list": [
+      "mask",
+      "value"
+    ]
+  },
+  "torch.Tensor.masked_fill_": {},
+  "torch.Tensor.masked_scatter": {},
+  "torch.Tensor.masked_scatter_": {},
+  "torch.Tensor.masked_select": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.masked_select",
+    "args_list": [
+      "mask"
+    ]
+  },
+  "torch.Tensor.matmul": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.matmul",
+    "args_list": [
+      "tensor2"
+    ],
+    "kwargs_change": {
+      "tensor2": "y"
+    }
+  },
+  "torch.Tensor.matrix_exp": {},
+  "torch.Tensor.matrix_power": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.matrix_power",
+    "args_list": [
+      "n"
+    ]
+  },
+  "torch.Tensor.max": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.max",
+    "args_list": [
+      "dim",
+      "keepdim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.maximum": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.maximum",
+    "args_list": [
+      "other"
+    ],
+    "kwargs_change": {
+      "other": "y"
+    }
+  },
+  "torch.Tensor.mean": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.mean",
+    "args_list": [
+      "dim",
+      "keepdim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.median": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.median",
+    "args_list": [
+      "dim",
+      "keepdim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.min": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.min",
+    "args_list": [
+      "dim",
+      "keepdim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.minimum": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.minimum",
+    "args_list": [
+      "other"
+    ],
+    "kwargs_change": {
+      "other": "y"
+    }
+  },
+  "torch.Tensor.mm": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.mm",
+    "args_list": [
+      "mat2"
+    ]
+  },
+  "torch.Tensor.mode": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.mode",
+    "args_list": [
+      "dim",
+      "keepdim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.moveaxis": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.moveaxis",
+    "args_list": [
+      "source",
+      "destination"
+    ]
+  },
+  "torch.Tensor.movedim": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.moveaxis",
+    "args_list": [
+      "source",
+      "destination"
+    ]
+  },
+  "torch.Tensor.msort": {
+    "Matcher": "MSortMatcher"
+  },
+  "torch.Tensor.mul": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.multiply",
+    "args_list": [
+      "value"
+    ],
+    "kwargs_change": {
+      "value": "y"
+    }
+  },
+  "torch.Tensor.mul_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.scale_",
+    "args_list": [
+      "value"
+    ],
+    "kwargs_change": {
+      "value": "scale"
+    }
+  },
+  "torch.Tensor.multinomial": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.multinomial",
+    "args_list": [
+      "num_samples",
+      "replacement",
+      "generator"
+    ]
+  },
+  "torch.Tensor.multiply": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.multiply",
+    "args_list": [
+      "value"
+    ],
+    "kwargs_change": {
+      "value": "y"
+    }
+  },
+  "torch.Tensor.multiply_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.scale_",
+    "args_list": [
+      "value"
+    ],
+    "kwargs_change": {
+      "value": "scale"
+    }
+  },
+  "torch.Tensor.mv": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.mv",
+    "args_list": [
+      "vec"
+    ]
+  },
+  "torch.Tensor.mvlgamma": {},
+  "torch.Tensor.mvlgamma_": {},
+  "torch.Tensor.nan_to_num": {},
+  "torch.Tensor.nan_to_num_": {},
+  "torch.Tensor.nanmean": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.nanmean",
+    "args_list": [
+      "dim",
+      "keepdim",
+      "dtype",
+      "out"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.nanmedian": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.nanmedian",
+    "args_list": [
+      "dim",
+      "keepdim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.nanquantile": {},
+  "torch.Tensor.nansum": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.nansum",
+    "args_list": [
+      "dim",
+      "keepdim",
+      "dtype"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.narrow": {
+    "Matcher": "NarrowMatcher",
+    "args_list": [
+      "dim",
+      "start",
+      "length"
+    ]
+  },
+  "torch.Tensor.narrow_copy": {
+    "Matcher": "NarrowCopyMatcher",
+    "args_list": [
+      "dim",
+      "start",
+      "length"
+    ]
+  },
+  "torch.Tensor.ndimension": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.ndimension"
+  },
+  "torch.Tensor.ne": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.not_equal",
+    "args_list": [
+      "other"
+    ],
+    "kwargs_change": {
+      "other": "y"
+    }
+  },
+  "torch.Tensor.ne_": {},
+  "torch.Tensor.neg": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.neg"
+  },
+  "torch.Tensor.neg_": {},
+  "torch.Tensor.negative": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.neg"
+  },
+  "torch.Tensor.negative_": {},
+  "torch.Tensor.nelement": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.size"
+  },
+  "torch.Tensor.new_empty": {
+    "Matcher": "TensorNew_Matcher",
+    "paddle_api": "paddle.empty",
+    "args_list": [
+      "size"
+    ]
+  },
+  "torch.Tensor.new_full": {
+    "Matcher": "TensorNewFullMatcher",
+    "paddle_api": "paddle.full",
+    "args_list": [
+      "size",
+      "fill_value"
+    ]
+  },
+  "torch.Tensor.new_ones": {
+    "Matcher": "TensorNew_Matcher",
+    "paddle_api": "paddle.ones",
+    "args_list": [
+      "size"
+    ]
+  },
+  "torch.Tensor.new_tensor": {
+    "Matcher": "TensorNewTensorMatcher",
+    "paddle_api": "paddle.to_tensor",
+    "args_list": [
+      "data",
+      "dtype",
+      "device",
+      "requires_grad",
+      "layout",
+      "pin_memory"
+    ],
+    "kwargs_change": {
+      "device": "place"
+    }
+  },
+  "torch.Tensor.new_zeros": {
+    "Matcher": "TensorNew_Matcher",
+    "paddle_api": "paddle.zeros",
+    "args_list": [
+      "size"
+    ]
+  },
+  "torch.Tensor.nextafter": {},
+  "torch.Tensor.nextafter_": {},
+  "torch.Tensor.nonzero": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.norm": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.norm",
+    "args_list": [
+      "p",
+      "dim",
+      "keepdim",
+      "dtype"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.normal_": {
+    "Matcher": "TensorNormal_Matcher",
+    "args_list": [
+      "mean",
+      "std"
+    ]
+  },
+  "torch.Tensor.not_equal": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.not_equal",
+    "args_list": [
+      "other"
+    ],
+    "kwargs_change": {
+      "other": "y"
+    }
+  },
+  "torch.Tensor.not_equal_": {},
+  "torch.Tensor.numel": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.size"
+  },
+  "torch.Tensor.numpy": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.numpy",
+    "args_list": [
+      "force"
+    ],
+    "kwargs_change": {
+      "force": ""
+    }
+  },
+  "torch.Tensor.orgqr": {},
+  "torch.Tensor.ormqr": {},
+  "torch.Tensor.outer": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.outer",
+    "args_list": [
+      "vec2"
+    ],
+    "kwargs_change": {
+      "vec2": "y"
+    }
+  },
+  "torch.Tensor.permute": {
+    "Matcher": "TensorPermuteMatcher",
+    "paddle_api": "paddle.Tensor.transpose"
+  },
+  "torch.Tensor.pin_memory": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.pin_memory"
+  },
+  "torch.Tensor.pinverse": {
+    "Matcher": "TensorFunc2PaddleFunc",
+    "paddle_api": "paddle.linalg.pinv"
+  },
+  "torch.Tensor.polygamma": {},
+  "torch.Tensor.polygamma_": {},
+  "torch.Tensor.positive": {},
+  "torch.Tensor.pow": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.pow",
+    "args_list": [
+      "exponent"
+    ],
+    "kwargs_change": {
+      "exponent": "y"
+    }
+  },
+  "torch.Tensor.pow_": {},
+  "torch.Tensor.prod": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.prod",
+    "args_list": [
+      "dim",
+      "keepdim",
+      "dtype"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.put_": {},
+  "torch.Tensor.q_per_channel_axis": {},
+  "torch.Tensor.q_per_channel_scales": {},
+  "torch.Tensor.q_per_channel_zero_points": {},
+  "torch.Tensor.q_scale": {},
+  "torch.Tensor.q_zero_point": {},
+  "torch.Tensor.qr": {},
+  "torch.Tensor.qscheme": {},
+  "torch.Tensor.quantile": {},
+  "torch.Tensor.rad2deg": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.random_": {},
+  "torch.Tensor.ravel": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.flatten"
+  },
+  "torch.Tensor.reciprocal": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.reciprocal"
+  },
+  "torch.Tensor.reciprocal_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.reciprocal_"
+  },
+  "torch.Tensor.record_stream": {},
+  "torch.Tensor.refine_names": {},
+  "torch.Tensor.register_hook": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.register_hook",
+    "args_list": [
+      "hook"
+    ]
+  },
+  "torch.Tensor.remainder": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.remainder",
+    "args_list": [
+      "divisor"
+    ],
+    "kwargs_change": {
+      "divisor": "y"
+    }
+  },
+  "torch.Tensor.remainder_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.remainder_",
+    "args_list": [
+      "divisor"
+    ],
+    "kwargs_change": {
+      "divisor": "y"
+    }
+  },
+  "torch.Tensor.rename": {},
+  "torch.Tensor.rename_": {},
+  "torch.Tensor.renorm": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.renorm",
+    "args_list": [
+      "p",
+      "dim",
+      "maxnorm",
+      "out"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.renorm_": {},
+  "torch.Tensor.repeat": {
+    "Matcher": "TensorRepeatMatcher"
+  },
+  "torch.Tensor.repeat_interleave": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.repeat_interleave",
+    "args_list": [
       "repeats",
       "dim",
       "output_size"
     ],
     "kwargs_change": {
-      "input": "x",
       "dim": "axis"
     }
+  },
+  "torch.Tensor.requires_grad": {},
+  "torch.Tensor.requires_grad_": {
+    "Matcher": "TensorRequiresGradMatcher",
+    "args_list": [
+      "requires_grad"
+    ]
+  },
+  "torch.Tensor.reshape": {
+    "Matcher": "TensorReshapeMatcher"
+  },
+  "torch.Tensor.reshape_as": {
+    "Matcher": "TensorReshape_asMatcher",
+    "args_list": [
+      "other"
+    ]
+  },
+  "torch.Tensor.resize_": {},
+  "torch.Tensor.resize_as_": {},
+  "torch.Tensor.resolve_conj": {},
+  "torch.Tensor.resolve_neg": {},
+  "torch.Tensor.retain_grad": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.retain_grad"
+  },
+  "torch.Tensor.retains_grad": {},
+  "torch.Tensor.roll": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.roll",
+    "args_list": [
+      "shifts",
+      "dim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.rot90": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.rot90",
+    "args_list": [
+      "k",
+      "dims"
+    ],
+    "kwargs_change": {
+      "dims": "axis"
+    }
+  },
+  "torch.Tensor.round": {
+    "Matcher": "TensorRoundMatcher",
+    "args_list": [
+      "input",
+      "decimals",
+      "out"
+    ]
+  },
+  "torch.Tensor.round_": {},
+  "torch.Tensor.rsqrt": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.rsqrt"
+  },
+  "torch.Tensor.rsqrt_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.rsqrt_"
+  },
+  "torch.Tensor.scatter": {},
+  "torch.Tensor.scatter_": {},
+  "torch.Tensor.scatter_add": {},
+  "torch.Tensor.scatter_add_": {},
+  "torch.Tensor.scatter_reduce": {},
+  "torch.Tensor.scatter_reduce_": {},
+  "torch.Tensor.select": {
+    "Matcher": "SelectMatcher",
+    "args_list": [
+      "dim",
+      "index"
+    ]
+  },
+  "torch.Tensor.select_scatter": {},
+  "torch.Tensor.set_": {},
+  "torch.Tensor.sgn": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.sgn"
+  },
+  "torch.Tensor.sgn_": {},
+  "torch.Tensor.share_memory_": {},
+  "torch.Tensor.short": {
+    "Matcher": "TensorShortMatcher",
+    "args_list": [
+      "memory_format"
+    ]
+  },
+  "torch.Tensor.sigmoid": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.sigmoid"
+  },
+  "torch.Tensor.sigmoid_": {},
+  "torch.Tensor.sign": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.sign_": {},
+  "torch.Tensor.signbit": {},
+  "torch.Tensor.sin": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.sin_": {},
+  "torch.Tensor.sinc": {
+    "Matcher": "SincMatcher"
+  },
+  "torch.Tensor.sinc_": {},
+  "torch.Tensor.sinh": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.sinh_": {},
+  "torch.Tensor.size": {
+    "Matcher": "TensorSizeMatcher",
+    "args_list": [
+      "dim"
+    ]
+  },
+  "torch.Tensor.slice_scatter": {},
+  "torch.Tensor.slogdet": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.slogdet"
+  },
+  "torch.Tensor.smm": {},
+  "torch.Tensor.softmax": {
+    "Matcher": "TensorSoftmaxMatcher",
+    "args_list": [
+      "dim"
+    ]
+  },
+  "torch.Tensor.sort": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.sort",
+    "args_list": [
+      "dim",
+      "descending"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.sparse_dim": {},
+  "torch.Tensor.sparse_mask": {},
+  "torch.Tensor.sparse_resize_": {},
+  "torch.Tensor.sparse_resize_and_clear_": {},
+  "torch.Tensor.split": {
+    "Matcher": "TensorSplitMatcher",
+    "paddle_api": "paddle.Tensor.split",
+    "args_list": [
+      "split_size",
+      "dim"
+    ]
+  },
+  "torch.Tensor.sqrt": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.sqrt_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.sqrt_"
+  },
+  "torch.Tensor.square": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.square"
+  },
+  "torch.Tensor.square_": {},
+  "torch.Tensor.squeeze": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.squeeze",
+    "args_list": [
+      "dim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.squeeze_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.squeeze_",
+    "args_list": [
+      "dim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.sspaddmm": {},
+  "torch.Tensor.std": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.std",
+    "args_list": [
+      "dim",
+      "unbiased",
+      "keepdim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.stft": {},
+  "torch.Tensor.storage": {},
+  "torch.Tensor.storage_offset": {},
+  "torch.Tensor.storage_type": {},
+  "torch.Tensor.stride": {},
+  "torch.Tensor.sub": {
+    "Matcher": "SubMatcher",
+    "args_list": [
+      "other",
+      "alpha"
+    ]
+  },
+  "torch.Tensor.sub_": {},
+  "torch.Tensor.subtract": {
+    "Matcher": "SubMatcher",
+    "args_list": [
+      "other",
+      "alpha"
+    ]
+  },
+  "torch.Tensor.subtract_": {},
+  "torch.Tensor.sum": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.sum",
+    "args_list": [
+      "dim",
+      "keepdim",
+      "dtype"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.sum_to_size": {},
+  "torch.Tensor.svd": {
+    "Matcher": "TensorSVDMatcher",
+    "args_list": [
+      "some",
+      "compute_uv"
+    ]
+  },
+  "torch.Tensor.swapaxes": {
+    "Matcher": "SwapAxesMatcher",
+    "args_list": [
+      "axis0",
+      "axis1"
+    ]
+  },
+  "torch.Tensor.swapdims": {
+    "Matcher": "SwapAxesMatcher",
+    "args_list": [
+      "dim0",
+      "dim1"
+    ]
+  },
+  "torch.Tensor.symeig": {},
+  "torch.Tensor.t": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.t"
+  },
+  "torch.Tensor.t_": {},
+  "torch.Tensor.take": {
+    "Matcher": "TensorTakeMatcher",
+    "paddle_api": "paddle.Tensor.take",
+    "args_list": [
+      "index"
+    ]
+  },
+  "torch.Tensor.take_along_dim": {},
+  "torch.Tensor.tan": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.tan_": {},
+  "torch.Tensor.tanh": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.tanh_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.tanh_"
+  },
+  "torch.Tensor.tensor_split": {},
+  "torch.Tensor.tile": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.tile",
+    "args_list": [
+      "reps"
+    ],
+    "kwargs_change": {
+      "reps": "repeat_times"
+    }
+  },
+  "torch.Tensor.to": {
+    "Matcher": "TensorToMatcher"
+  },
+  "torch.Tensor.to_dense": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.to_dense"
+  },
+  "torch.Tensor.to_mkldnn": {},
+  "torch.Tensor.to_sparse": {},
+  "torch.Tensor.tolist": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.topk": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.topk",
+    "args_list": [
+      "k",
+      "dim",
+      "largest",
+      "sorted"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.trace": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.transpose": {
+    "Matcher": "TensorTransposeMatcher",
+    "paddle_api": "paddle.Tensor.transpose",
+    "args_list": [
+      "dim0",
+      "dim1"
+    ]
+  },
+  "torch.Tensor.transpose_": {},
+  "torch.Tensor.triangular_solve": {},
+  "torch.Tensor.tril": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.tril"
+  },
+  "torch.Tensor.tril_": {},
+  "torch.Tensor.triu": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.triu"
+  },
+  "torch.Tensor.triu_": {},
+  "torch.Tensor.true_divide": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.divide",
+    "args_list": [
+      "value"
+    ],
+    "kwargs_change": {
+      "value": "y"
+    }
+  },
+  "torch.Tensor.true_divide_": {},
+  "torch.Tensor.trunc": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.trunc_": {},
+  "torch.Tensor.type": {},
+  "torch.Tensor.type_as": {
+    "Matcher": "TensorTypeAsMatcher",
+    "args_list": [
+      "tensor"
+    ]
+  },
+  "torch.Tensor.unbind": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.unbind",
+    "args_list": [
+      "dim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.unflatten": {
+    "Matcher": "UnflattenMatcher",
+    "args_list": [
+      "dim",
+      "sizes"
+    ]
+  },
+  "torch.Tensor.unfold": {},
+  "torch.Tensor.uniform_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.uniform_",
+    "args_list": [
+      "from",
+      "to"
+    ],
+    "kwargs_change": {
+      "from": "min",
+      "to": "max"
+    }
+  },
+  "torch.Tensor.unique": {
+    "Matcher": "TensorUniqueMatcher",
+    "args_list": [
+      "sorted",
+      "return_inverse",
+      "return_counts",
+      "dim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.unique_consecutive": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.unique_consecutive",
+    "args_list": [
+      "return_inverse",
+      "return_counts",
+      "dim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.unsqueeze": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.unsqueeze",
+    "args_list": [
+      "dim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.unsqueeze_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.unsqueeze_",
+    "args_list": [
+      "dim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.values": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.var": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.var",
+    "args_list": [
+      "dim",
+      "unbiased",
+      "keepdim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.Tensor.vdot": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.dot",
+    "args_list": [
+      "other"
+    ],
+    "kwargs_change": {
+      "other": "y"
+    }
+  },
+  "torch.Tensor.view": {},
+  "torch.Tensor.view_as": {},
+  "torch.Tensor.vsplit": {},
+  "torch.Tensor.where": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.where",
+    "args_list": [
+      "condition",
+      "y"
+    ]
+  },
+  "torch.Tensor.xlogy": {
+    "Matcher": "XLogYMatcher",
+    "args_list": [
+      "other"
+    ]
+  },
+  "torch.Tensor.xlogy_": {},
+  "torch.Tensor.zero_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.zero_"
+  },
+  "torch.__version__": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.__version__"
   },
   "torch.abs": {
     "Matcher": "GenericMatcher",
@@ -247,852 +2376,6 @@
     "kwargs_change": {
       "input": "x"
     }
-  },
-  "torch.Tensor.transpose": {
-    "Matcher": "TensorTransposeMatcher",
-    "paddle_api": "paddle.Tensor.transpose",
-    "args_list": [
-      "dim0",
-      "dim1"
-    ]
-  },
-  "torch.no_grad": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.no_grad"
-  },
-  "torch.nn.Module": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Layer"
-  },
-  "torch.Tensor": {
-    "Matcher": "TensorMatcher",
-    "paddle_api": "paddle.Tensor"
-  },
-  "torch.LongTensor": {
-    "Matcher": "TensorMatcher",
-    "paddle_api": "paddle.Tensor"
-  },
-  "torch.IntTensor": {
-    "Matcher": "TensorMatcher",
-    "paddle_api": "paddle.Tensor"
-  },
-  "torch.FloatTensor": {
-    "Matcher": "TensorMatcher",
-    "paddle_api": "paddle.Tensor"
-  },
-  "torch.bool": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "'bool'"
-  },
-  "torch.float16": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "'float16'"
-  },
-  "torch.half": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "'float16'"
-  },
-  "torch.bfloat16": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "'bfloat16'"
-  },
-  "torch.float32": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "'float32'"
-  },
-  "torch.float": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "'float32'"
-  },
-  "torch.float64": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "'float64'"
-  },
-  "torch.double": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "'float64'"
-  },
-  "torch.int8": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "'int8'"
-  },
-  "torch.int16": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "'int16'"
-  },
-  "torch.short": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "'int16'"
-  },
-  "torch.int32": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "'int32'"
-  },
-  "torch.int": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "'int32'"
-  },
-  "torch.int64": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "'int64'"
-  },
-  "torch.long": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "'int64'"
-  },
-  "torch.uint8": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "'uint8'"
-  },
-  "torch.complex64": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "'complex64'"
-  },
-  "torch.cfloat": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "'complex64'"
-  },
-  "torch.complex128": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "'complex128'"
-  },
-  "torch.cdouble": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "'complex128'"
-  },
-  "torch.is_tensor": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.is_tensor",
-    "args_list": [
-      "obj"
-    ],
-    "kwargs_change": {
-      "obj": "x"
-    }
-  },
-  "torch.is_complex": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.is_complex",
-    "args_list": [
-      "input"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.is_floating_point": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.is_floating_point",
-    "args_list": [
-      "input"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.is_nonzero": {
-    "Matcher": "IsNonzeroMatcher",
-    "args_list": [
-      "input"
-    ]
-  },
-  "torch.set_default_dtype": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.set_default_dtype",
-    "args_list": [
-      "d"
-    ]
-  },
-  "torch.get_default_dtype": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.get_default_dtype"
-  },
-  "torch.set_rng_state": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.set_cuda_rng_state",
-    "args_list": [
-      "new_state"
-    ],
-    "kwargs_change": {
-      "new_state": "state_list"
-    }
-  },
-  "torch.random.set_rng_state": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.set_cuda_rng_state",
-    "args_list": [
-      "new_state"
-    ],
-    "kwargs_change": {
-      "new_state": "state_list"
-    }
-  },
-  "torch.get_rng_state": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.get_cuda_rng_state"
-  },
-  "torch.random.get_rng_state": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.get_cuda_rng_state"
-  },
-  "torch.set_printoptions": {
-    "Matcher": "SetPrintOptionsMatcher",
-    "args_list": [
-      "precision",
-      "threshold",
-      "edgeitems",
-      "linewidth",
-      "profile",
-      "sci_mode"
-    ],
-    "paddle_default_kwargs": {
-      "precision": 4
-    }
-  },
-  "torch.dtype": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.dtype"
-  },
-  "torch.numel": {
-    "Matcher": "NumelMatcher",
-    "args_list": [
-      "input"
-    ]
-  },
-  "torch.sparse_coo_tensor": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.sparse.sparse_coo_tensor",
-    "args_list": [
-      "indices",
-      "values",
-      "size",
-      "dtype",
-      "device",
-      "requires_grad"
-    ],
-    "kwargs_change": {
-      "size": "shape"
-    }
-  },
-  "torch.sparse.sum": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.sparse.sum",
-    "args_list": [
-      "input",
-      "dim",
-      "dtype"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    },
-    "unsupport_args": [
-      "dtype"
-    ]
-  },
-  "torch.as_tensor": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.to_tensor",
-    "args_list": [
-      "data",
-      "dtype",
-      "device"
-    ],
-    "kwargs_change": {
-      "device": "place"
-    }
-  },
-  "torch.from_numpy": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.to_tensor",
-    "args_list": [
-      "ndarray"
-    ],
-    "kwargs_change": {
-      "ndarray": "data"
-    }
-  },
-  "torch.zeros_like": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.zeros_like",
-    "args_list": [
-      "input",
-      "dtype",
-      "layout",
-      "device",
-      "requires_grad",
-      "memory_format"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.ones_like": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.ones_like",
-    "args_list": [
-      "input",
-      "dtype",
-      "layout",
-      "device",
-      "requires_grad",
-      "memory_format"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.arange": {
-    "Matcher": "ArangeMatcher",
-    "paddle_api": "paddle.arange",
-    "args_list": [
-      "start",
-      "end",
-      "step",
-      "dtype",
-      "layout",
-      "device",
-      "requires_grad"
-    ]
-  },
-  "torch.linspace": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.linspace",
-    "args_list": [
-      "start",
-      "end",
-      "steps",
-      "out",
-      "dtype",
-      "layout",
-      "device",
-      "requires_grad"
-    ],
-    "kwargs_change": {
-      "end": "stop",
-      "steps": "num"
-    }
-  },
-  "torch.logspace": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.logspace",
-    "args_list": [
-      "start",
-      "end",
-      "steps",
-      "base",
-      "out",
-      "dtype",
-      "layout",
-      "device",
-      "requires_grad"
-    ],
-    "kwargs_change": {
-      "end": "stop",
-      "steps": "num"
-    }
-  },
-  "torch.eye": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.eye",
-    "args_list": [
-      "n",
-      "m",
-      "out",
-      "dtype",
-      "layout",
-      "device",
-      "requires_grad"
-    ],
-    "kwargs_change": {
-      "n": "num_rows",
-      "m": "num_columns"
-    }
-  },
-  "torch.empty": {
-    "Matcher": "CreateMatcher",
-    "paddle_api": "paddle.empty"
-  },
-  "torch.empty_like": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.empty_like",
-    "args_list": [
-      "input",
-      "dtype",
-      "layout",
-      "device",
-      "requires_grad",
-      "memory_format"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.full_like": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.full_like",
-    "args_list": [
-      "input",
-      "fill_value",
-      "dtype",
-      "layout",
-      "device",
-      "requires_grad",
-      "memory_format"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.complex": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.complex",
-    "args_list": [
-      "real",
-      "imag",
-      "out"
-    ]
-  },
-  "torch.real": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.real",
-    "args_list": [
-      "input"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.imag": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.imag",
-    "args_list": [
-      "input"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.hypot": {
-    "Matcher": "HypotMatcher",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ]
-  },
-  "torch.angle": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.angle",
-    "args_list": [
-      "input",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.heaviside": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.heaviside",
-    "args_list": [
-      "input",
-      "values",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "values": "y"
-    }
-  },
-  "torch.cat": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.concat",
-    "args_list": [
-      "tensors",
-      "dim",
-      "out"
-    ],
-    "kwargs_change": {
-      "tensors": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.concat": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.concat",
-    "args_list": [
-      "tensors",
-      "dim",
-      "out"
-    ],
-    "kwargs_change": {
-      "tensors": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.count_nonzero": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.count_nonzero",
-    "args_list": [
-      "input",
-      "dim"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.chunk": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.chunk",
-    "args_list": [
-      "input",
-      "chunks",
-      "dim"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.cov": {
-    "Matcher": "CovMatcher",
-    "args_list": [
-      "input",
-      "correction",
-      "fweight",
-      "aweight"
-    ]
-  },
-  "torch.dstack": {
-    "args_list": [
-      "tensors",
-      "out"
-    ],
-    "kwargs_change": {
-      "tensors": "x"
-    }
-  },
-  "torch.select": {
-    "Matcher": "SelectMatcher",
-    "args_list": [
-      "input",
-      "dim",
-      "index"
-    ]
-  },
-  "torch.index_select": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.index_select",
-    "args_list": [
-      "input",
-      "dim",
-      "index",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.masked_select": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.masked_select",
-    "args_list": [
-      "input",
-      "mask",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.movedim": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.moveaxis",
-    "args_list": [
-      "input",
-      "source",
-      "destination"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.moveaxis": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.moveaxis",
-    "args_list": [
-      "input",
-      "source",
-      "destination"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nonzero": {
-    "Matcher": "NonzeroMatcher",
-    "paddle_api": "paddle.nonzero",
-    "args_list": [
-      "input",
-      "as_tuple",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.squeeze": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.squeeze",
-    "args_list": [
-      "input",
-      "dim"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.stack": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.stack",
-    "args_list": [
-      "tensor",
-      "dim",
-      "out"
-    ],
-    "kwargs_change": {
-      "tensor": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.vstack": {
-    "Matcher": "VStackMatcher",
-    "args_list": [
-      "tensors",
-      "out"
-    ]
-  },
-  "torch.hstack": {
-    "Matcher": "HStackMatcher",
-    "args_list": [
-      "tensors",
-      "out"
-    ]
-  },
-  "torch.column_stack": {
-    "Matcher": "ColumnStackMatcher",
-    "args_list": [
-      "tensors",
-      "out"
-    ]
-  },
-  "torch.row_stack": {
-    "Matcher": "VStackMatcher",
-    "args_list": [
-      "tensors",
-      "out"
-    ]
-  },
-  "torch.t": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.t",
-    "args_list": [
-      "input"
-    ]
-  },
-  "torch.tile": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.tile",
-    "args_list": [
-      "input",
-      "dims"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dims": "repeat_times"
-    }
-  },
-  "torch.unbind": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.unbind",
-    "args_list": [
-      "input",
-      "dim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.unsqueeze": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.unsqueeze",
-    "args_list": [
-      "input",
-      "dim"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.where": {
-    "Matcher": "WhereMatcher",
-    "paddle_api": "paddle.where",
-    "args_list": [
-      "condition",
-      "x",
-      "y"
-    ]
-  },
-  "torch.manual_seed": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.seed",
-    "args_list": [
-      "seed"
-    ]
-  },
-  "torch.seed": {
-    "Matcher": "SeedMatcher"
-  },
-  "torch.random.seed": {
-    "Matcher": "SeedMatcher"
-  },
-  "torch.initial_seed": {
-    "Matcher": "SeedMatcher"
-  },
-  "torch.bernoulli": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.bernoulli",
-    "args_list": [
-      "input",
-      "generator",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.bucketize": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.bucketize",
-    "args_list": [
-      "input",
-      "boundaries",
-      "out_int32",
-      "right"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "boundaries": "sorted_sequence"
-    }
-  },
-  "torch.multinomial": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.multinomial",
-    "args_list": [
-      "input",
-      "num_samples",
-      "replacement",
-      "generator",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.normal": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.normal",
-    "args_list": [
-      "mean",
-      "std",
-      "generator",
-      "out"
-    ],
-    "kwargs_change": {
-      "size": "shape"
-    }
-  },
-  "torch.poisson": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.poisson",
-    "args_list": [
-      "input",
-      "generator"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.randperm": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.randperm",
-    "args_list": [
-      "n",
-      "generator",
-      "out",
-      "dtype",
-      "layout",
-      "device",
-      "requires_grad",
-      "pin_memory"
-    ]
-  },
-  "torch.rand_like": {
-    "Matcher": "RandLikeMatcher",
-    "paddle_api": "paddle.rand",
-    "args_list": [
-      "input",
-      "dtype",
-      "layout",
-      "device",
-      "requires_grad",
-      "memory_format"
-    ]
-  },
-  "torch.randn_like": {
-    "Matcher": "RandLikeMatcher",
-    "paddle_api": "paddle.randn",
-    "args_list": [
-      "input",
-      "dtype",
-      "layout",
-      "device",
-      "requires_grad",
-      "memory_format"
-    ]
-  },
-  "torch.randint_like": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.randint_like",
-    "args_list": [
-      "input",
-      "low",
-      "high",
-      "dtype",
-      "layout",
-      "device",
-      "requires_grad",
-      "memory_format"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.set_grad_enabled": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.set_grad_enabled",
-    "args_list": [
-      "mode"
-    ]
-  },
-  "torch.enable_grad": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.enable_grad"
   },
   "torch.absolute": {
     "Matcher": "GenericMatcher",
@@ -1116,9 +2399,9 @@
       "input": "x"
     }
   },
-  "torch.arccos": {
+  "torch.acosh": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.acos",
+    "paddle_api": "paddle.acosh",
     "args_list": [
       "input",
       "out"
@@ -1127,9 +2410,200 @@
       "input": "x"
     }
   },
-  "torch.acosh": {
+  "torch.add": {
+    "Matcher": "TorchAddMatcher",
+    "paddle_api": "paddle.add",
+    "args_list": [
+      "input",
+      "other",
+      "alpha",
+      "out"
+    ]
+  },
+  "torch.addbmm": {
+    "Matcher": "AddBmmMatcher",
+    "args_list": [
+      "input",
+      "batch1",
+      "batch2",
+      "alpha",
+      "beta",
+      "out"
+    ]
+  },
+  "torch.addcdiv": {
+    "Matcher": "AddCDivMatcher",
+    "args_list": [
+      "input",
+      "tensor1",
+      "tensor2",
+      "value",
+      "out"
+    ]
+  },
+  "torch.addcmul": {
+    "Matcher": "AddCMulMatcher",
+    "args_list": [
+      "input",
+      "tensor1",
+      "tensor2",
+      "value",
+      "out"
+    ]
+  },
+  "torch.addmm": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.acosh",
+    "paddle_api": "paddle.addmm",
+    "args_list": [
+      "input",
+      "mat1",
+      "mat2",
+      "alpha",
+      "beta",
+      "out"
+    ],
+    "kwargs_change": {
+      "mat1": "x",
+      "mat2": "y"
+    }
+  },
+  "torch.addmv": {
+    "Matcher": "AddMRMatcher",
+    "paddle_api": "paddle.mm",
+    "args_list": [
+      "input",
+      "mat",
+      "vec",
+      "beta",
+      "alpha",
+      "out"
+    ]
+  },
+  "torch.addr": {
+    "Matcher": "AddMRMatcher",
+    "paddle_api": "paddle.outer",
+    "args_list": [
+      "input",
+      "vec1",
+      "vec2",
+      "beta",
+      "alpha",
+      "out"
+    ]
+  },
+  "torch.adjoint": {
+    "Matcher": "AdjointMatcher",
+    "args_list": [
+      "input"
+    ]
+  },
+  "torch.all": {
+    "Matcher": "AllMatcher",
+    "paddle_api": "paddle.all",
+    "args_list": [
+      "input",
+      "dim",
+      "keepdim",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.allclose": {
+    "Matcher": "AllcloseMatcher",
+    "paddle_api": "paddle.allclose",
+    "args_list": [
+      "input",
+      "other",
+      "rtol",
+      "atol",
+      "equal_nan"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "other": "y"
+    }
+  },
+  "torch.amax": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.amax",
+    "args_list": [
+      "input",
+      "dim",
+      "keepdim",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.amin": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.amin",
+    "args_list": [
+      "input",
+      "dim",
+      "keepdim",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.aminmax": {
+    "Matcher": "AMinMaxMatcher",
+    "args_list": [
+      "input",
+      "dim",
+      "keepdim",
+      "out"
+    ]
+  },
+  "torch.angle": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.angle",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.any": {
+    "Matcher": "AllMatcher",
+    "paddle_api": "paddle.any",
+    "args_list": [
+      "input",
+      "dim",
+      "keepdim",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.arange": {
+    "Matcher": "ArangeMatcher",
+    "paddle_api": "paddle.arange",
+    "args_list": [
+      "start",
+      "end",
+      "step",
+      "dtype",
+      "layout",
+      "device",
+      "requires_grad"
+    ]
+  },
+  "torch.arccos": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.acos",
     "args_list": [
       "input",
       "out"
@@ -1149,7 +2623,7 @@
       "input": "x"
     }
   },
-  "torch.asin": {
+  "torch.arcsin": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.asin",
     "args_list": [
@@ -1160,7 +2634,118 @@
       "input": "x"
     }
   },
-  "torch.arcsin": {
+  "torch.arcsinh": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.asinh",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.arctan": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.atan",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.arctan2": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.atan2",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "other": "y"
+    }
+  },
+  "torch.arctanh": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.atanh",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.argmax": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.argmax",
+    "args_list": [
+      "input",
+      "dim",
+      "keepdim"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.argmin": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.argmin",
+    "args_list": [
+      "input",
+      "dim",
+      "keepdim"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.argsort": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.argsort",
+    "args_list": [
+      "input",
+      "dim",
+      "descending",
+      "stable"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    },
+    "unsupport_args": [
+      "stable"
+    ]
+  },
+  "torch.argwhere": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nonzero",
+    "args_list": [
+      "input"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.as_tensor": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.to_tensor",
+    "args_list": [
+      "data",
+      "dtype",
+      "device"
+    ],
+    "kwargs_change": {
+      "device": "place"
+    }
+  },
+  "torch.asin": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.asin",
     "args_list": [
@@ -1182,53 +2767,9 @@
       "input": "x"
     }
   },
-  "torch.arcsinh": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.asinh",
-    "args_list": [
-      "input",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
   "torch.atan": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.atan",
-    "args_list": [
-      "input",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.arctan": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.atan",
-    "args_list": [
-      "input",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.atanh": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.atanh",
-    "args_list": [
-      "input",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.arctanh": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.atanh",
     "args_list": [
       "input",
       "out"
@@ -1250,9 +2791,97 @@
       "other": "y"
     }
   },
-  "torch.arctan2": {
+  "torch.atanh": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.atan2",
+    "paddle_api": "paddle.atanh",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.autograd.grad": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.grad",
+    "args_list": [
+      "outputs",
+      "inputs",
+      "grad_outputs",
+      "retain_graph",
+      "create_graph",
+      "only_inputs",
+      "allow_unused",
+      "is_grads_batched"
+    ],
+    "kwargs_change": {
+      "is_grads_batched": ""
+    },
+    "unsupport_args": [
+      "only_inputs"
+    ]
+  },
+  "torch.backends.cuda.is_built": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.device.is_compiled_with_cuda"
+  },
+  "torch.backends.cudnn.benchmark": {
+    "Matcher": "DeleteMatcher"
+  },
+  "torch.backends.cudnn.deterministic": {
+    "Matcher": "DeleteMatcher"
+  },
+  "torch.backends.cudnn.is_available": {
+    "Matcher": "CudnnIsAvailableMatcher"
+  },
+  "torch.backends.cudnn.version": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.device.get_cudnn_version"
+  },
+  "torch.baddbmm": {
+    "Matcher": "AddMRMatcher",
+    "paddle_api": "paddle.bmm",
+    "args_list": [
+      "input",
+      "batch1",
+      "batch2",
+      "alpha",
+      "beta",
+      "out"
+    ]
+  },
+  "torch.bernoulli": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.bernoulli",
+    "args_list": [
+      "input",
+      "generator",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.bfloat16": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "'bfloat16'"
+  },
+  "torch.bincount": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.bincount",
+    "args_list": [
+      "input",
+      "weights",
+      "minlength"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.bitwise_and": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.bitwise_and",
     "args_list": [
       "input",
       "other",
@@ -1272,19 +2901,6 @@
     ],
     "kwargs_change": {
       "input": "x"
-    }
-  },
-  "torch.bitwise_and": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.bitwise_and",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "other": "y"
     }
   },
   "torch.bitwise_or": {
@@ -1313,11 +2929,164 @@
       "other": "y"
     }
   },
+  "torch.bmm": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.bmm",
+    "args_list": [
+      "input",
+      "mat2",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "mat2": "y"
+    }
+  },
+  "torch.bool": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "'bool'"
+  },
+  "torch.broadcast_to": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.broadcast_to",
+    "args_list": [
+      "input",
+      "size"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "size": "shape"
+    }
+  },
+  "torch.bucketize": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.bucketize",
+    "args_list": [
+      "input",
+      "boundaries",
+      "out_int32",
+      "right"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "boundaries": "sorted_sequence"
+    }
+  },
+  "torch.cat": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.concat",
+    "args_list": [
+      "tensors",
+      "dim",
+      "out"
+    ],
+    "kwargs_change": {
+      "tensors": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.cdist": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.cdist",
+    "args_list": [
+      "x1",
+      "x2",
+      "p",
+      "compute_mode"
+    ],
+    "kwargs_change": {
+      "x1": "x",
+      "x2": "y"
+    }
+  },
+  "torch.cdouble": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "'complex128'"
+  },
   "torch.ceil": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.ceil",
     "args_list": [
       "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.cfloat": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "'complex64'"
+  },
+  "torch.chain_matmul": {
+    "Matcher": "Chain_MatmulMatcher"
+  },
+  "torch.cholesky": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.linalg.cholesky",
+    "args_list": [
+      "input",
+      "upper",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.cholesky_inverse": {
+    "Matcher": "CholeskyInverseMatcher",
+    "args_list": [
+      "input",
+      "upper",
+      "out"
+    ]
+  },
+  "torch.cholesky_solve": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.linalg.cholesky_solve",
+    "args_list": [
+      "input",
+      "input2",
+      "upper",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "input2": "y"
+    }
+  },
+  "torch.chunk": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.chunk",
+    "args_list": [
+      "input",
+      "chunks",
+      "dim"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.clamp": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.clip",
+    "args_list": [
+      "input",
+      "min",
+      "max",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.clamp_min": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.clip",
+    "args_list": [
+      "input",
+      "min",
       "out"
     ],
     "kwargs_change": {
@@ -1337,24 +3106,53 @@
       "input": "x"
     }
   },
-  "torch.narrow": {
-    "Matcher": "NarrowMatcher",
+  "torch.clone": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.clone",
     "args_list": [
       "input",
-      "dim",
-      "start",
-      "length"
-    ]
+      "memory_format"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
   },
-  "torch.narrow_copy": {
-    "Matcher": "NarrowCopyMatcher",
+  "torch.column_stack": {
+    "Matcher": "ColumnStackMatcher",
     "args_list": [
-      "input",
-      "dim",
-      "start",
-      "length",
+      "tensors",
       "out"
     ]
+  },
+  "torch.complex": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.complex",
+    "args_list": [
+      "real",
+      "imag",
+      "out"
+    ]
+  },
+  "torch.complex128": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "'complex128'"
+  },
+  "torch.complex64": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "'complex64'"
+  },
+  "torch.concat": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.concat",
+    "args_list": [
+      "tensors",
+      "dim",
+      "out"
+    ],
+    "kwargs_change": {
+      "tensors": "x",
+      "dim": "axis"
+    }
   },
   "torch.conj": {
     "Matcher": "GenericMatcher",
@@ -1387,6 +3185,17 @@
       "input": "x"
     }
   },
+  "torch.cosh": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.cosh",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
   "torch.cosine_similarity": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.nn.functional.cosine_similarity",
@@ -1400,16 +3209,176 @@
       "dim": "axis"
     }
   },
-  "torch.cosh": {
+  "torch.count_nonzero": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.cosh",
+    "paddle_api": "paddle.count_nonzero",
     "args_list": [
       "input",
+      "dim"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.cov": {
+    "Matcher": "CovMatcher",
+    "args_list": [
+      "input",
+      "correction",
+      "fweight",
+      "aweight"
+    ]
+  },
+  "torch.cross": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.cross",
+    "args_list": [
+      "input",
+      "other",
+      "dim",
       "out"
     ],
     "kwargs_change": {
-      "input": "x"
+      "input": "x",
+      "other": "y",
+      "dim": "axis"
     }
+  },
+  "torch.cuda.Event": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.device.cuda.Event",
+    "args_list": [
+      "enable_timing",
+      "blocking",
+      "interprocess"
+    ]
+  },
+  "torch.cuda.current_stream": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.device.cuda.current_stream",
+    "args_list": [
+      "device"
+    ],
+    "kwargs_change": {
+      "device": "device"
+    }
+  },
+  "torch.cuda.device_count": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.device.cuda.device_count"
+  },
+  "torch.cuda.empty_cache": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.device.cuda.empty_cache"
+  },
+  "torch.cuda.get_device_capability": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.device.cuda.get_device_capability",
+    "args_list": [
+      "device"
+    ],
+    "kwargs_change": {
+      "device": "device"
+    }
+  },
+  "torch.cuda.get_device_properties": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.device.cuda.get_device_properties",
+    "args_list": [
+      "device"
+    ],
+    "kwargs_change": {
+      "device": "device"
+    }
+  },
+  "torch.cuda.is_available": {
+    "Matcher": "CudaIsAvailableMatcher",
+    "paddle_api": "paddle.device.cuda.device_count"
+  },
+  "torch.cuda.manual_seed": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.seed",
+    "args_list": [
+      "seed"
+    ]
+  },
+  "torch.cuda.max_memory_allocated": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.device.cuda.max_memory_allocated",
+    "args_list": [
+      "device"
+    ],
+    "kwargs_change": {
+      "device": "device"
+    }
+  },
+  "torch.cuda.max_memory_reserved": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.device.cuda.max_memory_reserved",
+    "args_list": [
+      "device"
+    ],
+    "kwargs_change": {
+      "device": "device"
+    }
+  },
+  "torch.cuda.memory_allocated": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.device.cuda.memory_allocated",
+    "args_list": [
+      "device"
+    ],
+    "kwargs_change": {
+      "device": "device"
+    }
+  },
+  "torch.cuda.memory_reserved": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.device.cuda.memory_reserved",
+    "args_list": [
+      "device"
+    ],
+    "kwargs_change": {
+      "device": "device"
+    }
+  },
+  "torch.cuda.set_device": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.device.set_device",
+    "args_list": [
+      "device"
+    ],
+    "kwargs_change": {
+      "device": "device"
+    }
+  },
+  "torch.cuda.synchronize": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.device.cuda.synchronize",
+    "args_list": [
+      "device"
+    ]
+  },
+  "torch.cumprod": {
+    "Matcher": "CumprodMatcher",
+    "paddle_api": "paddle.cumprod",
+    "args_list": [
+      "input",
+      "dim",
+      "dtype",
+      "out"
+    ]
+  },
+  "torch.cumsum": {
+    "Matcher": "CumsumMatcher",
+    "paddle_api": "paddle.cumsum",
+    "args_list": [
+      "input",
+      "dim",
+      "dtype",
+      "out"
+    ]
   },
   "torch.deg2rad": {
     "Matcher": "GenericMatcher",
@@ -1420,6 +3389,88 @@
     ],
     "kwargs_change": {
       "input": "x"
+    }
+  },
+  "torch.det": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.linalg.det",
+    "args_list": [
+      "input"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.device": {
+    "Matcher": "DeviceMatcher",
+    "paddle_api": "str",
+    "args_list": [
+      "type",
+      "index"
+    ]
+  },
+  "torch.diag": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.diag",
+    "args_list": [
+      "input",
+      "diagonal",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "diagonal": "offset"
+    }
+  },
+  "torch.diag_embed": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.diag_embed",
+    "args_list": [
+      "input",
+      "offset",
+      "dim1",
+      "dim2"
+    ]
+  },
+  "torch.diagflat": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.diagflat",
+    "args_list": [
+      "input",
+      "offset"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.diagonal": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.diagonal",
+    "args_list": [
+      "input",
+      "offset",
+      "dim1",
+      "dim2"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim1": "axis1",
+      "dim2": "axis2"
+    }
+  },
+  "torch.diff": {
+    "Matcher": "DiffMatcher",
+    "paddle_api": "paddle.diff",
+    "args_list": [
+      "input",
+      "n",
+      "dim",
+      "prepend",
+      "append"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
     }
   },
   "torch.digamma": {
@@ -1433,48 +3484,141 @@
       "input": "x"
     }
   },
-  "torch.special.digamma": {
+  "torch.dist": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.digamma",
+    "paddle_api": "paddle.dist",
     "args_list": [
       "input",
+      "other",
+      "p"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "other": "y"
+    }
+  },
+  "torch.distributions.beta.Beta": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.distribution.Beta",
+    "args_list": [
+      "concentration1",
+      "concentration0",
+      "validate_args"
+    ],
+    "kwargs_change": {
+      "concentration1": "alpha",
+      "concentration0": "beta"
+    }
+  },
+  "torch.distributions.kl.kl_divergence": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.distribution.kl_divergence",
+    "args_list": [
+      "p",
+      "q"
+    ]
+  },
+  "torch.div": {
+    "Matcher": "DivMatcher",
+    "args_list": [
+      "input",
+      "other",
+      "rounding_mode",
       "out"
+    ]
+  },
+  "torch.divide": {
+    "Matcher": "DivMatcher",
+    "args_list": [
+      "input",
+      "other",
+      "rounding_mode",
+      "out"
+    ]
+  },
+  "torch.dot": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.dot",
+    "args_list": [
+      "input",
+      "tensor",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "tensor": "y"
+    }
+  },
+  "torch.double": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "'float64'"
+  },
+  "torch.dstack": {
+    "args_list": [
+      "tensors",
+      "out"
+    ],
+    "kwargs_change": {
+      "tensors": "x"
+    }
+  },
+  "torch.dtype": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.dtype"
+  },
+  "torch.einsum": {
+    "Matcher": "IdentityMatcher",
+    "paddle_api": "paddle.einsum"
+  },
+  "torch.empty": {
+    "Matcher": "CreateMatcher",
+    "paddle_api": "paddle.empty"
+  },
+  "torch.empty_like": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.empty_like",
+    "args_list": [
+      "input",
+      "dtype",
+      "layout",
+      "device",
+      "requires_grad",
+      "memory_format"
     ],
     "kwargs_change": {
       "input": "x"
     }
   },
-  "torch.special.psi": {
+  "torch.enable_grad": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.digamma",
-    "args_list": [
-      "input",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
+    "paddle_api": "paddle.enable_grad"
   },
-  "torch.special.xlog1py": {
-    "Matcher": "SpecialXLog1pYMatcher",
+  "torch.eq": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.equal",
     "args_list": [
       "input",
       "other",
       "out"
-    ]
-  },
-  "torch.erf": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.erf",
-    "args_list": [
-      "input",
-      "out"
     ],
     "kwargs_change": {
-      "input": "x"
+      "input": "x",
+      "other": "y"
     }
   },
-  "torch.special.erf": {
+  "torch.equal": {
+    "Matcher": "EqualMatcher",
+    "paddle_api": "paddle.equal_all",
+    "args_list": [
+      "input",
+      "other"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "other": "y"
+    }
+  },
+  "torch.erf": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.erf",
     "args_list": [
@@ -1489,14 +3633,6 @@
     "Matcher": "ErfCMatcher",
     "args_list": [
       "input",
-      "out"
-    ]
-  },
-  "torch.fmod": {
-    "Matcher": "FModMatcher",
-    "args_list": [
-      "input",
-      "other",
       "out"
     ]
   },
@@ -1537,37 +3673,288 @@
       "input": "x"
     }
   },
-  "torch.ldexp": {
-    "Matcher": "LdExpMatcher",
+  "torch.eye": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.eye",
     "args_list": [
-      "input",
-      "other",
-      "out"
-    ]
+      "n",
+      "m",
+      "out",
+      "dtype",
+      "layout",
+      "device",
+      "requires_grad"
+    ],
+    "kwargs_change": {
+      "n": "num_rows",
+      "m": "num_columns"
+    }
   },
-  "torch.logaddexp": {
-    "Matcher": "LogAddExpMatcher",
+  "torch.fft.fft": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.fft.fft",
     "args_list": [
       "input",
-      "other",
+      "n",
+      "dim",
+      "norm",
       "out"
-    ]
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
   },
-  "torch.logaddexp2": {
-    "Matcher": "LogAddExp2Matcher",
+  "torch.fft.fft2": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.fft.fft2",
     "args_list": [
       "input",
-      "other",
+      "s",
+      "dim",
+      "norm",
       "out"
-    ]
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axes"
+    }
   },
-  "torch.xlogy": {
-    "Matcher": "XLogYMatcher",
+  "torch.fft.fftfreq": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.fft.fftfreq",
+    "args_list": [
+      "n",
+      "d",
+      "dtype",
+      "layout",
+      "device",
+      "requires_grad"
+    ],
+    "kwargs_change": {
+      "dim": "axis",
+      "input": "x"
+    }
+  },
+  "torch.fft.fftn": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.fft.fftn",
     "args_list": [
       "input",
-      "other",
+      "s",
+      "dim",
+      "norm",
       "out"
-    ]
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axes"
+    }
+  },
+  "torch.fft.fftshift": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.fft.fftshift",
+    "args_list": [
+      "input",
+      "dim"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axes"
+    }
+  },
+  "torch.fft.hfft": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.fft.hfft",
+    "args_list": [
+      "input",
+      "n",
+      "dim",
+      "norm",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.fft.ifft": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.fft.ifft",
+    "args_list": [
+      "input",
+      "n",
+      "dim",
+      "norm",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.fft.ifft2": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.fft.ifft2",
+    "args_list": [
+      "input",
+      "s",
+      "dim",
+      "norm",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axes"
+    }
+  },
+  "torch.fft.ifftn": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.fft.ifftn",
+    "args_list": [
+      "input",
+      "s",
+      "dim",
+      "norm",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axes"
+    }
+  },
+  "torch.fft.ifftshift": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.fft.ifftshift",
+    "args_list": [
+      "input",
+      "dim"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axes"
+    }
+  },
+  "torch.fft.ihfft": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.fft.ihfft",
+    "args_list": [
+      "input",
+      "n",
+      "dim",
+      "norm",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.fft.irfft": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.fft.irfft",
+    "args_list": [
+      "input",
+      "n",
+      "dim",
+      "norm",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.fft.irfft2": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.fft.irfft2",
+    "args_list": [
+      "input",
+      "s",
+      "dim",
+      "norm",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axes"
+    }
+  },
+  "torch.fft.irfftn": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.fft.irfftn",
+    "args_list": [
+      "input",
+      "s",
+      "dim",
+      "norm",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axes"
+    }
+  },
+  "torch.fft.rfft": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.fft.rfft",
+    "args_list": [
+      "input",
+      "n",
+      "dim",
+      "norm",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.fft.rfft2": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.fft.rfft2",
+    "args_list": [
+      "input",
+      "s",
+      "dim",
+      "norm",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axes"
+    }
+  },
+  "torch.fft.rfftfreq": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.fft.rfftfreq",
+    "args_list": [
+      "n",
+      "d",
+      "dtype",
+      "layout",
+      "device",
+      "requires_grad"
+    ],
+    "kwargs_change": {
+      "dim": "axis",
+      "input": "x"
+    }
+  },
+  "torch.fft.rfftn": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.fft.rfftn",
+    "args_list": [
+      "input",
+      "s",
+      "dim",
+      "norm",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axes"
+    }
   },
   "torch.fix": {
     "Matcher": "GenericMatcher",
@@ -1577,13 +3964,73 @@
       "out"
     ]
   },
-  "torch.trunc": {
+  "torch.flatten": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.trunc",
+    "paddle_api": "paddle.flatten",
     "args_list": [
       "input",
-      "out"
-    ]
+      "start_dim",
+      "end_dim"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "start_dim": "start_axis",
+      "end_dim": "stop_axis"
+    }
+  },
+  "torch.flip": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.flip",
+    "args_list": [
+      "input",
+      "dims"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dims": "axis"
+    }
+  },
+  "torch.fliplr": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.flip",
+    "args_list": [
+      "input"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    },
+    "paddle_default_kwargs": {
+      "axis": 1
+    }
+  },
+  "torch.flipud": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.flip",
+    "args_list": [
+      "input"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    },
+    "paddle_default_kwargs": {
+      "axis": 0
+    }
+  },
+  "torch.float": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "'float32'"
+  },
+  "torch.float16": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "'float16'"
+  },
+  "torch.float32": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "'float32'"
+  },
+  "torch.float64": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "'float64'"
   },
   "torch.floor": {
     "Matcher": "GenericMatcher",
@@ -1605,6 +4052,40 @@
       "out"
     ]
   },
+  "torch.fmax": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.fmax",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "other": "y"
+    }
+  },
+  "torch.fmin": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.fmin",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "other": "y"
+    }
+  },
+  "torch.fmod": {
+    "Matcher": "FModMatcher",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ]
+  },
   "torch.frac": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.frac",
@@ -1615,6 +4096,418 @@
     "kwargs_change": {
       "input": "x"
     }
+  },
+  "torch.from_numpy": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.to_tensor",
+    "args_list": [
+      "ndarray"
+    ],
+    "kwargs_change": {
+      "ndarray": "data"
+    }
+  },
+  "torch.full": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.full",
+    "args_list": [
+      "size",
+      "fill_value",
+      "dtype",
+      "layout",
+      "device",
+      "requires_grad"
+    ],
+    "kwargs_change": {
+      "size": "shape"
+    }
+  },
+  "torch.full_like": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.full_like",
+    "args_list": [
+      "input",
+      "fill_value",
+      "dtype",
+      "layout",
+      "device",
+      "requires_grad",
+      "memory_format"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.gather": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.take_along_axis",
+    "args_list": [
+      "input",
+      "dim",
+      "index",
+      "sparse_grad",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "arr",
+      "dim": "axis",
+      "index": "indices",
+      "sparse_grad": ""
+    }
+  },
+  "torch.gcd": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.gcd",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "other": "y"
+    }
+  },
+  "torch.ge": {
+    "Matcher": "Num2TensorBinaryMatcher",
+    "paddle_api": "paddle.greater_equal",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ]
+  },
+  "torch.ger": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.outer",
+    "args_list": [
+      "input",
+      "vec2",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "vec2": "y"
+    }
+  },
+  "torch.get_default_dtype": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.get_default_dtype"
+  },
+  "torch.get_rng_state": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.get_cuda_rng_state"
+  },
+  "torch.greater": {
+    "Matcher": "Num2TensorBinaryMatcher",
+    "paddle_api": "paddle.greater_than",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ]
+  },
+  "torch.greater_equal": {
+    "Matcher": "Num2TensorBinaryMatcher",
+    "paddle_api": "paddle.greater_equal",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ]
+  },
+  "torch.gt": {
+    "Matcher": "Num2TensorBinaryMatcher",
+    "paddle_api": "paddle.greater_than",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ]
+  },
+  "torch.half": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "'float16'"
+  },
+  "torch.heaviside": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.heaviside",
+    "args_list": [
+      "input",
+      "values",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "values": "y"
+    }
+  },
+  "torch.histc": {
+    "Matcher": "HistcMatcher",
+    "paddle_api": "paddle.histogram",
+    "args_list": [
+      "input",
+      "bins",
+      "min",
+      "max",
+      "out"
+    ]
+  },
+  "torch.hstack": {
+    "Matcher": "HStackMatcher",
+    "args_list": [
+      "tensors",
+      "out"
+    ]
+  },
+  "torch.hypot": {
+    "Matcher": "HypotMatcher",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ]
+  },
+  "torch.imag": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.imag",
+    "args_list": [
+      "input"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.index_add": {
+    "Matcher": "IndexAddMatcher",
+    "paddle_api": "paddle.index_add",
+    "args_list": [
+      "input",
+      "dim",
+      "index",
+      "source",
+      "alpha",
+      "out"
+    ]
+  },
+  "torch.index_select": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.index_select",
+    "args_list": [
+      "input",
+      "dim",
+      "index",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.initial_seed": {
+    "Matcher": "SeedMatcher"
+  },
+  "torch.inner": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.inner",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "other": "y"
+    }
+  },
+  "torch.int": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "'int32'"
+  },
+  "torch.int16": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "'int16'"
+  },
+  "torch.int32": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "'int32'"
+  },
+  "torch.int64": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "'int64'"
+  },
+  "torch.int8": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "'int8'"
+  },
+  "torch.inverse": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.linalg.inv",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.is_complex": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.is_complex",
+    "args_list": [
+      "input"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.is_floating_point": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.is_floating_point",
+    "args_list": [
+      "input"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.is_nonzero": {
+    "Matcher": "IsNonzeroMatcher",
+    "args_list": [
+      "input"
+    ]
+  },
+  "torch.is_tensor": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.is_tensor",
+    "args_list": [
+      "obj"
+    ],
+    "kwargs_change": {
+      "obj": "x"
+    }
+  },
+  "torch.isclose": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.isclose",
+    "args_list": [
+      "input",
+      "other",
+      "rtol",
+      "atol",
+      "equal_nan"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "other": "y"
+    }
+  },
+  "torch.isfinite": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.isfinite",
+    "args_list": [
+      "input"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.isinf": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.isinf",
+    "args_list": [
+      "input"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.isnan": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.isnan",
+    "args_list": [
+      "input"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.istft": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.signal.istft",
+    "args_list": [
+      "input",
+      "n_fft",
+      "hop_length",
+      "win_length",
+      "window",
+      "center",
+      "normalized",
+      "onesided",
+      "length",
+      "return_complex"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.kron": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.kron",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "other": "y"
+    }
+  },
+  "torch.kthvalue": {
+    "Matcher": "TupleAssignMatcher",
+    "paddle_api": "paddle.kthvalue",
+    "args_list": [
+      "input",
+      "k",
+      "dim",
+      "keepdim",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.lcm": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.lcm",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "other": "y"
+    }
+  },
+  "torch.ldexp": {
+    "Matcher": "LdExpMatcher",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ]
+  },
+  "torch.le": {
+    "Matcher": "Num2TensorBinaryMatcher",
+    "paddle_api": "paddle.less_equal",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ]
   },
   "torch.lerp": {
     "Matcher": "GenericMatcher",
@@ -1630,6 +4523,24 @@
       "end": "y"
     }
   },
+  "torch.less": {
+    "Matcher": "Num2TensorBinaryMatcher",
+    "paddle_api": "paddle.less_than",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ]
+  },
+  "torch.less_equal": {
+    "Matcher": "Num2TensorBinaryMatcher",
+    "paddle_api": "paddle.less_equal",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ]
+  },
   "torch.lgamma": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.lgamma",
@@ -1639,6 +4550,171 @@
     ],
     "kwargs_change": {
       "input": "x"
+    }
+  },
+  "torch.linalg.cholesky": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.linalg.cholesky",
+    "args_list": [
+      "A",
+      "upper",
+      "out"
+    ],
+    "kwargs_change": {
+      "A": "x"
+    }
+  },
+  "torch.linalg.cross": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.cross",
+    "args_list": [
+      "input",
+      "other",
+      "dim",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "other": "y",
+      "dim": "axis"
+    },
+    "paddle_default_kwargs": {
+      "axis": -1
+    }
+  },
+  "torch.linalg.det": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.linalg.det",
+    "args_list": [
+      "A",
+      "out"
+    ],
+    "kwargs_change": {
+      "A": "x"
+    }
+  },
+  "torch.linalg.diagonal": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.diagonal",
+    "args_list": [
+      "A",
+      "offset",
+      "dim1",
+      "dim2"
+    ],
+    "kwargs_change": {
+      "A": "x",
+      "dim1": "axis1",
+      "dim2": "axis2"
+    },
+    "paddle_default_kwargs": {
+      "axis1": -2,
+      "axis2": -1
+    }
+  },
+  "torch.linalg.eig": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.linalg.eig",
+    "args_list": [
+      "A",
+      "out"
+    ],
+    "kwargs_change": {
+      "A": "x"
+    }
+  },
+  "torch.linalg.eigvals": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.linalg.eigvals",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.linalg.lstsq": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.linalg.lstsq",
+    "args_list": [
+      "A",
+      "B",
+      "rcond",
+      "driver"
+    ],
+    "kwargs_change": {
+      "A": "x",
+      "B": "y"
+    }
+  },
+  "torch.linalg.matmul": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.matmul",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "other": "y"
+    }
+  },
+  "torch.linalg.norm": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.linalg.norm",
+    "args_list": [
+      "input",
+      "p",
+      "dim",
+      "keepdim",
+      "out",
+      "dtype"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis",
+      "ord": "p"
+    }
+  },
+  "torch.linalg.slogdet": {
+    "Matcher": "SLogDetMatcher",
+    "paddle_api": "paddle.linalg.slogdet",
+    "args_list": [
+      "A"
+    ]
+  },
+  "torch.linspace": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.linspace",
+    "args_list": [
+      "start",
+      "end",
+      "steps",
+      "out",
+      "dtype",
+      "layout",
+      "device",
+      "requires_grad"
+    ],
+    "kwargs_change": {
+      "end": "stop",
+      "steps": "num"
+    }
+  },
+  "torch.load": {
+    "Matcher": "LoadMatcher",
+    "paddle_api": "paddle.load",
+    "args_list": [
+      "f",
+      "map_location",
+      "pickle_module",
+      "weights_only",
+      "pickle_load_args"
+    ],
+    "kwargs_change": {
+      "f": "path"
     }
   },
   "torch.log": {
@@ -1684,6 +4760,41 @@
     "kwargs_change": {
       "input": "x"
     }
+  },
+  "torch.logaddexp": {
+    "Matcher": "LogAddExpMatcher",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ]
+  },
+  "torch.logaddexp2": {
+    "Matcher": "LogAddExp2Matcher",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ]
+  },
+  "torch.logcumsumexp": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.logcumsumexp",
+    "args_list": [
+      "input",
+      "dim",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.logdet": {
+    "Matcher": "LogDetMatcher",
+    "args_list": [
+      "input"
+    ]
   },
   "torch.logical_and": {
     "Matcher": "LogicalMatcher",
@@ -1743,390 +4854,23 @@
       "input": "x"
     }
   },
-  "torch.mul": {
-    "Matcher": "MulMatcher",
-    "paddle_api": "paddle.multiply",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ]
-  },
-  "torch.multiply": {
-    "Matcher": "Num2TensorBinaryMatcher",
-    "paddle_api": "paddle.multiply",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ]
-  },
-  "torch.neg": {
+  "torch.logspace": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.neg",
+    "paddle_api": "paddle.logspace",
     "args_list": [
-      "input",
-      "out"
+      "start",
+      "end",
+      "steps",
+      "base",
+      "out",
+      "dtype",
+      "layout",
+      "device",
+      "requires_grad"
     ],
     "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.negative": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.neg",
-    "args_list": [
-      "input",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.pow": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.pow",
-    "args_list": [
-      "input",
-      "exponent",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "exponent": "y"
-    }
-  },
-  "torch.polar": {
-    "Matcher": "PolarMatcher",
-    "args_list": [
-      "abs",
-      "angle",
-      "out"
-    ]
-  },
-  "torch.rad2deg": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.rad2deg",
-    "args_list": [
-      "input",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.reciprocal": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.reciprocal",
-    "args_list": [
-      "input",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.remainder": {
-    "Matcher": "Num2TensorBinaryMatcher",
-    "paddle_api": "paddle.remainder",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ]
-  },
-  "torch.rsqrt": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.rsqrt",
-    "args_list": [
-      "input",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.sigmoid": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.sigmoid",
-    "args_list": [
-      "input",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.sign": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.sign",
-    "args_list": [
-      "input",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.sin": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.sin",
-    "args_list": [
-      "input",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.sinc": {
-    "Matcher": "SincMatcher",
-    "args_list": [
-      "input",
-      "out"
-    ]
-  },
-  "torch.special.sinc": {
-    "Matcher": "SincMatcher",
-    "args_list": [
-      "input",
-      "out"
-    ]
-  },
-  "torch.special.ndtri": {
-    "Matcher": "SpecialNdtriMatcher",
-    "args_list": [
-      "input",
-      "out"
-    ]
-  },
-  "torch.sinh": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.sinh",
-    "args_list": [
-      "input",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.sqrt": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.sqrt",
-    "args_list": [
-      "input",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.square": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.square",
-    "args_list": [
-      "input",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.tan": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.tan",
-    "args_list": [
-      "input",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.tanh": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.tanh",
-    "args_list": [
-      "input",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.true_divide": {
-    "Matcher": "TrueDivideMatcher",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ]
-  },
-  "torch.argmax": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.argmax",
-    "args_list": [
-      "input",
-      "dim",
-      "keepdim"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.argmin": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.argmin",
-    "args_list": [
-      "input",
-      "dim",
-      "keepdim"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.argsort": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.argsort",
-    "args_list": [
-      "input",
-      "dim",
-      "descending",
-      "stable"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    },
-    "unsupport_args": [
-      "stable"
-    ]
-  },
-  "torch.argwhere": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nonzero",
-    "args_list": [
-      "input"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.amax": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.amax",
-    "args_list": [
-      "input",
-      "dim",
-      "keepdim",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.amin": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.amin",
-    "args_list": [
-      "input",
-      "dim",
-      "keepdim",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.aminmax": {
-    "Matcher": "AMinMaxMatcher",
-    "args_list": [
-      "input",
-      "dim",
-      "keepdim",
-      "out"
-    ]
-  },
-  "torch.all": {
-    "Matcher": "AllMatcher",
-    "paddle_api": "paddle.all",
-    "args_list": [
-      "input",
-      "dim",
-      "keepdim",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.any": {
-    "Matcher": "AllMatcher",
-    "paddle_api": "paddle.any",
-    "args_list": [
-      "input",
-      "dim",
-      "keepdim",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.distributions.kl.kl_divergence": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.distribution.kl_divergence",
-    "args_list": [
-      "p",
-      "q"
-    ]
-  },
-  "torch.distributions.beta.Beta": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.distribution.Beta",
-    "args_list": [
-      "concentration1",
-      "concentration0",
-      "validate_args"
-    ],
-    "kwargs_change": {
-      "concentration1": "alpha",
-      "concentration0": "beta"
-    }
-  },
-  "torch.dist": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.dist",
-    "args_list": [
-      "input",
-      "other",
-      "p"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "other": "y"
-    }
-  },
-  "torch.cdist": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.cdist",
-    "args_list": [
-      "x1",
-      "x2",
-      "p",
-      "compute_mode"
-    ],
-    "kwargs_change": {
-      "x1": "x",
-      "x2": "y"
+      "end": "stop",
+      "steps": "num"
     }
   },
   "torch.logsumexp": {
@@ -2143,29 +4887,116 @@
       "dim": "axis"
     }
   },
-  "torch.special.logsumexp": {
-    "Matcher": "LogsumexpMatcher",
-    "paddle_api": "paddle.logsumexp",
+  "torch.long": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "'int64'"
+  },
+  "torch.lt": {
+    "Matcher": "Num2TensorBinaryMatcher",
+    "paddle_api": "paddle.less_than",
     "args_list": [
       "input",
-      "dim",
-      "keepdim",
+      "other",
+      "out"
+    ]
+  },
+  "torch.lu": {
+    "Matcher": "LuMatcher",
+    "paddle_api": "paddle.linalg.lu",
+    "args_list": [
+      "A",
+      "pivot",
+      "get_infos",
       "out"
     ],
     "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
+      "A": "x"
     }
   },
-  "torch.special.log1p": {
+  "torch.lu_unpack": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.log1p",
+    "paddle_api": "paddle.linalg.lu_unpack",
+    "args_list": [
+      "LU_data",
+      "LU_pivots",
+      "unpack_data",
+      "unpack_pivots",
+      "out"
+    ],
+    "kwargs_change": {
+      "LU_data": "x",
+      "LU_pivots": "y",
+      "unpack_data": "unpack_ludata"
+    }
+  },
+  "torch.manual_seed": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.seed",
+    "args_list": [
+      "seed"
+    ]
+  },
+  "torch.masked_select": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.masked_select",
     "args_list": [
       "input",
+      "mask",
       "out"
     ],
     "kwargs_change": {
       "input": "x"
+    }
+  },
+  "torch.matmul": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.matmul",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "other": "y"
+    }
+  },
+  "torch.matrix_power": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.linalg.matrix_power",
+    "args_list": [
+      "input",
+      "n",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.max": {
+    "Matcher": "MaxMinMatcher",
+    "paddle_api": "paddle.maximum",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "other": "y"
+    }
+  },
+  "torch.maximum": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.maximum",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "other": "y"
     }
   },
   "torch.mean": {
@@ -2200,396 +5031,17 @@
       "dim"
     ]
   },
-  "torch.nanmedian": {},
-  "torch.nan_to_num": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nan_to_num",
+  "torch.meshgrid": {
+    "Matcher": "MeshgridMatcher",
+    "paddle_api": "paddle.meshgrid",
     "args_list": [
-      "input",
-      "nan",
-      "posinf",
-      "neginf",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.mode": {
-    "Matcher": "TupleAssignMatcher",
-    "paddle_api": "paddle.mode",
-    "args_list": [
-      "input",
-      "dim",
-      "keepdim",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.norm": {
-    "Matcher": "NormMatcher",
-    "paddle_api": "paddle.linalg.norm",
-    "args_list": [
-      "input",
-      "ord",
-      "dim",
-      "keepdim",
-      "out",
-      "dtype"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.linalg.norm": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.linalg.norm",
-    "args_list": [
-      "input",
-      "p",
-      "dim",
-      "keepdim",
-      "out",
-      "dtype"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "ord": "p",
-      "dim": "axis"
-    }
-  },
-  "torch.nansum": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nansum",
-    "args_list": [
-      "input",
-      "dim",
-      "keepdim",
-      "dtype"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.nansum": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.nansum",
-    "args_list": [
-      "dim",
-      "keepdim",
-      "dtype"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.nanmean": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nanmean",
-    "args_list": [
-      "input",
-      "dim",
-      "keepdim",
-      "dtype",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.nanmean": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.nanmean",
-    "args_list": [
-      "dim",
-      "keepdim",
-      "dtype",
-      "out"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.prod": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.prod",
-    "args_list": [
-      "input",
-      "dim",
-      "keepdim",
-      "dtype",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.std": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.std",
-    "args_list": [
-      "input",
-      "dim",
-      "unbiased",
-      "keepdim",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.std_mean": {
-    "Matcher": "StdMeanMatcher",
-    "args_list": [
-      "input",
-      "dim",
-      "correction",
-      "keepdim",
-      "out"
+      "tensors",
+      "indexing"
     ]
   },
-  "torch.sum": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.sum",
-    "args_list": [
-      "input",
-      "dim",
-      "keepdim",
-      "dtype"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.unique": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.unique",
-    "args_list": [
-      "input",
-      "sorted",
-      "return_inverse",
-      "return_counts",
-      "dim"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    },
-    "unsupport_args": [
-      "sorted"
-    ]
-  },
-  "torch.unique_consecutive": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.unique_consecutive",
-    "args_list": [
-      "input",
-      "return_inverse",
-      "return_counts",
-      "dim"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.var": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.var",
-    "args_list": [
-      "input",
-      "dim",
-      "unbiased",
-      "keepdim",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.var_mean": {
-    "Matcher": "VarMeanMatcher",
-    "args_list": [
-      "input",
-      "dim",
-      "correction",
-      "keepdim",
-      "out"
-    ]
-  },
-  "torch.allclose": {
-    "Matcher": "AllcloseMatcher",
-    "paddle_api": "paddle.allclose",
-    "args_list": [
-      "input",
-      "other",
-      "rtol",
-      "atol",
-      "equal_nan"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "other": "y"
-    }
-  },
-  "torch.eq": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.equal",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "other": "y"
-    }
-  },
-  "torch.ge": {
-    "Matcher": "Num2TensorBinaryMatcher",
-    "paddle_api": "paddle.greater_equal",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ]
-  },
-  "torch.greater_equal": {
-    "Matcher": "Num2TensorBinaryMatcher",
-    "paddle_api": "paddle.greater_equal",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ]
-  },
-  "torch.gt": {
-    "Matcher": "Num2TensorBinaryMatcher",
-    "paddle_api": "paddle.greater_than",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ]
-  },
-  "torch.greater": {
-    "Matcher": "Num2TensorBinaryMatcher",
-    "paddle_api": "paddle.greater_than",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ]
-  },
-  "torch.isclose": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.isclose",
-    "args_list": [
-      "input",
-      "other",
-      "rtol",
-      "atol",
-      "equal_nan"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "other": "y"
-    }
-  },
-  "torch.isfinite": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.isfinite",
-    "args_list": [
-      "input"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.isinf": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.isinf",
-    "args_list": [
-      "input"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.isnan": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.isnan",
-    "args_list": [
-      "input"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.kthvalue": {
-    "Matcher": "TupleAssignMatcher",
-    "paddle_api": "paddle.kthvalue",
-    "args_list": [
-      "input",
-      "k",
-      "dim",
-      "keepdim",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.le": {
-    "Matcher": "Num2TensorBinaryMatcher",
-    "paddle_api": "paddle.less_equal",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ]
-  },
-  "torch.less_equal": {
-    "Matcher": "Num2TensorBinaryMatcher",
-    "paddle_api": "paddle.less_equal",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ]
-  },
-  "torch.lt": {
-    "Matcher": "Num2TensorBinaryMatcher",
-    "paddle_api": "paddle.less_than",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ]
-  },
-  "torch.less": {
-    "Matcher": "Num2TensorBinaryMatcher",
-    "paddle_api": "paddle.less_than",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ]
-  },
-  "torch.maximum": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.maximum",
+  "torch.min": {
+    "Matcher": "MaxMinMatcher",
+    "paddle_api": "paddle.minimum",
     "args_list": [
       "input",
       "other",
@@ -2613,940 +5065,89 @@
       "other": "y"
     }
   },
-  "torch.fmax": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.fmax",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "other": "y"
-    }
-  },
-  "torch.fmin": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.fmin",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "other": "y"
-    }
-  },
-  "torch.ne": {
-    "Matcher": "Num2TensorBinaryMatcher",
-    "paddle_api": "paddle.not_equal",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "other": "y"
-    }
-  },
-  "torch.not_equal": {
-    "Matcher": "Num2TensorBinaryMatcher",
-    "paddle_api": "paddle.not_equal",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "other": "y"
-    }
-  },
-  "torch.topk": {
-    "Matcher": "TupleAssignMatcher",
-    "paddle_api": "paddle.topk",
-    "args_list": [
-      "input",
-      "k",
-      "dim",
-      "largest",
-      "sorted",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.istft": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.signal.istft",
-    "args_list": [
-      "input",
-      "n_fft",
-      "hop_length",
-      "win_length",
-      "window",
-      "center",
-      "normalized",
-      "onesided",
-      "length",
-      "return_complex"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.index_add": {
-    "Matcher": "IndexAddMatcher",
-    "paddle_api": "paddle.index_add",
-    "args_list": [
-      "input",
-      "dim",
-      "index",
-      "source",
-      "alpha",
-      "out"
-    ]
-  },
-  "torch.bincount": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.bincount",
-    "args_list": [
-      "input",
-      "weights",
-      "minlength"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.broadcast_to": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.broadcast_to",
-    "args_list": [
-      "input",
-      "size"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "size": "shape"
-    }
-  },
-  "torch.clone": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.clone",
-    "args_list": [
-      "input",
-      "memory_format"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.soft_margin_loss": {
-    "Matcher": "SizeAverageMatcher",
-    "paddle_api": "paddle.nn.functional.soft_margin_loss",
-    "args_list": [
-      "input",
-      "target",
-      "size_average",
-      "reduce",
-      "reduction"
-    ],
-    "kwargs_change": {
-      "target": "label"
-    }
-  },
-  "torch.vander": {},
-  "torch.cross": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.cross",
-    "args_list": [
-      "input",
-      "other",
-      "dim",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "other": "y",
-      "dim": "axis"
-    }
-  },
-  "torch.linalg.cross": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.cross",
-    "args_list": [
-      "input",
-      "other",
-      "dim",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "other": "y",
-      "dim": "axis"
-    },
-    "paddle_default_kwargs": {
-      "axis": -1
-    }
-  },
-  "torch.cumprod": {
-    "Matcher": "CumprodMatcher",
-    "paddle_api": "paddle.cumprod",
-    "args_list": [
-      "input",
-      "dim",
-      "dtype",
-      "out"
-    ]
-  },
-  "torch.cumsum": {
-    "Matcher": "CumsumMatcher",
-    "paddle_api": "paddle.cumsum",
-    "args_list": [
-      "input",
-      "dim",
-      "dtype",
-      "out"
-    ]
-  },
-  "torch.diag": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.diag",
-    "args_list": [
-      "input",
-      "diagonal",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "diagonal": "offset"
-    }
-  },
-  "torch.diag_embed": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.diag_embed",
-    "args_list": [
-      "input",
-      "offset",
-      "dim1",
-      "dim2"
-    ]
-  },
-  "torch.diagflat": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.diagflat",
-    "args_list": [
-      "input",
-      "offset"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.diagonal": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.diagonal",
-    "args_list": [
-      "input",
-      "offset",
-      "dim1",
-      "dim2"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim1": "axis1",
-      "dim2": "axis2"
-    }
-  },
-  "torch.linalg.diagonal": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.diagonal",
-    "args_list": [
-      "A",
-      "offset",
-      "dim1",
-      "dim2"
-    ],
-    "kwargs_change": {
-      "A": "x",
-      "dim1": "axis1",
-      "dim2": "axis2"
-    },
-    "paddle_default_kwargs": {
-      "axis1": -2,
-      "axis2": -1
-    }
-  },
-  "torch.diff": {
-    "Matcher": "DiffMatcher",
-    "paddle_api": "paddle.diff",
-    "args_list": [
-      "input",
-      "n",
-      "dim",
-      "prepend",
-      "append"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.einsum": {
-    "Matcher": "IdentityMatcher",
-    "paddle_api": "paddle.einsum"
-  },
-  "torch.flatten": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.flatten",
-    "args_list": [
-      "input",
-      "start_dim",
-      "end_dim"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "start_dim": "start_axis",
-      "end_dim": "stop_axis"
-    }
-  },
-  "torch.flip": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.flip",
-    "args_list": [
-      "input",
-      "dims"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dims": "axis"
-    }
-  },
-  "torch.fliplr": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.flip",
-    "args_list": [
-      "input"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    },
-    "paddle_default_kwargs": {
-      "axis": 1
-    }
-  },
-  "torch.flipud": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.flip",
-    "args_list": [
-      "input"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    },
-    "paddle_default_kwargs": {
-      "axis": 0
-    }
-  },
-  "torch.kron": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.kron",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "other": "y"
-    }
-  },
-  "torch.rot90": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.rot90",
-    "args_list": [
-      "input",
-      "k",
-      "dims"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dims": "axes"
-    }
-  },
-  "torch.gcd": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.gcd",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "other": "y"
-    }
-  },
-  "torch.histc": {
-    "Matcher": "HistcMatcher",
-    "paddle_api": "paddle.histogram",
-    "args_list": [
-      "input",
-      "bins",
-      "min",
-      "max",
-      "out"
-    ]
-  },
-  "torch.lcm": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.lcm",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "other": "y"
-    }
-  },
-  "torch.logcumsumexp": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.logcumsumexp",
-    "args_list": [
-      "input",
-      "dim",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.ravel": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.flatten",
-    "args_list": [
-      "input"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.renorm": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.renorm",
-    "args_list": [
-      "input",
-      "p",
-      "dim",
-      "maxnorm",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis",
-      "maxnorm": "max_norm"
-    }
-  },
-  "torch.unflatten": {
-    "Matcher": "UnflattenMatcher",
-    "args_list": [
-      "input",
-      "dim",
-      "sizes"
-    ]
-  },
-  "torch.Tensor.renorm": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.renorm",
-    "args_list": [
-      "p",
-      "dim",
-      "maxnorm",
-      "out"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.roll": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.roll",
-    "args_list": [
-      "input",
-      "shifts",
-      "dims"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dims": "axis"
-    }
-  },
-  "torch.round": {
-    "Matcher": "RoundMatcher",
-    "args_list": [
-      "input",
-      "decimals",
-      "out"
-    ]
-  },
-  "torch.tensordot": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.tensordot",
-    "args_list": [
-      "a",
-      "b",
-      "dims",
-      "out"
-    ],
-    "kwargs_change": {
-      "a": "x",
-      "b": "y",
-      "dims": "axes"
-    }
-  },
-  "torch.trace": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.trace",
-    "args_list": [
-      "input"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.tril": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.tril",
-    "args_list": [
-      "input",
-      "diagonal",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.tril_indices": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.tril_indices",
-    "args_list": [
-      "row",
-      "col",
-      "offset",
-      "dtype",
-      "device",
-      "layout"
-    ]
-  },
-  "torch.triu": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.triu",
-    "args_list": [
-      "input",
-      "diagonal",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.triu_indices": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.triu_indices",
-    "args_list": [
-      "row",
-      "col",
-      "offset",
-      "dtype",
-      "device",
-      "layout"
-    ]
-  },
-  "torch.view_as_real": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.as_real",
-    "args_list": [
-      "input"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.view_as_complex": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.as_complex",
-    "args_list": [
-      "input"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.adjoint": {
-    "Matcher": "AdjointMatcher",
-    "args_list": [
-      "input"
-    ]
-  },
-  "torch.addmm": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.addmm",
-    "args_list": [
-      "input",
-      "mat1",
-      "mat2",
-      "alpha",
-      "beta",
-      "out"
-    ],
-    "kwargs_change": {
-      "mat1": "x",
-      "mat2": "y"
-    }
-  },
-  "torch.baddbmm": {
-    "Matcher": "AddMRMatcher",
-    "paddle_api": "paddle.bmm",
-    "args_list": [
-      "input",
-      "batch1",
-      "batch2",
-      "alpha",
-      "beta",
-      "out"
-    ]
-  },
-  "torch.addbmm": {
-    "Matcher": "AddBmmMatcher",
-    "args_list": [
-      "input",
-      "batch1",
-      "batch2",
-      "alpha",
-      "beta",
-      "out"
-    ]
-  },
-  "torch.addmv": {
-    "Matcher": "AddMRMatcher",
-    "paddle_api": "paddle.mm",
-    "args_list": [
-      "input",
-      "mat",
-      "vec",
-      "beta",
-      "alpha",
-      "out"
-    ]
-  },
-  "torch.addr": {
-    "Matcher": "AddMRMatcher",
-    "paddle_api": "paddle.outer",
-    "args_list": [
-      "input",
-      "vec1",
-      "vec2",
-      "beta",
-      "alpha",
-      "out"
-    ]
-  },
-  "torch.addcmul": {
-    "Matcher": "AddCMulMatcher",
-    "args_list": [
-      "input",
-      "tensor1",
-      "tensor2",
-      "value",
-      "out"
-    ]
-  },
-  "torch.addcdiv": {
-    "Matcher": "AddCDivMatcher",
-    "args_list": [
-      "input",
-      "tensor1",
-      "tensor2",
-      "value",
-      "out"
-    ]
-  },
-  "torch.bmm": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.bmm",
-    "args_list": [
-      "input",
-      "mat2",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "mat2": "y"
-    }
-  },
-  "torch.cholesky": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.linalg.cholesky",
-    "args_list": [
-      "input",
-      "upper",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.linalg.cholesky": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.linalg.cholesky",
-    "args_list": [
-      "A",
-      "upper",
-      "out"
-    ],
-    "kwargs_change": {
-      "A": "x"
-    }
-  },
-  "torch.cholesky_inverse": {
-    "Matcher": "CholeskyInverseMatcher",
-    "args_list": [
-      "input",
-      "upper",
-      "out"
-    ]
-  },
-  "torch.cholesky_solve": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.linalg.cholesky_solve",
-    "args_list": [
-      "input",
-      "input2",
-      "upper",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "input2": "y"
-    }
-  },
-  "torch.dot": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.dot",
-    "args_list": [
-      "input",
-      "tensor",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "tensor": "y"
-    }
-  },
-  "torch.vdot": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.dot",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "other": "y"
-    }
-  },
-  "torch.linalg.eig": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.linalg.eig",
-    "args_list": [
-      "A",
-      "out"
-    ],
-    "kwargs_change": {
-      "A": "x"
-    }
-  },
-  "torch.ger": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.outer",
-    "args_list": [
-      "input",
-      "vec2",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "vec2": "y"
-    }
-  },
-  "torch.outer": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.outer",
-    "args_list": [
-      "input",
-      "vec2",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "vec2": "y"
-    }
-  },
-  "torch.inner": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.inner",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "other": "y"
-    }
-  },
-  "torch.inverse": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.linalg.inv",
-    "args_list": [
-      "input",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.det": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.linalg.det",
-    "args_list": [
-      "input"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.linalg.det": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.linalg.det",
-    "args_list": [
-      "A",
-      "out"
-    ],
-    "kwargs_change": {
-      "A": "x"
-    }
-  },
-  "torch.slogdet": {
-    "Matcher": "SLogDetMatcher",
-    "paddle_api": "paddle.linalg.slogdet",
-    "args_list": [
-      "input"
-    ]
-  },
-  "torch.linalg.slogdet": {
-    "Matcher": "SLogDetMatcher",
-    "paddle_api": "paddle.linalg.slogdet",
-    "args_list": [
-      "A"
-    ]
-  },
-  "torch.logdet": {
-    "Matcher": "LogDetMatcher",
-    "args_list": [
-      "input"
-    ]
-  },
-  "torch.linalg.lstsq": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.linalg.lstsq",
-    "args_list": [
-      "A",
-      "B",
-      "rcond",
-      "driver"
-    ],
-    "kwargs_change": {
-      "A": "x",
-      "B": "y"
-    }
-  },
-  "torch.lu_unpack": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.linalg.lu_unpack",
-    "args_list": [
-      "LU_data",
-      "LU_pivots",
-      "unpack_data",
-      "unpack_pivots",
-      "out"
-    ],
-    "kwargs_change": {
-      "LU_data": "x",
-      "LU_pivots": "y",
-      "unpack_data": "unpack_ludata"
-    }
-  },
-  "torch.swapaxes": {
-    "Matcher": "SwapAxesMatcher",
-    "args_list": [
-      "input",
-      "axis0",
-      "axis1"
-    ]
-  },
-  "torch.swapdims": {
-    "Matcher": "TransposeMatcher",
-    "args_list": [
-      "input",
-      "dim0",
-      "dim1"
-    ]
-  },
-  "torch.matmul": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.matmul",
-    "args_list": [
-      "input",
-      "other",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "other": "y"
-    }
-  },
-  "torch.chain_matmul": {
-    "Matcher": "Chain_MatmulMatcher"
-  },
-  "torch.matrix_power": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.linalg.matrix_power",
-    "args_list": [
-      "input",
-      "n",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
   "torch.mm": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.mm",
     "args_list": [
       "input",
       "mat2",
+      "out"
+    ]
+  },
+  "torch.mode": {
+    "Matcher": "TupleAssignMatcher",
+    "paddle_api": "paddle.mode",
+    "args_list": [
+      "input",
+      "dim",
+      "keepdim",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.moveaxis": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.moveaxis",
+    "args_list": [
+      "input",
+      "source",
+      "destination"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.movedim": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.moveaxis",
+    "args_list": [
+      "input",
+      "source",
+      "destination"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.msort": {
+    "Matcher": "MSortMatcher",
+    "args_list": [
+      "input",
+      "out"
+    ]
+  },
+  "torch.mul": {
+    "Matcher": "MulMatcher",
+    "paddle_api": "paddle.multiply",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ]
+  },
+  "torch.multinomial": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.multinomial",
+    "args_list": [
+      "input",
+      "num_samples",
+      "replacement",
+      "generator",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.multiply": {
+    "Matcher": "Num2TensorBinaryMatcher",
+    "paddle_api": "paddle.multiply",
+    "args_list": [
+      "input",
+      "other",
       "out"
     ]
   },
@@ -3562,132 +5163,123 @@
       "input": "x"
     }
   },
-  "torch.pinverse": {
+  "torch.nan_to_num": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.linalg.pinv",
+    "paddle_api": "paddle.nan_to_num",
     "args_list": [
       "input",
-      "rcond"
+      "nan",
+      "posinf",
+      "neginf",
+      "out"
     ],
     "kwargs_change": {
       "input": "x"
     }
   },
-  "torch.triangular_solve": {
-    "Matcher": "TriangularSolveMatcher",
-    "paddle_api": "paddle.linalg.triangular_solve",
+  "torch.nanmean": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nanmean",
     "args_list": [
-      "b",
-      "A",
-      "upper",
-      "transpose",
-      "unitriangular",
+      "input",
+      "dim",
+      "keepdim",
+      "dtype",
       "out"
     ],
     "kwargs_change": {
-      "b": "y",
-      "A": "x"
+      "input": "x",
+      "dim": "axis"
     }
   },
-  "torch.equal": {
-    "Matcher": "EqualMatcher",
-    "paddle_api": "paddle.equal_all",
+  "torch.nanmedian": {},
+  "torch.nansum": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nansum",
     "args_list": [
       "input",
-      "other"
+      "dim",
+      "keepdim",
+      "dtype"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.narrow": {
+    "Matcher": "NarrowMatcher",
+    "args_list": [
+      "input",
+      "dim",
+      "start",
+      "length"
+    ]
+  },
+  "torch.narrow_copy": {
+    "Matcher": "NarrowCopyMatcher",
+    "args_list": [
+      "input",
+      "dim",
+      "start",
+      "length",
+      "out"
+    ]
+  },
+  "torch.ne": {
+    "Matcher": "Num2TensorBinaryMatcher",
+    "paddle_api": "paddle.not_equal",
+    "args_list": [
+      "input",
+      "other",
+      "out"
     ],
     "kwargs_change": {
       "input": "x",
       "other": "y"
     }
   },
-  "torch.tensor": {
-    "Matcher": "TorchTensorMatcher",
-    "paddle_api": "paddle.to_tensor",
+  "torch.neg": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.neg",
     "args_list": [
-      "data",
-      "dtype",
-      "device",
-      "requires_grad",
-      "pin_memory"
-    ]
-  },
-  "torch.randint": {
-    "Matcher": "RandintMatcher",
-    "paddle_api": "paddle.randint",
-    "args_list": [
-      "low",
-      "high",
-      "size"
+      "input",
+      "out"
     ],
     "kwargs_change": {
-      "size": "shape"
+      "input": "x"
     }
   },
-  "torch.__version__": {
+  "torch.negative": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.__version__"
-  },
-  "torch.nn.ParameterList": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.ParameterList",
+    "paddle_api": "paddle.neg",
     "args_list": [
-      "values"
+      "input",
+      "out"
     ],
     "kwargs_change": {
-      "values": "parameters"
+      "input": "x"
     }
   },
-  "torch.nn.Parameter": {
-    "Matcher": "ParameterMatcher",
+  "torch.nn.AdaptiveAvgPool1d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.AdaptiveAvgPool1D",
     "args_list": [
-      "data",
-      "requires_grad"
+      "output_size"
     ]
   },
-  "torch.nn.Fold": {
+  "torch.nn.AdaptiveAvgPool2d": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Fold",
+    "paddle_api": "paddle.nn.AdaptiveAvgPool2D",
     "args_list": [
-      "output_size",
-      "kernel_size",
-      "stride",
-      "padding",
-      "dilation"
-    ],
-    "kwargs_change": {
-      "output_size": "output_sizes",
-      "kernel_size": "kernel_sizes",
-      "stride": "strides",
-      "padding": "paddings",
-      "dilation": "dilations"
-    }
-  },
-  "torch.nn.MaxUnpool1d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.MaxUnPool1D",
-    "args_list": [
-      "kernel_size",
-      "stride",
-      "padding"
+      "output_size"
     ]
   },
-  "torch.nn.MaxUnpool2d": {
+  "torch.nn.AdaptiveAvgPool3d": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.MaxUnPool2D",
+    "paddle_api": "paddle.nn.AdaptiveAvgPool3D",
     "args_list": [
-      "kernel_size",
-      "stride",
-      "padding"
-    ]
-  },
-  "torch.nn.MaxUnpool3d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.MaxUnPool3D",
-    "args_list": [
-      "kernel_size",
-      "stride",
-      "padding"
+      "output_size"
     ]
   },
   "torch.nn.AdaptiveMaxPool1d": {
@@ -3723,25 +5315,12 @@
       "return_indices": "return_mask"
     }
   },
-  "torch.nn.AdaptiveAvgPool1d": {
+  "torch.nn.AlphaDropout": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.AdaptiveAvgPool1D",
+    "paddle_api": "paddle.nn.AlphaDropout",
     "args_list": [
-      "output_size"
-    ]
-  },
-  "torch.nn.AdaptiveAvgPool2d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.AdaptiveAvgPool2D",
-    "args_list": [
-      "output_size"
-    ]
-  },
-  "torch.nn.AdaptiveAvgPool3d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.AdaptiveAvgPool3D",
-    "args_list": [
-      "output_size"
+      "p",
+      "inplace"
     ]
   },
   "torch.nn.AvgPool1d": {
@@ -3779,71 +5358,93 @@
       "divisor_override"
     ]
   },
-  "torch.nn.ReflectionPad1d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Pad1D",
+  "torch.nn.BCEWithLogitsLoss": {
+    "Matcher": "SizeAverageMatcher",
+    "paddle_api": "paddle.nn.BCEWithLogitsLoss",
     "args_list": [
-      "padding"
+      "weight",
+      "size_average",
+      "reduce",
+      "reduction",
+      "pos_weight"
+    ]
+  },
+  "torch.nn.BatchNorm1d": {
+    "Matcher": "BatchNormMatcher",
+    "paddle_api": "paddle.nn.BatchNorm1D",
+    "args_list": [
+      "num_features",
+      "eps",
+      "momentum",
+      "affine",
+      "track_running_stats",
+      "device",
+      "dtype"
     ],
-    "paddle_default_kwargs": {
-      "mode": "'reflect'"
+    "kwargs_change": {
+      "eps": "epsilon",
+      "dtype": ""
     }
   },
-  "torch.nn.ReflectionPad2d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Pad2D",
+  "torch.nn.BatchNorm2d": {
+    "Matcher": "BatchNormMatcher",
+    "paddle_api": "paddle.nn.BatchNorm2D",
     "args_list": [
-      "padding"
+      "num_features",
+      "eps",
+      "momentum",
+      "affine",
+      "track_running_stats",
+      "device",
+      "dtype"
     ],
-    "paddle_default_kwargs": {
-      "mode": "'reflect'"
+    "kwargs_change": {
+      "eps": "epsilon",
+      "dtype": ""
     }
   },
-  "torch.nn.ReflectionPad3d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Pad3D",
+  "torch.nn.BatchNorm3d": {
+    "Matcher": "BatchNormMatcher",
+    "paddle_api": "paddle.nn.BatchNorm3D",
     "args_list": [
-      "padding"
+      "num_features",
+      "eps",
+      "momentum",
+      "affine",
+      "track_running_stats",
+      "device",
+      "dtype"
     ],
-    "paddle_default_kwargs": {
-      "mode": "'reflect'"
+    "kwargs_change": {
+      "eps": "epsilon",
+      "dtype": ""
     }
   },
-  "torch.nn.ReplicationPad1d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Pad1D",
+  "torch.nn.Bilinear": {
+    "Matcher": "LayerMatcher",
+    "paddle_api": "paddle.nn.Bilinear",
     "args_list": [
-      "padding"
-    ],
-    "paddle_default_kwargs": {
-      "mode": "'replicate'"
-    }
+      "in1_features",
+      "in2_features",
+      "out_features",
+      "bias",
+      "device",
+      "dtype"
+    ]
   },
-  "torch.nn.ReplicationPad2d": {
+  "torch.nn.CELU": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Pad2D",
+    "paddle_api": "paddle.nn.CELU",
     "args_list": [
-      "padding"
-    ],
-    "paddle_default_kwargs": {
-      "mode": "'replicate'"
-    }
+      "alpha",
+      "inplace"
+    ]
   },
-  "torch.nn.ReplicationPad3d": {
+  "torch.nn.ChannelShuffle": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Pad3D",
+    "paddle_api": "paddle.nn.ChannelShuffle",
     "args_list": [
-      "padding"
-    ],
-    "paddle_default_kwargs": {
-      "mode": "'replicate'"
-    }
-  },
-  "torch.nn.ZeroPad2d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.ZeroPad2D",
-    "args_list": [
-      "padding"
+      "groups"
     ]
   },
   "torch.nn.ConstantPad1d": {
@@ -3868,1393 +5469,6 @@
     "args_list": [
       "padding",
       "value"
-    ]
-  },
-  "torch.nn.ELU": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.ELU",
-    "args_list": [
-      "alpha",
-      "inplace"
-    ]
-  },
-  "torch.nn.Embedding": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Embedding",
-    "args_list": [
-      "num_embeddings",
-      "embedding_dim",
-      "padding_idx",
-      "max_norm",
-      "norm_type",
-      "scale_grad_by_freq",
-      "sparse"
-    ],
-    "unsupport_args": [
-      "max_norm",
-      "norm_type",
-      "scale_grad_by_freq"
-    ]
-  },
-  "torch.nn.functional.embedding": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.embedding",
-    "args_list": [
-      "input",
-      "weight",
-      "padding_idx",
-      "max_norm",
-      "norm_type",
-      "scale_grad_by_freq",
-      "sparse"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    },
-    "unsupport_args": [
-      "max_norm",
-      "norm_type",
-      "scale_grad_by_freq"
-    ]
-  },
-  "torch.nn.Hardshrink": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Hardshrink",
-    "args_list": [
-      "lambd"
-    ],
-    "kwargs_change": {
-      "lambd": "threshold"
-    }
-  },
-  "torch.nn.Hardsigmoid": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Hardsigmoid",
-    "args_list": [
-      "inplace"
-    ]
-  },
-  "torch.nn.Hardtanh": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Hardtanh",
-    "args_list": [
-      "min_val",
-      "max_val",
-      "inplace"
-    ],
-    "kwargs_change": {
-      "min_val": "min",
-      "max_val": "max"
-    }
-  },
-  "torch.nn.Hardswish": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Hardswish",
-    "args_list": [
-      "inplace"
-    ]
-  },
-  "torch.nn.LeakyReLU": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.LeakyReLU",
-    "args_list": [
-      "negative_slope",
-      "inplace"
-    ]
-  },
-  "torch.nn.LogSigmoid": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.LogSigmoid"
-  },
-  "torch.nn.PReLU": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.PReLU",
-    "args_list": [
-      "num_parameters",
-      "init",
-      "device",
-      "dtype"
-    ],
-    "kwargs_change": {
-      "dtype": ""
-    }
-  },
-  "torch.nn.ReLU": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.ReLU",
-    "args_list": [
-      "inplace"
-    ]
-  },
-  "torch.nn.ReLU6": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.ReLU6",
-    "args_list": [
-      "inplace"
-    ]
-  },
-  "torch.nn.RReLU": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.RReLU",
-    "args_list": [
-      "lower",
-      "upper",
-      "inplace"
-    ]
-  },
-  "torch.nn.SELU": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.SELU",
-    "args_list": [
-      "inplace"
-    ]
-  },
-  "torch.nn.CELU": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.CELU",
-    "args_list": [
-      "alpha",
-      "inplace"
-    ]
-  },
-  "torch.nn.Sigmoid": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Sigmoid"
-  },
-  "torch.nn.SiLU": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Silu",
-    "args_list": [
-      "inplace"
-    ]
-  },
-  "torch.nn.Softplus": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Softplus",
-    "args_list": [
-      "beta",
-      "threshold"
-    ]
-  },
-  "torch.nn.Softshrink": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Softshrink",
-    "args_list": [
-      "lambd"
-    ],
-    "kwargs_change": {
-      "lambd": "threshold"
-    }
-  },
-  "torch.nn.Softsign": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Softsign"
-  },
-  "torch.nn.Tanh": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Tanh"
-  },
-  "torch.nn.Tanhshrink": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Tanhshrink"
-  },
-  "torch.nn.Softmax": {
-    "Matcher": "SoftmaxMatcher",
-    "paddle_api": "paddle.nn.Softmax",
-    "args_list": [
-      "dim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.nn.LogSoftmax": {
-    "Matcher": "SoftmaxMatcher",
-    "paddle_api": "paddle.nn.LogSoftmax",
-    "args_list": [
-      "dim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.nn.LocalResponseNorm": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.LocalResponseNorm",
-    "args_list": [
-      "size",
-      "alpha",
-      "beta",
-      "k"
-    ]
-  },
-  "torch.nn.TransformerDecoder": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.TransformerDecoder",
-    "args_list": [
-      "decoder_layer",
-      "num_layers",
-      "norm"
-    ]
-  },
-  "torch.nn.Dropout": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Dropout",
-    "args_list": [
-      "p",
-      "inplace"
-    ]
-  },
-  "torch.nn.Dropout2d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Dropout2D",
-    "args_list": [
-      "p",
-      "inplace"
-    ]
-  },
-  "torch.nn.Dropout3d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Dropout3D",
-    "args_list": [
-      "p",
-      "inplace"
-    ]
-  },
-  "torch.nn.AlphaDropout": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.AlphaDropout",
-    "args_list": [
-      "p",
-      "inplace"
-    ]
-  },
-  "torch.nn.CosineSimilarity": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.CosineSimilarity",
-    "args_list": [
-      "dim",
-      "eps"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.nn.PairwiseDistance": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.PairwiseDistance",
-    "args_list": [
-      "p",
-      "eps",
-      "keepdim"
-    ],
-    "kwargs_change": {
-      "eps": "epsilon"
-    }
-  },
-  "torch.nn.TripletMarginWithDistanceLoss": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.TripletMarginWithDistanceLoss",
-    "args_list": [
-      "margin",
-      "swap",
-      "reduction"
-    ]
-  },
-  "torch.nn.PixelShuffle": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.PixelShuffle",
-    "args_list": [
-      "upscale_factor"
-    ]
-  },
-  "torch.nn.PixelUnshuffle": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.PixelUnshuffle",
-    "args_list": [
-      "downscale_factor"
-    ]
-  },
-  "torch.nn.UpsamplingNearest2d": {
-    "Matcher": "UpsampleMatcher",
-    "paddle_api": "paddle.nn.UpsamplingNearest2D",
-    "args_list": [
-      "size",
-      "scale_factor"
-    ]
-  },
-  "torch.nn.UpsamplingBilinear2d": {
-    "Matcher": "UpsampleMatcher",
-    "paddle_api": "paddle.nn.UpsamplingBilinear2D",
-    "args_list": [
-      "size",
-      "scale_factor"
-    ]
-  },
-  "torch.nn.Unflatten": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Unflatten",
-    "args_list": [
-      "dim",
-      "unflattened_size"
-    ],
-    "kwargs_change": {
-      "dim": "axis",
-      "unflattened_size": "shape"
-    }
-  },
-  "torch.nn.ChannelShuffle": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.ChannelShuffle",
-    "args_list": [
-      "groups"
-    ]
-  },
-  "torch.nn.utils.parameters_to_vector": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.utils.parameters_to_vector",
-    "args_list": [
-      "parameters"
-    ]
-  },
-  "torch.nn.utils.vector_to_parameters": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.utils.vector_to_parameters",
-    "args_list": [
-      "vec",
-      "parameters"
-    ]
-  },
-  "torch.nn.utils.weight_norm": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.utils.weight_norm",
-    "args_list": [
-      "module",
-      "name",
-      "dim"
-    ],
-    "kwargs_change": {
-      "module": "Layer"
-    }
-  },
-  "torch.nn.utils.remove_weight_norm": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.utils.remove_weight_norm",
-    "args_list": [
-      "module",
-      "name"
-    ],
-    "kwargs_change": {
-      "module": "Layer"
-    }
-  },
-  "torch.nn.utils.spectral_norm": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.utils.spectral_norm",
-    "args_list": [
-      "module",
-      "name",
-      "n_power_iterations",
-      "eps"
-    ],
-    "kwargs_change": {
-      "module": "Layer"
-    }
-  },
-  "torch.nn.Flatten": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Flatten",
-    "args_list": [
-      "start_dim",
-      "end_dim"
-    ],
-    "kwargs_change": {
-      "start_dim": "start_axis",
-      "end_dim": "stop_axis"
-    }
-  },
-  "torch.nn.functional.conv1d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.conv1d",
-    "args_list": [
-      "input",
-      "weight",
-      "bias",
-      "stride",
-      "padding",
-      "dilation",
-      "groups"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.conv2d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.conv2d",
-    "args_list": [
-      "input",
-      "weight",
-      "bias",
-      "stride",
-      "padding",
-      "dilation",
-      "groups"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.conv3d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.conv3d",
-    "args_list": [
-      "input",
-      "weight",
-      "bias",
-      "stride",
-      "padding",
-      "dilation",
-      "groups"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.conv_transpose1d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.conv1d_transpose",
-    "args_list": [
-      "input",
-      "weight",
-      "bias",
-      "stride",
-      "padding",
-      "output_padding",
-      "dilation",
-      "groups"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.conv_transpose2d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.conv2d_transpose",
-    "args_list": [
-      "input",
-      "weight",
-      "bias",
-      "stride",
-      "padding",
-      "output_padding",
-      "dilation",
-      "groups"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.conv_transpose3d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.conv3d_transpose",
-    "args_list": [
-      "input",
-      "weight",
-      "bias",
-      "stride",
-      "padding",
-      "output_padding",
-      "dilation",
-      "groups"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.fold": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.fold",
-    "args_list": [
-      "input",
-      "output_size",
-      "kernel_size",
-      "stride",
-      "padding",
-      "dilation"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "output_size": "output_sizes",
-      "kernel_size": "kernel_sizes",
-      "stride": "strides",
-      "padding": "paddings",
-      "dilation": "dilations"
-    }
-  },
-  "torch.nn.functional.max_unpool1d": {
-    "Matcher": "UnpoolMatcher",
-    "paddle_api": "paddle.nn.functional.max_unpool1d",
-    "args_list": [
-      "input",
-      "indices",
-      "kernel_size",
-      "stride",
-      "padding",
-      "output_size"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    },
-    "unsupport_args": [
-      "output_size"
-    ]
-  },
-  "torch.nn.functional.max_unpool2d": {
-    "Matcher": "UnpoolMatcher",
-    "paddle_api": "paddle.nn.functional.max_unpool2d",
-    "args_list": [
-      "input",
-      "indices",
-      "kernel_size",
-      "stride",
-      "padding",
-      "output_size"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.max_unpool3d": {
-    "Matcher": "UnpoolMatcher",
-    "paddle_api": "paddle.nn.functional.max_unpool3d",
-    "args_list": [
-      "input",
-      "indices",
-      "kernel_size",
-      "stride",
-      "padding",
-      "output_size"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.adaptive_max_pool1d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.adaptive_max_pool1d",
-    "args_list": [
-      "input",
-      "output_size",
-      "return_indices"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "return_indices": "return_mask"
-    }
-  },
-  "torch.nn.functional.adaptive_max_pool2d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.adaptive_max_pool2d",
-    "args_list": [
-      "input",
-      "output_size",
-      "return_indices"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "return_indices": "return_mask"
-    }
-  },
-  "torch.nn.functional.adaptive_max_pool3d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.adaptive_max_pool3d",
-    "args_list": [
-      "input",
-      "output_size",
-      "return_indices"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "return_indices": "return_mask"
-    }
-  },
-  "torch.nn.functional.relu": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.relu",
-    "args_list": [
-      "input",
-      "inplace"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.relu": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.relu",
-    "args_list": [
-      "input"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.hardtanh": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.hardtanh",
-    "args_list": [
-      "input",
-      "min_val",
-      "max_val",
-      "inplace"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "min_val": "min",
-      "max_val": "max"
-    }
-  },
-  "torch.nn.functional.hardswish": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.hardswish",
-    "args_list": [
-      "input",
-      "inplace"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.relu_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.relu_",
-    "args_list": [
-      "input"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.relu6": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.relu6",
-    "args_list": [
-      "input",
-      "inplace"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.elu": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.elu",
-    "args_list": [
-      "input",
-      "alpha",
-      "inplace"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.elu_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.elu_",
-    "args_list": [
-      "input",
-      "alpha"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.selu": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.selu",
-    "args_list": [
-      "input",
-      "inplace"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.celu": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.celu",
-    "args_list": [
-      "input",
-      "alpha",
-      "inplace"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.leaky_relu": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.leaky_relu",
-    "args_list": [
-      "input",
-      "negative_slope",
-      "inplace"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.prelu": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.prelu",
-    "args_list": [
-      "input",
-      "weight"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.rrelu": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.rrelu",
-    "args_list": [
-      "input",
-      "lower",
-      "upper",
-      "training",
-      "inplace"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.rrelu_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.rrelu",
-    "args_list": [
-      "input",
-      "lower",
-      "upper",
-      "training"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.glu": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.glu",
-    "args_list": [
-      "input",
-      "dim"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.nn.functional.logsigmoid": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.log_sigmoid",
-    "args_list": [
-      "input"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.hardshrink": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.hardshrink",
-    "args_list": [
-      "input",
-      "lambd"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "lambd": "threshold"
-    }
-  },
-  "torch.nn.functional.tanhshrink": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.tanhshrink",
-    "args_list": [
-      "input"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.softsign": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.softsign",
-    "args_list": [
-      "input"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.softplus": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.softplus",
-    "args_list": [
-      "input",
-      "beta",
-      "threshold"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.softmax": {
-    "Matcher": "FunctionalSoftmaxMatcher",
-    "paddle_api": "paddle.nn.functional.softmax",
-    "args_list": [
-      "input",
-      "dim",
-      "_stacklevel",
-      "dtype"
-    ]
-  },
-  "torch.nn.functional.softmin": {
-    "Matcher": "FSoftMinMatcher",
-    "args_list": [
-      "input",
-      "dim",
-      "_stacklevel",
-      "dtype"
-    ]
-  },
-  "torch.nn.functional.softshrink": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.softshrink",
-    "args_list": [
-      "input",
-      "lambd"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "lambd": "threshold"
-    }
-  },
-  "torch.nn.functional.tanh": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.tanh",
-    "args_list": [
-      "input"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.sigmoid": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.sigmoid",
-    "args_list": [
-      "input"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.hardsigmoid": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.hardsigmoid",
-    "args_list": [
-      "input",
-      "inplace"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.silu": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.silu",
-    "args_list": [
-      "input",
-      "inplace"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.batch_norm": {
-    "Matcher": "FBatchNormMatcher",
-    "paddle_api": "paddle.nn.functional.batch_norm",
-    "args_list": [
-      "input",
-      "running_mean",
-      "running_var",
-      "weight",
-      "bias",
-      "training",
-      "momentum",
-      "eps"
-    ]
-  },
-  "torch.nn.functional.instance_norm": {
-    "Matcher": "FInstanceNormMatcher",
-    "paddle_api": "paddle.nn.functional.instance_norm",
-    "args_list": [
-      "input",
-      "running_mean",
-      "running_var",
-      "weight",
-      "bias",
-      "use_input_stats",
-      "eps",
-      "momentum"
-    ]
-  },
-  "torch.nn.functional.kl_div": {
-    "Matcher": "FunctionalKLDivMatcher",
-    "paddle_api": "paddle.nn.functional.kl_div",
-    "args_list": [
-      "input",
-      "target",
-      "size_average",
-      "reduce",
-      "reduction",
-      "log_target"
-    ]
-  },
-  "torch.nn.functional.layer_norm": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.layer_norm",
-    "args_list": [
-      "input",
-      "normalized_shape",
-      "weight",
-      "bias",
-      "eps"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "eps": "epsilon"
-    }
-  },
-  "torch.nn.functional.local_response_norm": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.local_response_norm",
-    "args_list": [
-      "input",
-      "size",
-      "alpha",
-      "beta",
-      "k"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.normalize": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.normalize",
-    "args_list": [
-      "input",
-      "p",
-      "dim",
-      "eps",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis",
-      "eps": "epsilon"
-    }
-  },
-  "torch.nn.functional.linear": {
-    "Matcher": "FunctionalLinearMatcher",
-    "paddle_api": "paddle.nn.functional.linear",
-    "args_list": [
-      "input",
-      "weight",
-      "bias"
-    ]
-  },
-  "torch.nn.functional.bilinear": {
-    "Matcher": "FunctionalBilinearMatcher",
-    "paddle_api": "paddle.nn.functional.bilinear",
-    "args_list": [
-      "input1",
-      "input2",
-      "weight",
-      "bias"
-    ],
-    "kwargs_change": {
-      "input1": "x1",
-      "input2": "x2"
-    }
-  },
-  "torch.nn.functional.dropout": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.dropout",
-    "args_list": [
-      "input",
-      "p",
-      "training",
-      "inplace"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.alpha_dropout": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.alpha_dropout",
-    "args_list": [
-      "input",
-      "p",
-      "training",
-      "inplace"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.dropout2d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.dropout2d",
-    "args_list": [
-      "input",
-      "p",
-      "training",
-      "inplace"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.dropout3d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.dropout3d",
-    "args_list": [
-      "input",
-      "p",
-      "training",
-      "inplace"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.one_hot": {
-    "Matcher": "FunctionalOneHotMatcher",
-    "paddle_api": "paddle.nn.functional.one_hot",
-    "args_list": [
-      "input",
-      "num_classes"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.cosine_similarity": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.cosine_similarity",
-    "args_list": [
-      "x1",
-      "x2",
-      "dim",
-      "eps"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.nn.functional.cross_entropy": {
-    "Matcher": "SizeAverageMatcher",
-    "paddle_api": "paddle.nn.functional.cross_entropy",
-    "args_list": [
-      "input",
-      "label",
-      "weight",
-      "size_average",
-      "ignore_index",
-      "reduce",
-      "reduction",
-      "label_smoothing"
-    ],
-    "kwargs_change": {
-      "label_smoothing": "soft_label"
-    }
-  },
-  "torch.nn.functional.mse_loss": {
-    "Matcher": "SizeAverageMatcher",
-    "paddle_api": "paddle.nn.functional.mse_loss",
-    "args_list": [
-      "input",
-      "target",
-      "size_average",
-      "reduce",
-      "reduction"
-    ],
-    "kwargs_change": {
-      "target": "label"
-    }
-  },
-  "torch.nn.functional.margin_ranking_loss": {
-    "Matcher": "SizeAverageMatcher",
-    "paddle_api": "paddle.nn.functional.margin_ranking_loss",
-    "args_list": [
-      "input1",
-      "input2",
-      "target",
-      "margin",
-      "size_average",
-      "reduce",
-      "reduction"
-    ],
-    "kwargs_change": {
-      "input1": "input",
-      "input2": "other",
-      "target": "label"
-    }
-  },
-  "torch.nn.functional.nll_loss": {
-    "Matcher": "SizeAverageMatcher",
-    "paddle_api": "paddle.nn.functional.nll_loss",
-    "args_list": [
-      "input",
-      "target",
-      "weight",
-      "size_average",
-      "ignore_index",
-      "reduce",
-      "reduction"
-    ],
-    "kwargs_change": {
-      "target": "label"
-    }
-  },
-  "torch.nn.functional.smooth_l1_loss": {
-    "Matcher": "FunctionalSmoothL1LossMatcher",
-    "paddle_api": "paddle.nn.functional.smooth_l1_loss",
-    "args_list": [
-      "input",
-      "target",
-      "size_average",
-      "reduce",
-      "reduction",
-      "beta"
-    ],
-    "kwargs_change": {
-      "target": "label"
-    }
-  },
-  "torch.nn.functional.triplet_margin_with_distance_loss": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.triplet_margin_with_distance_loss",
-    "args_list": [
-      "anchor",
-      "positive",
-      "negative",
-      "distance_function",
-      "margin",
-      "swap",
-      "reduction"
-    ]
-  },
-  "torch.nn.functional.pixel_shuffle": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.pixel_shuffle",
-    "args_list": [
-      "input",
-      "upscale_factor"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.pixel_unshuffle": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.pixel_unshuffle",
-    "args_list": [
-      "input",
-      "downscale_factor"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.pad": {
-    "paddle_api": "paddle.nn.functional.pad",
-    "args_list": [
-      "input",
-      "pad",
-      "mode",
-      "value"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.upsample": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.upsample",
-    "args_list": [
-      "input",
-      "size",
-      "scale_factor",
-      "mode",
-      "align_corners"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.grid_sample": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.grid_sample",
-    "args_list": [
-      "input",
-      "grid",
-      "mode",
-      "align_corners",
-      "padding_mode"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.affine_grid": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.affine_grid",
-    "args_list": [
-      "theta",
-      "size",
-      "align_corners"
-    ],
-    "kwargs_change": {
-      "size": "out_shape"
-    }
-  },
-  "torch.nn.functional.avg_pool1d": {
-    "Matcher": "AvgPoolMatcher",
-    "paddle_api": "paddle.nn.functional.avg_pool1d",
-    "args_list": [
-      "input",
-      "kernel_size",
-      "stride",
-      "padding",
-      "ceil_mode",
-      "count_include_pad"
-    ]
-  },
-  "torch.nn.functional.avg_pool2d": {
-    "Matcher": "AvgPoolMatcher",
-    "paddle_api": "paddle.nn.functional.avg_pool2d",
-    "args_list": [
-      "input",
-      "kernel_size",
-      "stride",
-      "padding",
-      "ceil_mode",
-      "count_include_pad",
-      "divisor_override"
-    ]
-  },
-  "torch.nn.functional.avg_pool3d": {
-    "Matcher": "AvgPoolMatcher",
-    "paddle_api": "paddle.nn.functional.avg_pool3d",
-    "args_list": [
-      "input",
-      "kernel_size",
-      "stride",
-      "padding",
-      "ceil_mode",
-      "count_include_pad",
-      "divisor_override"
-    ]
-  },
-  "torch.nn.functional.adaptive_avg_pool1d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.adaptive_avg_pool1d",
-    "args_list": [
-      "input",
-      "output_size"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.adaptive_avg_pool2d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.adaptive_avg_pool2d",
-    "args_list": [
-      "input",
-      "output_size"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.adaptive_avg_pool3d": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.functional.adaptive_avg_pool3d",
-    "args_list": [
-      "input",
-      "output_size"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional.interpolate": {
-    "Matcher": "FunctionInterpolateMatcher",
-    "paddle_api": "paddle.nn.functional.interpolate",
-    "args_list": [
-      "input",
-      "size",
-      "scale_factor",
-      "mode",
-      "align_corners",
-      "recompute_scale_factor",
-      "antialias"
-    ],
-    "kwargs_change": {
-      "input": "x"
-    }
-  },
-  "torch.nn.functional._Reduction.get_enum": {
-    "Matcher": "Get_EnumMatcher",
-    "args_list": [
-      "reduction"
-    ]
-  },
-  "torch.device": {
-    "Matcher": "DeviceMatcher",
-    "paddle_api": "str",
-    "args_list": [
-      "type",
-      "index"
-    ]
-  },
-  "torch.nn.Linear": {
-    "Matcher": "LayerMatcher",
-    "paddle_api": "paddle.nn.Linear",
-    "args_list": [
-      "in_features",
-      "out_features",
-      "bias",
-      "device",
-      "dtype"
-    ]
-  },
-  "torch.nn.Bilinear": {
-    "Matcher": "LayerMatcher",
-    "paddle_api": "paddle.nn.Bilinear",
-    "args_list": [
-      "in1_features",
-      "in2_features",
-      "out_features",
-      "bias",
-      "device",
-      "dtype"
     ]
   },
   "torch.nn.Conv1d": {
@@ -5371,3002 +5585,16 @@
       "padding_mode"
     ]
   },
-  "torch.nn.functional.upsample_nearest": {
-    "Matcher": "FUpsampleNearestMatcher",
-    "args_list": [
-      "input",
-      "size",
-      "scale_factor"
-    ]
-  },
-  "torch.nn.functional.upsample_bilinear": {
-    "Matcher": "FUpsampleBilinearMatcher",
-    "args_list": [
-      "input",
-      "size",
-      "scale_factor"
-    ]
-  },
-  "torch.nn.functional.gelu": {
-    "Matcher": "GeluMatcher",
-    "paddle_api": "paddle.nn.functional.gelu",
-    "args_list": [
-      "input",
-      "approximate"
-    ]
-  },
-  "torch.nn.GELU": {
-    "Matcher": "GeluMatcher",
-    "paddle_api": "paddle.nn.GELU",
-    "args_list": [
-      "approximate"
-    ]
-  },
-  "torch.add": {
-    "Matcher": "TorchAddMatcher",
-    "paddle_api": "paddle.add",
-    "args_list": [
-      "input",
-      "other",
-      "alpha",
-      "out"
-    ]
-  },
-  "torch.Tensor.add": {
-    "Matcher": "TensorAddMatcher",
-    "args_list": [
-      "other",
-      "alpha"
-    ]
-  },
-  "torch.Tensor.requires_grad": {},
-  "torch.Tensor.new_tensor": {
-    "Matcher": "TensorNewTensorMatcher",
-    "paddle_api": "paddle.to_tensor",
-    "args_list": [
-      "data",
-      "dtype",
-      "device",
-      "requires_grad",
-      "layout",
-      "pin_memory"
-    ],
-    "kwargs_change": {
-      "device": "place"
-    }
-  },
-  "torch.Tensor.new_full": {
-    "Matcher": "TensorNewFullMatcher",
-    "paddle_api": "paddle.full",
-    "args_list": [
-      "size",
-      "fill_value"
-    ]
-  },
-  "torch.Tensor.new_empty": {
-    "Matcher": "TensorNew_Matcher",
-    "paddle_api": "paddle.empty",
-    "args_list": [
-      "size"
-    ]
-  },
-  "torch.Tensor.new_ones": {
-    "Matcher": "TensorNew_Matcher",
-    "paddle_api": "paddle.ones",
-    "args_list": [
-      "size"
-    ]
-  },
-  "torch.Tensor.new_zeros": {
-    "Matcher": "TensorNew_Matcher",
-    "paddle_api": "paddle.zeros",
-    "args_list": [
-      "size"
-    ]
-  },
-  "torch.Tensor.abs": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.abs_": {},
-  "torch.Tensor.absolute": {
+  "torch.nn.CosineSimilarity": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.abs"
-  },
-  "torch.Tensor.absolute_": {},
-  "torch.Tensor.acos": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.acos"
-  },
-  "torch.Tensor.acos_": {},
-  "torch.Tensor.arccos": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.acos"
-  },
-  "torch.Tensor.arccos_": {},
-  "torch.Tensor.addmm": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.addmm",
-    "args_list": [
-      "mat1",
-      "mat2",
-      "alpha",
-      "beta"
-    ],
-    "kwargs_change": {
-      "mat1": "x",
-      "mat2": "y"
-    }
-  },
-  "torch.Tensor.addmm_": {},
-  "torch.Tensor.allclose": {
-    "Matcher": "AllcloseMatcher",
-    "paddle_api": "paddle.Tensor.allclose",
-    "args_list": [
-      "other",
-      "rtol",
-      "atol",
-      "equal_nan"
-    ],
-    "kwargs_change": {
-      "other": "y"
-    }
-  },
-  "torch.Tensor.amax": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.amax",
+    "paddle_api": "paddle.nn.CosineSimilarity",
     "args_list": [
       "dim",
-      "keepdim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.amin": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.amin",
-    "args_list": [
-      "dim",
-      "keepdim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.angle": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.angle"
-  },
-  "torch.Tensor.argmax": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.argmax",
-    "args_list": [
-      "dim",
-      "keepdim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.argmin": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.argmin",
-    "args_list": [
-      "dim",
-      "keepdim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.argsort": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.argsort",
-    "args_list": [
-      "dim",
-      "descending"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.asin": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.asin"
-  },
-  "torch.Tensor.asin_": {},
-  "torch.Tensor.arcsin": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.arcsin_": {},
-  "torch.Tensor.atan": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.atan"
-  },
-  "torch.Tensor.atan_": {},
-  "torch.Tensor.arctan": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.arctan_": {},
-  "torch.Tensor.atan2": {
-    "Matcher": "TensorFunc2PaddleFunc",
-    "paddle_api": "paddle.atan2",
-    "args_list": [
-      "other"
-    ],
-    "kwargs_change": {
-      "other": "y"
-    }
-  },
-  "torch.Tensor.atan2_": {},
-  "torch.Tensor.all": {
-    "Matcher": "TensorToBoolMatcher",
-    "paddle_api": "paddle.Tensor.all",
-    "args_list": [
-      "dim",
-      "keepdim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.any": {
-    "Matcher": "TensorToBoolMatcher",
-    "paddle_api": "paddle.Tensor.any",
-    "args_list": [
-      "dim",
-      "keepdim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.bincount": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.bincount",
-    "args_list": [
-      "weights",
-      "minlength"
-    ]
-  },
-  "torch.Tensor.bitwise_not": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.bitwise_not"
-  },
-  "torch.Tensor.bitwise_and": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.bitwise_and",
-    "args_list": [
-      "other"
-    ],
-    "kwargs_change": {
-      "other": "y"
-    }
-  },
-  "torch.Tensor.bitwise_or": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.bitwise_or",
-    "args_list": [
-      "other"
-    ],
-    "kwargs_change": {
-      "other": "y"
-    }
-  },
-  "torch.Tensor.bitwise_xor": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.bitwise_xor",
-    "args_list": [
-      "other"
-    ],
-    "kwargs_change": {
-      "other": "y"
-    }
-  },
-  "torch.Tensor.bmm": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.bmm",
-    "args_list": [
-      "mat2"
-    ],
-    "kwargs_change": {
-      "mat2": "y"
-    }
-  },
-  "torch.Tensor.broadcast_to": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.broadcast_to",
-    "args_list": [
-      "size"
-    ],
-    "kwargs_change": {
-      "size": "shape"
-    }
-  },
-  "torch.Tensor.ceil": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.ceil_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.ceil_"
-  },
-  "torch.Tensor.cholesky": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.cholesky",
-    "args_list": [
-      "upper"
-    ]
-  },
-  "torch.Tensor.chunk": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.chunk",
-    "args_list": [
-      "chunks",
-      "dim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.clamp": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.clip",
-    "args_list": [
-      "min",
-      "max"
-    ]
-  },
-  "torch.Tensor.clamp_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.clip_",
-    "args_list": [
-      "min",
-      "max"
-    ]
-  },
-  "torch.Tensor.clip": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.clip_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.clip_",
-    "args_list": [
-      "min",
-      "max"
-    ]
-  },
-  "torch.Tensor.clone": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.clone",
-    "args_list": [
-      "memory_format"
-    ]
-  },
-  "torch.Tensor.conj": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.cos": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.cos"
-  },
-  "torch.Tensor.cosh": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.cosh"
-  },
-  "torch.Tensor.acosh": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.acosh"
-  },
-  "torch.Tensor.arccosh": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.acosh"
-  },
-  "torch.Tensor.cross": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.cross",
-    "args_list": [
-      "other",
-      "dim"
-    ],
-    "kwargs_change": {
-      "other": "y",
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.logcumsumexp": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.logcumsumexp",
-    "args_list": [
-      "dim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.cumsum": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.cumsum",
-    "args_list": [
-      "dim",
-      "dtype"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.deg2rad": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.detach": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.detach"
-  },
-  "torch.Tensor.diag_embed": {
-    "Matcher": "TensorFunc2PaddleFunc",
-    "paddle_api": "paddle.nn.functional.diag_embed",
-    "args_list": [
-      "offset",
-      "dim1",
-      "dim2"
-    ]
-  },
-  "torch.Tensor.diagonal": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.diagonal",
-    "args_list": [
-      "offset",
-      "dim1",
-      "dim2"
-    ],
-    "kwargs_change": {
-      "dim1": "axis1",
-      "dim2": "axis2"
-    }
-  },
-  "torch.Tensor.fill_diagonal_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.fill_diagonal_",
-    "args_list": [
-      "fill_value",
-      "wrap"
-    ],
-    "kwargs_change": {
-      "fill_value": "value"
-    }
-  },
-  "torch.Tensor.fmax": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.fmax",
-    "args_list": [
-      "other"
-    ],
-    "kwargs_change": {
-      "other": "y"
-    }
-  },
-  "torch.Tensor.fmin": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.fmin",
-    "args_list": [
-      "other"
-    ],
-    "kwargs_change": {
-      "other": "y"
-    }
-  },
-  "torch.Tensor.diff": {
-    "Matcher": "DiffMatcher",
-    "paddle_api": "paddle.Tensor.diff",
-    "args_list": [
-      "n",
-      "dim",
-      "prepend",
-      "append"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.digamma": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.digamma"
-  },
-  "torch.Tensor.dim": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.dim"
-  },
-  "torch.Tensor.ndimension": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.ndimension"
-  },
-  "torch.Tensor.dist": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.dist",
-    "args_list": [
-      "other",
-      "p"
-    ],
-    "kwargs_change": {
-      "other": "y"
-    }
-  },
-  "torch.Tensor.dot": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.dot",
-    "args_list": [
-      "tensor"
-    ],
-    "kwargs_change": {
-      "tensor": "y"
-    }
-  },
-  "torch.Tensor.element_size": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.element_size"
-  },
-  "torch.Tensor.eq": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.equal",
-    "args_list": [
-      "other"
-    ],
-    "kwargs_change": {
-      "other": "y"
-    }
-  },
-  "torch.Tensor.equal": {
-    "Matcher": "EqualMatcher",
-    "paddle_api": "paddle.Tensor.equal_all",
-    "args_list": [
-      "other"
-    ],
-    "kwargs_change": {
-      "other": "y"
-    }
-  },
-  "torch.Tensor.erf": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.erf"
-  },
-  "torch.Tensor.erfinv": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.erfinv"
-  },
-  "torch.Tensor.erfinv_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.erfinv_"
-  },
-  "torch.Tensor.exp": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.exp"
-  },
-  "torch.Tensor.exp_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.exp_"
-  },
-  "torch.Tensor.expand_as": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.expand_as",
-    "args_list": [
-      "other"
-    ],
-    "kwargs_change": {
-      "other": "y"
-    }
-  },
-  "torch.Tensor.exponential_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.exponential_",
-    "args_list": [
-      "lambd",
-      "generator"
-    ],
-    "kwargs_change": {
-      "lambd": "lam"
-    }
-  },
-  "torch.Tensor.fix": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.trunc"
-  },
-  "torch.Tensor.fill_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.fill_",
-    "args_list": [
-      "value"
-    ]
-  },
-  "torch.Tensor.flatten": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.flatten",
-    "args_list": [
-      "start_dim",
-      "end_dim"
-    ],
-    "kwargs_change": {
-      "start_dim": "start_axis",
-      "end_dim": "stop_axis"
-    }
-  },
-  "torch.Tensor.flip": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.flip",
-    "args_list": [
-      "dims"
-    ],
-    "kwargs_change": {
-      "dims": "axis"
-    }
-  },
-  "torch.Tensor.floor": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.is_cuda": {},
-  "torch.Tensor.is_quantized": {},
-  "torch.Tensor.is_meta": {},
-  "torch.Tensor.floor_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.floor_"
-  },
-  "torch.Tensor.floor_divide": {
-    "Matcher": "Num2TensorBinaryMatcher",
-    "paddle_api": "paddle.Tensor.floor_divide",
-    "args_list": [
-      "other"
-    ]
-  },
-  "torch.Tensor.fmod": {
-    "Matcher": "Num2TensorBinaryMatcher",
-    "paddle_api": "paddle.Tensor.mod",
-    "args_list": [
-      "other"
-    ],
-    "kwargs_change": {
-      "other": "y"
-    }
-  },
-  "torch.Tensor.frac": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.frac"
-  },
-  "torch.Tensor.gather": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.take_along_axis",
-    "args_list": [
-      "dim",
-      "index"
-    ],
-    "kwargs_change": {
-      "dim": "axis",
-      "index": "indices"
-    }
-  },
-  "torch.Tensor.gcd": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.gcd",
-    "args_list": [
-      "other"
-    ],
-    "kwargs_change": {
-      "other": "y"
-    }
-  },
-  "torch.Tensor.ge": {
-    "Matcher": "Num2TensorBinaryMatcher",
-    "paddle_api": "paddle.Tensor.greater_equal",
-    "args_list": [
-      "other"
-    ]
-  },
-  "torch.Tensor.greater_equal": {
-    "Matcher": "Num2TensorBinaryMatcher",
-    "paddle_api": "paddle.Tensor.greater_equal",
-    "args_list": [
-      "other"
-    ],
-    "kwargs_change": {
-      "other": "y"
-    }
-  },
-  "torch.Tensor.ger": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.outer",
-    "args_list": [
-      "vec2"
-    ],
-    "kwargs_change": {
-      "vec2": "y"
-    }
-  },
-  "torch.Tensor.get_device": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.device.get_device"
-  },
-  "torch.Tensor.gt": {
-    "Matcher": "Num2TensorBinaryMatcher",
-    "paddle_api": "paddle.Tensor.greater_than",
-    "args_list": [
-      "other"
-    ]
-  },
-  "torch.Tensor.greater": {
-    "Matcher": "Num2TensorBinaryMatcher",
-    "paddle_api": "paddle.Tensor.greater_than",
-    "args_list": [
-      "other"
-    ]
-  },
-  "torch.Tensor.heaviside": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.heaviside",
-    "args_list": [
-      "data"
-    ],
-    "kwargs_change": {
-      "data": "y"
-    }
-  },
-  "torch.Tensor.index_select": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.index_select",
-    "args_list": [
-      "dim",
-      "index"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.inner": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.inner",
-    "args_list": [
-      "other"
-    ],
-    "kwargs_change": {
-      "other": "y"
-    }
-  },
-  "torch.Tensor.inverse": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.inverse"
-  },
-  "torch.Tensor.isclose": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.isclose",
-    "args_list": [
-      "other",
-      "rtol",
-      "atol",
-      "equal_nan"
-    ],
-    "kwargs_change": {
-      "other": "y"
-    }
-  },
-  "torch.Tensor.isfinite": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.isfinite"
-  },
-  "torch.Tensor.isinf": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.isinf"
-  },
-  "torch.Tensor.isnan": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.isnan"
-  },
-  "torch.Tensor.is_complex": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.is_complex"
-  },
-  "torch.Tensor.is_floating_point": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.is_floating_point"
-  },
-  "torch.Tensor.item": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.kthvalue": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.kthvalue",
-    "args_list": [
-      "k",
-      "dim",
-      "keepdim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.lcm": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.lcm",
-    "args_list": [
-      "other"
-    ],
-    "kwargs_change": {
-      "other": "y"
-    }
-  },
-  "torch.Tensor.le": {
-    "Matcher": "Num2TensorBinaryMatcher",
-    "paddle_api": "paddle.Tensor.less_equal",
-    "args_list": [
-      "other"
-    ]
-  },
-  "torch.Tensor.less_equal": {
-    "Matcher": "Num2TensorBinaryMatcher",
-    "paddle_api": "paddle.Tensor.less_equal",
-    "args_list": [
-      "other"
-    ]
-  },
-  "torch.Tensor.lerp": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.lerp",
-    "args_list": [
-      "end",
-      "weight"
-    ],
-    "kwargs_change": {
-      "end": "y"
-    }
-  },
-  "torch.Tensor.lerp_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.lerp_",
-    "args_list": [
-      "end",
-      "weight"
-    ],
-    "kwargs_change": {
-      "end": "y"
-    }
-  },
-  "torch.Tensor.lgamma": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.lgamma"
-  },
-  "torch.Tensor.log": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.log"
-  },
-  "torch.Tensor.log10": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.log10"
-  },
-  "torch.Tensor.log1p": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.log2": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.log2"
-  },
-  "torch.Tensor.logsumexp": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.logsumexp",
-    "args_list": [
-      "dim",
-      "keepdim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.logical_and": {
-    "Matcher": "TensorLogicalMatcher",
-    "paddle_api": "paddle.Tensor.logical_and",
-    "args_list": [
-      "other"
-    ]
-  },
-  "torch.Tensor.logical_not": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.logical_not"
-  },
-  "torch.Tensor.logical_or": {
-    "Matcher": "TensorLogicalMatcher",
-    "paddle_api": "paddle.Tensor.logical_or",
-    "args_list": [
-      "other"
-    ]
-  },
-  "torch.Tensor.logical_xor": {
-    "Matcher": "TensorLogicalMatcher",
-    "paddle_api": "paddle.Tensor.logical_xor",
-    "args_list": [
-      "other"
-    ]
-  },
-  "torch.Tensor.logit": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.logit",
-    "args_list": [
       "eps"
-    ]
-  },
-  "torch.Tensor.lt": {
-    "Matcher": "Num2TensorBinaryMatcher",
-    "paddle_api": "paddle.Tensor.less_than",
-    "args_list": [
-      "other"
-    ]
-  },
-  "torch.Tensor.less": {
-    "Matcher": "Num2TensorBinaryMatcher",
-    "paddle_api": "paddle.Tensor.less_than",
-    "args_list": [
-      "other"
-    ]
-  },
-  "torch.Tensor.lu": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.lu",
-    "args_list": [
-      "pivot",
-      "get_infos"
-    ]
-  },
-  "torch.Tensor.masked_select": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.masked_select",
-    "args_list": [
-      "mask"
-    ]
-  },
-  "torch.Tensor.matmul": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.matmul",
-    "args_list": [
-      "tensor2"
-    ],
-    "kwargs_change": {
-      "tensor2": "y"
-    }
-  },
-  "torch.Tensor.matrix_power": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.matrix_power",
-    "args_list": [
-      "n"
-    ]
-  },
-  "torch.Tensor.max": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.max",
-    "args_list": [
-      "dim",
-      "keepdim"
     ],
     "kwargs_change": {
       "dim": "axis"
     }
-  },
-  "torch.Tensor.maximum": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.maximum",
-    "args_list": [
-      "other"
-    ],
-    "kwargs_change": {
-      "other": "y"
-    }
-  },
-  "torch.Tensor.mean": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.mean",
-    "args_list": [
-      "dim",
-      "keepdim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.median": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.median",
-    "args_list": [
-      "dim",
-      "keepdim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.nanmedian": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.nanmedian",
-    "args_list": [
-      "dim",
-      "keepdim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.min": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.min",
-    "args_list": [
-      "dim",
-      "keepdim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.minimum": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.minimum",
-    "args_list": [
-      "other"
-    ],
-    "kwargs_change": {
-      "other": "y"
-    }
-  },
-  "torch.Tensor.mm": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.mm",
-    "args_list": [
-      "mat2"
-    ]
-  },
-  "torch.Tensor.mode": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.mode",
-    "args_list": [
-      "dim",
-      "keepdim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.moveaxis": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.moveaxis",
-    "args_list": [
-      "source",
-      "destination"
-    ]
-  },
-  "torch.Tensor.movedim": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.moveaxis",
-    "args_list": [
-      "source",
-      "destination"
-    ]
-  },
-  "torch.Tensor.mul": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.multiply",
-    "args_list": [
-      "value"
-    ],
-    "kwargs_change": {
-      "value": "y"
-    }
-  },
-  "torch.Tensor.mul_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.scale_",
-    "args_list": [
-      "value"
-    ],
-    "kwargs_change": {
-      "value": "scale"
-    }
-  },
-  "torch.Tensor.multiply": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.multiply",
-    "args_list": [
-      "value"
-    ],
-    "kwargs_change": {
-      "value": "y"
-    }
-  },
-  "torch.Tensor.multiply_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.scale_",
-    "args_list": [
-      "value"
-    ],
-    "kwargs_change": {
-      "value": "scale"
-    }
-  },
-  "torch.Tensor.multinomial": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.multinomial",
-    "args_list": [
-      "num_samples",
-      "replacement",
-      "generator"
-    ]
-  },
-  "torch.Tensor.mv": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.mv",
-    "args_list": [
-      "vec"
-    ]
-  },
-  "torch.Tensor.ne": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.not_equal",
-    "args_list": [
-      "other"
-    ],
-    "kwargs_change": {
-      "other": "y"
-    }
-  },
-  "torch.Tensor.not_equal": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.not_equal",
-    "args_list": [
-      "other"
-    ],
-    "kwargs_change": {
-      "other": "y"
-    }
-  },
-  "torch.Tensor.neg": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.neg"
-  },
-  "torch.Tensor.nelement": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.size"
-  },
-  "torch.Tensor.nonzero": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.norm": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.norm",
-    "args_list": [
-      "p",
-      "dim",
-      "keepdim",
-      "dtype"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.numel": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.size"
-  },
-  "torch.Tensor.outer": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.outer",
-    "args_list": [
-      "vec2"
-    ],
-    "kwargs_change": {
-      "vec2": "y"
-    }
-  },
-  "torch.Tensor.pin_memory": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.pin_memory"
-  },
-  "torch.Tensor.pow": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.pow",
-    "args_list": [
-      "exponent"
-    ],
-    "kwargs_change": {
-      "exponent": "y"
-    }
-  },
-  "torch.Tensor.prod": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.prod",
-    "args_list": [
-      "dim",
-      "keepdim",
-      "dtype"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.rad2deg": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.reciprocal": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.reciprocal"
-  },
-  "torch.Tensor.reciprocal_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.reciprocal_"
-  },
-  "torch.Tensor.register_hook": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.register_hook",
-    "args_list": [
-      "hook"
-    ]
-  },
-  "torch.Tensor.remainder": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.remainder",
-    "args_list": [
-      "divisor"
-    ],
-    "kwargs_change": {
-      "divisor": "y"
-    }
-  },
-  "torch.Tensor.remainder_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.remainder_",
-    "args_list": [
-      "divisor"
-    ],
-    "kwargs_change": {
-      "divisor": "y"
-    }
-  },
-  "torch.Tensor.roll": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.roll",
-    "args_list": [
-      "shifts",
-      "dim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.rot90": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.rot90",
-    "args_list": [
-      "k",
-      "dims"
-    ],
-    "kwargs_change": {
-      "dims": "axis"
-    }
-  },
-  "torch.Tensor.rsqrt": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.rsqrt"
-  },
-  "torch.Tensor.rsqrt_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.rsqrt_"
-  },
-  "torch.Tensor.sign": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.sin": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.sinh": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.asinh": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.asinh"
-  },
-  "torch.Tensor.arcsinh": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.sort": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.sort",
-    "args_list": [
-      "dim",
-      "descending"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.split": {
-    "Matcher": "TensorSplitMatcher",
-    "paddle_api": "paddle.Tensor.split",
-    "args_list": [
-      "split_size",
-      "dim"
-    ]
-  },
-  "torch.Tensor.softmax": {
-    "Matcher": "TensorSoftmaxMatcher",
-    "args_list": [
-      "dim"
-    ]
-  },
-  "torch.Tensor.sqrt": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.sqrt_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.sqrt_"
-  },
-  "torch.Tensor.square": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.square"
-  },
-  "torch.Tensor.squeeze": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.squeeze",
-    "args_list": [
-      "dim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.squeeze_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.squeeze_",
-    "args_list": [
-      "dim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.std": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.std",
-    "args_list": [
-      "dim",
-      "unbiased",
-      "keepdim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.sum": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.sum",
-    "args_list": [
-      "dim",
-      "keepdim",
-      "dtype"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.t": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.t"
-  },
-  "torch.Tensor.tile": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.tile",
-    "args_list": [
-      "reps"
-    ],
-    "kwargs_change": {
-      "reps": "repeat_times"
-    }
-  },
-  "torch.Tensor.tan": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.tanh": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.tanh_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.tanh_"
-  },
-  "torch.Tensor.atanh": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.atanh"
-  },
-  "torch.Tensor.arctanh": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.tolist": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.topk": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.topk",
-    "args_list": [
-      "k",
-      "dim",
-      "largest",
-      "sorted"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.trace": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.true_divide": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.divide",
-    "args_list": [
-      "value"
-    ],
-    "kwargs_change": {
-      "value": "y"
-    }
-  },
-  "torch.Tensor.trunc": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.unbind": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.unbind",
-    "args_list": [
-      "dim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.uniform_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.uniform_",
-    "args_list": [
-      "from",
-      "to"
-    ],
-    "kwargs_change": {
-      "from": "min",
-      "to": "max"
-    }
-  },
-  "torch.Tensor.unique_consecutive": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.unique_consecutive",
-    "args_list": [
-      "return_inverse",
-      "return_counts",
-      "dim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.unsqueeze": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.unsqueeze",
-    "args_list": [
-      "dim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.unsqueeze_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.unsqueeze_",
-    "args_list": [
-      "dim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.var": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.var",
-    "args_list": [
-      "dim",
-      "unbiased",
-      "keepdim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.where": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.where",
-    "args_list": [
-      "condition",
-      "y"
-    ]
-  },
-  "torch.Tensor.zero_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.zero_"
-  },
-  "torch.Tensor.lcm_": {},
-  "torch.Tensor.ldexp": {
-    "Matcher": "LdExpMatcher",
-    "args_list": [
-      "other"
-    ]
-  },
-  "torch.Tensor.ldexp_": {},
-  "torch.Tensor.le_": {},
-  "torch.Tensor.lgamma_": {},
-  "torch.Tensor.log_": {},
-  "torch.Tensor.logdet": {
-    "Matcher": "LogDetMatcher",
-    "args_list": []
-  },
-  "torch.Tensor.log10_": {},
-  "torch.Tensor.log1p_": {},
-  "torch.Tensor.log2_": {},
-  "torch.Tensor.log_normal_": {},
-  "torch.Tensor.logaddexp": {
-    "Matcher": "LogAddExpMatcher",
-    "args_list": [
-      "other"
-    ]
-  },
-  "torch.Tensor.logaddexp2": {
-    "Matcher": "LogAddExp2Matcher",
-    "args_list": [
-      "other"
-    ]
-  },
-  "torch.Tensor.logical_and_": {},
-  "torch.Tensor.logical_not_": {},
-  "torch.Tensor.logical_or_": {},
-  "torch.Tensor.logical_xor_": {},
-  "torch.Tensor.logit_": {},
-  "torch.Tensor.lstsq": {},
-  "torch.Tensor.lt_": {},
-  "torch.Tensor.less_": {},
-  "torch.Tensor.lu_solve": {},
-  "torch.Tensor.as_subclass": {},
-  "torch.Tensor.map_": {},
-  "torch.Tensor.masked_scatter_": {},
-  "torch.Tensor.masked_scatter": {},
-  "torch.Tensor.masked_fill_": {},
-  "torch.Tensor.masked_fill": {
-    "Matcher": "TensorMaskedFillMatcher",
-    "args_list": [
-      "mask",
-      "value"
-    ]
-  },
-  "torch.Tensor.matrix_exp": {},
-  "torch.Tensor.smm": {},
-  "torch.Tensor.msort": {
-    "Matcher": "MSortMatcher"
-  },
-  "torch.Tensor.mvlgamma": {},
-  "torch.Tensor.mvlgamma_": {},
-  "torch.Tensor.narrow": {
-    "Matcher": "NarrowMatcher",
-    "args_list": [
-      "dim",
-      "start",
-      "length"
-    ]
-  },
-  "torch.Tensor.narrow_copy": {
-    "Matcher": "NarrowCopyMatcher",
-    "args_list": [
-      "dim",
-      "start",
-      "length"
-    ]
-  },
-  "torch.Tensor.nan_to_num": {},
-  "torch.Tensor.nan_to_num_": {},
-  "torch.Tensor.ne_": {},
-  "torch.Tensor.not_equal_": {},
-  "torch.Tensor.neg_": {},
-  "torch.Tensor.negative": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.neg"
-  },
-  "torch.Tensor.negative_": {},
-  "torch.Tensor.nextafter": {},
-  "torch.Tensor.nextafter_": {},
-  "torch.Tensor.normal_": {
-    "Matcher": "TensorNormal_Matcher",
-    "args_list": [
-      "mean",
-      "std"
-    ]
-  },
-  "torch.Tensor.numpy": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.numpy",
-    "args_list": [
-      "force"
-    ],
-    "kwargs_change": {
-      "force": ""
-    }
-  },
-  "torch.Tensor.orgqr": {},
-  "torch.Tensor.ormqr": {},
-  "torch.Tensor.permute": {
-    "Matcher": "TensorPermuteMatcher",
-    "paddle_api": "paddle.Tensor.transpose"
-  },
-  "torch.Tensor.pinverse": {
-    "Matcher": "TensorFunc2PaddleFunc",
-    "paddle_api": "paddle.linalg.pinv"
-  },
-  "torch.Tensor.polygamma": {},
-  "torch.Tensor.polygamma_": {},
-  "torch.Tensor.pow_": {},
-  "torch.Tensor.put_": {},
-  "torch.Tensor.qr": {},
-  "torch.Tensor.qscheme": {},
-  "torch.Tensor.quantile": {},
-  "torch.Tensor.nanquantile": {},
-  "torch.Tensor.q_scale": {},
-  "torch.Tensor.q_zero_point": {},
-  "torch.Tensor.q_per_channel_scales": {},
-  "torch.Tensor.q_per_channel_zero_points": {},
-  "torch.Tensor.q_per_channel_axis": {},
-  "torch.Tensor.random_": {},
-  "torch.Tensor.ravel": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.flatten"
-  },
-  "torch.Tensor.record_stream": {},
-  "torch.Tensor.renorm_": {},
-  "torch.Tensor.repeat": {
-    "Matcher": "TensorRepeatMatcher"
-  },
-  "torch.Tensor.repeat_interleave": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.repeat_interleave",
-    "args_list": [
-      "repeats",
-      "dim",
-      "output_size"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.requires_grad_": {
-    "Matcher": "TensorRequiresGradMatcher",
-    "args_list": [
-      "requires_grad"
-    ]
-  },
-  "torch.Tensor.reshape": {
-    "Matcher": "TensorReshapeMatcher"
-  },
-  "torch.Tensor.reshape_as": {
-    "Matcher": "TensorReshape_asMatcher",
-    "args_list": [
-      "other"
-    ]
-  },
-  "torch.Tensor.resize_": {},
-  "torch.Tensor.resize_as_": {},
-  "torch.Tensor.retain_grad": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.retain_grad"
-  },
-  "torch.Tensor.round": {
-    "Matcher": "TensorRoundMatcher",
-    "args_list": [
-      "input",
-      "decimals",
-      "out"
-    ]
-  },
-  "torch.Tensor.round_": {},
-  "torch.Tensor.scatter": {},
-  "torch.Tensor.scatter_add": {},
-  "torch.Tensor.select": {
-    "Matcher": "SelectMatcher",
-    "args_list": [
-      "dim",
-      "index"
-    ]
-  },
-  "torch.Tensor.set_": {},
-  "torch.Tensor.share_memory_": {},
-  "torch.Tensor.sigmoid": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.sigmoid"
-  },
-  "torch.Tensor.sigmoid_": {},
-  "torch.Tensor.sign_": {},
-  "torch.Tensor.signbit": {},
-  "torch.Tensor.sgn": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.sgn"
-  },
-  "torch.Tensor.sgn_": {},
-  "torch.Tensor.sin_": {},
-  "torch.Tensor.sinc": {
-    "Matcher": "SincMatcher"
-  },
-  "torch.Tensor.sinc_": {},
-  "torch.Tensor.sinh_": {},
-  "torch.Tensor.asinh_": {},
-  "torch.Tensor.arcsinh_": {},
-  "torch.Tensor.size": {
-    "Matcher": "TensorSizeMatcher",
-    "args_list": [
-      "dim"
-    ]
-  },
-  "torch.Tensor.slogdet": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.slogdet"
-  },
-  "torch.Tensor.sparse_mask": {},
-  "torch.Tensor.sparse_dim": {},
-  "torch.Tensor.square_": {},
-  "torch.Tensor.stft": {},
-  "torch.Tensor.storage": {},
-  "torch.Tensor.storage_offset": {},
-  "torch.Tensor.storage_type": {},
-  "torch.Tensor.stride": {},
-  "torch.Tensor.sub": {
-    "Matcher": "SubMatcher",
-    "args_list": [
-      "other",
-      "alpha"
-    ]
-  },
-  "torch.Tensor.sub_": {},
-  "torch.Tensor.subtract": {
-    "Matcher": "SubMatcher",
-    "args_list": [
-      "other",
-      "alpha"
-    ]
-  },
-  "torch.Tensor.subtract_": {},
-  "torch.Tensor.sum_to_size": {},
-  "torch.Tensor.svd": {
-    "Matcher": "TensorSVDMatcher",
-    "args_list": [
-      "some",
-      "compute_uv"
-    ]
-  },
-  "torch.Tensor.swapaxes": {
-    "Matcher": "SwapAxesMatcher",
-    "args_list": [
-      "axis0",
-      "axis1"
-    ]
-  },
-  "torch.Tensor.swapdims": {
-    "Matcher": "SwapAxesMatcher",
-    "args_list": [
-      "dim0",
-      "dim1"
-    ]
-  },
-  "torch.Tensor.symeig": {},
-  "torch.Tensor.t_": {},
-  "torch.Tensor.tensor_split": {},
-  "torch.Tensor.to": {
-    "Matcher": "TensorToMatcher"
-  },
-  "torch.Tensor.to_mkldnn": {},
-  "torch.Tensor.take": {
-    "Matcher": "TensorTakeMatcher",
-    "paddle_api": "paddle.Tensor.take",
-    "args_list": [
-      "index"
-    ]
-  },
-  "torch.Tensor.tan_": {},
-  "torch.Tensor.atanh_": {},
-  "torch.Tensor.arctanh_": {},
-  "torch.Tensor.to_sparse": {},
-  "torch.Tensor.transpose_": {},
-  "torch.Tensor.triangular_solve": {},
-  "torch.Tensor.tril": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.tril"
-  },
-  "torch.Tensor.tril_": {},
-  "torch.Tensor.triu": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.triu"
-  },
-  "torch.Tensor.triu_": {},
-  "torch.Tensor.true_divide_": {},
-  "torch.Tensor.trunc_": {},
-  "torch.Tensor.type": {},
-  "torch.Tensor.type_as": {
-    "Matcher": "TensorTypeAsMatcher",
-    "args_list": [
-      "tensor"
-    ]
-  },
-  "torch.Tensor.unfold": {},
-  "torch.Tensor.unique": {
-    "Matcher": "TensorUniqueMatcher",
-    "args_list": [
-      "sorted",
-      "return_inverse",
-      "return_counts",
-      "dim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.vdot": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.dot",
-    "args_list": [
-      "other"
-    ],
-    "kwargs_change": {
-      "other": "y"
-    }
-  },
-  "torch.Tensor.view": {},
-  "torch.Tensor.view_as": {},
-  "torch.Tensor.xlogy": {
-    "Matcher": "XLogYMatcher",
-    "args_list": [
-      "other"
-    ]
-  },
-  "torch.Tensor.xlogy_": {},
-  "torch.Tensor.add_": {},
-  "torch.Tensor.addbmm": {
-    "Matcher": "AddBmmMatcher",
-    "args_list": [
-      "batch1",
-      "batch2",
-      "beta",
-      "alpha"
-    ]
-  },
-  "torch.Tensor.addbmm_": {},
-  "torch.Tensor.addcdiv": {
-    "Matcher": "AddCDivMatcher",
-    "args_list": [
-      "tensor1",
-      "tensor2",
-      "value"
-    ]
-  },
-  "torch.Tensor.addcdiv_": {},
-  "torch.Tensor.addcmul": {
-    "Matcher": "AddCMulMatcher",
-    "args_list": [
-      "tensor1",
-      "tensor2",
-      "value"
-    ]
-  },
-  "torch.Tensor.addcmul_": {},
-  "torch.Tensor.sspaddmm": {},
-  "torch.Tensor.addmv": {
-    "Matcher": "AddMRMatcher",
-    "paddle_api": "paddle.mm",
-    "args_list": [
-      "mat",
-      "vec",
-      "beta",
-      "alpha"
-    ]
-  },
-  "torch.Tensor.addmv_": {},
-  "torch.Tensor.addr": {
-    "Matcher": "AddMRMatcher",
-    "paddle_api": "paddle.outer",
-    "args_list": [
-      "vec1",
-      "vec2",
-      "beta",
-      "alpha"
-    ]
-  },
-  "torch.Tensor.addr_": {},
-  "torch.Tensor.apply_": {},
-  "torch.Tensor.as_strided": {},
-  "torch.Tensor.backward": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.backward",
-    "args_list": [
-      "gradient",
-      "retain_graph",
-      "create_graph",
-      "input"
-    ],
-    "kwargs_change": {
-      "gradient": "grad_tensor"
-    },
-    "unsupport_args": [
-      "create_graph",
-      "input"
-    ]
-  },
-  "torch.Tensor.baddbmm": {
-    "Matcher": "AddMRMatcher",
-    "paddle_api": "paddle.bmm",
-    "args_list": [
-      "batch1",
-      "batch2",
-      "alpha",
-      "beta"
-    ]
-  },
-  "torch.Tensor.baddbmm_": {},
-  "torch.Tensor.bernoulli": {},
-  "torch.Tensor.bernoulli_": {
-    "Matcher": "TensorBernoulli_Matcher",
-    "args_list": [
-      "p",
-      "generator"
-    ]
-  },
-  "torch.Tensor.bfloat16": {
-    "Matcher": "TensorBF16Matcher",
-    "args_list": [
-      "memory_format"
-    ]
-  },
-  "torch.Tensor.bool": {
-    "Matcher": "TensorBoolMatcher",
-    "args_list": [
-      "memory_format"
-    ]
-  },
-  "torch.Tensor.byte": {
-    "Matcher": "TensorByteMatcher",
-    "args_list": [
-      "memory_format"
-    ]
-  },
-  "torch.Tensor.char": {
-    "Matcher": "TensorCharMatcher",
-    "args_list": [
-      "memory_format"
-    ]
-  },
-  "torch.Tensor.double": {
-    "Matcher": "TensorDoubleMatcher",
-    "args_list": [
-      "memory_format"
-    ]
-  },
-  "torch.Tensor.float": {
-    "Matcher": "TensorFloatMatcher",
-    "args_list": [
-      "memory_format"
-    ]
-  },
-  "torch.Tensor.half": {
-    "Matcher": "TensorFP16Matcher",
-    "args_list": [
-      "memory_format"
-    ]
-  },
-  "torch.Tensor.int": {
-    "Matcher": "TensorIntMatcher",
-    "args_list": [
-      "memory_format"
-    ]
-  },
-  "torch.Tensor.long": {
-    "Matcher": "TensorLongMatcher",
-    "args_list": [
-      "memory_format"
-    ]
-  },
-  "torch.Tensor.short": {
-    "Matcher": "TensorShortMatcher",
-    "args_list": [
-      "memory_format"
-    ]
-  },
-  "torch.Tensor.chalf": {},
-  "torch.Tensor.cfloat": {
-    "Matcher": "TensorCfloatMatcher",
-    "args_list": [
-      "memory_format"
-    ]
-  },
-  "torch.Tensor.cdouble": {
-    "Matcher": "TensorCdoubleMatcher",
-    "args_list": [
-      "memory_format"
-    ]
-  },
-  "torch.Tensor.bitwise_not_": {},
-  "torch.Tensor.bitwise_and_": {},
-  "torch.Tensor.bitwise_or_": {},
-  "torch.Tensor.bitwise_xor_": {},
-  "torch.Tensor.cauchy_": {},
-  "torch.Tensor.cholesky_inverse": {
-    "Matcher": "CholeskyInverseMatcher",
-    "args_list": [
-      "upper"
-    ]
-  },
-  "torch.Tensor.cholesky_solve": {},
-  "torch.Tensor.contiguous": {
-    "Matcher": "TensorSkipMatcher"
-  },
-  "torch.Tensor.copy_": {
-    "Matcher": "TensorCopyMatcher",
-    "args_list": [
-      "src",
-      "non_blocking"
-    ]
-  },
-  "torch.Tensor.copysign": {},
-  "torch.Tensor.copysign_": {},
-  "torch.Tensor.cos_": {},
-  "torch.Tensor.cosh_": {},
-  "torch.Tensor.count_nonzero": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.count_nonzero",
-    "args_list": [
-      "dim"
-    ],
-    "kwargs_change": {
-      "dim": "axis"
-    }
-  },
-  "torch.Tensor.acosh_": {},
-  "torch.Tensor.arccosh_": {},
-  "torch.Tensor.cpu": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.cpu"
-  },
-  "torch.Tensor.cuda": {
-    "Matcher": "TensorSkipMatcher",
-    "args_list": [
-      "device",
-      "non_blocking",
-      "memory_format"
-    ]
-  },
-  "torch.Tensor.cummax": {},
-  "torch.Tensor.cummin": {},
-  "torch.Tensor.cumprod": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.cumprod_": {},
-  "torch.Tensor.cumsum_": {},
-  "torch.Tensor.data_ptr": {},
-  "torch.Tensor.dequantize": {},
-  "torch.Tensor.det": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.det"
-  },
-  "torch.Tensor.dense_dim": {},
-  "torch.Tensor.detach_": {},
-  "torch.Tensor.diag": {
-    "Matcher": "TensorDiagMatcher",
-    "args_list": [
-      "diagonal"
-    ]
-  },
-  "torch.Tensor.diagflat": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.diagflat"
-  },
-  "torch.Tensor.digamma_": {},
-  "torch.Tensor.div": {
-    "Matcher": "DivMatcher",
-    "args_list": [
-      "other",
-      "rounding_mode"
-    ]
-  },
-  "torch.Tensor.div_": {},
-  "torch.Tensor.divide": {
-    "Matcher": "DivMatcher",
-    "args_list": [
-      "other",
-      "rounding_mode"
-    ]
-  },
-  "torch.Tensor.divide_": {},
-  "torch.Tensor.eig": {},
-  "torch.Tensor.eq_": {},
-  "torch.Tensor.erf_": {},
-  "torch.Tensor.erfc": {
-    "Matcher": "ErfCMatcher"
-  },
-  "torch.Tensor.erfc_": {},
-  "torch.Tensor.expm1": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.expm1_": {},
-  "torch.Tensor.expand": {
-    "Matcher": "TensorExpandMatcher",
-    "paddle_api": "paddle.Tensor.expand"
-  },
-  "torch.Tensor.fix_": {},
-  "torch.Tensor.fliplr": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.flip",
-    "paddle_default_kwargs": {
-      "axis": 1
-    }
-  },
-  "torch.Tensor.flipud": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.flip",
-    "paddle_default_kwargs": {
-      "axis": 0
-    }
-  },
-  "torch.Tensor.float_power": {},
-  "torch.Tensor.float_power_": {},
-  "torch.Tensor.floor_divide_": {},
-  "torch.Tensor.fmod_": {},
-  "torch.Tensor.frac_": {},
-  "torch.Tensor.gcd_": {},
-  "torch.Tensor.ge_": {},
-  "torch.Tensor.greater_equal_": {},
-  "torch.Tensor.geometric_": {},
-  "torch.Tensor.geqrf": {},
-  "torch.Tensor.gt_": {},
-  "torch.Tensor.greater_": {},
-  "torch.Tensor.hardshrink": {
-    "Matcher": "TensorHardShrinkMatcher",
-    "args_list": [
-      "lambd"
-    ]
-  },
-  "torch.Tensor.hypot": {
-    "Matcher": "HypotMatcher",
-    "args_list": [
-      "other"
-    ]
-  },
-  "torch.Tensor.hypot_": {},
-  "torch.Tensor.i0": {},
-  "torch.Tensor.i0_": {},
-  "torch.Tensor.igamma": {},
-  "torch.Tensor.igamma_": {},
-  "torch.Tensor.igammac": {},
-  "torch.Tensor.igammac_": {},
-  "torch.Tensor.index_add_": {
-    "Matcher": "IndexAddMatcher",
-    "paddle_api": "paddle.index_add_",
-    "args_list": [
-      "dim",
-      "index",
-      "source",
-      "alpha"
-    ]
-  },
-  "torch.Tensor.index_add": {
-    "Matcher": "IndexAddMatcher",
-    "paddle_api": "paddle.index_add",
-    "args_list": [
-      "dim",
-      "index",
-      "source",
-      "alpha"
-    ]
-  },
-  "torch.Tensor.index_copy_": {
-    "Matcher": "TensorIndexCopyMatcher",
-    "args_list": [
-      "dim",
-      "index",
-      "tensor"
-    ]
-  },
-  "torch.Tensor.index_copy": {},
-  "torch.Tensor.index_fill_": {},
-  "torch.Tensor.index_fill": {},
-  "torch.Tensor.index_put_": {},
-  "torch.Tensor.index_put": {},
-  "torch.Tensor.indices": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.indices"
-  },
-  "torch.Tensor.values": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.int_repr": {},
-  "torch.Tensor.isposinf": {},
-  "torch.Tensor.isneginf": {},
-  "torch.Tensor.is_contiguous": {
-    "Matcher": "TensorIsContiguousMatcher"
-  },
-  "torch.Tensor.is_pinned": {},
-  "torch.Tensor.is_set_to": {},
-  "torch.Tensor.is_shared": {},
-  "torch.Tensor.is_signed": {},
-  "torch.Tensor.istft": {
-    "Matcher": "TensorFunc2PaddleFunc",
-    "paddle_api": "paddle.signal.istft",
-    "args_list": [
-      "n_fft",
-      "hop_length",
-      "win_length",
-      "window",
-      "center",
-      "normalized",
-      "onesided",
-      "length",
-      "return_complex"
-    ]
-  },
-  "torch.Tensor.isreal": {},
-  "torch.Tensor.less_equal_": {},
-  "torch.Tensor.scatter_add_": {},
-  "torch.Tensor.scatter_": {},
-  "torch.Tensor.index_reduce_": {},
-  "torch.Tensor.index_reduce": {},
-  "torch.Tensor.scatter_reduce_": {},
-  "torch.Tensor.adjoint": {
-    "Matcher": "AdjointMatcher"
-  },
-  "torch.Tensor.argwhere": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.nonzero"
-  },
-  "torch.Tensor.arctan2": {
-    "Matcher": "TensorFunc2PaddleFunc",
-    "paddle_api": "paddle.atan2",
-    "args_list": [
-      "other"
-    ],
-    "kwargs_change": {
-      "other": "y"
-    }
-  },
-  "torch.Tensor.arctan2_": {},
-  "torch.Tensor.diagonal_scatter": {},
-  "torch.Tensor.scatter_reduce": {},
-  "torch.Tensor.select_scatter": {},
-  "torch.Tensor.slice_scatter": {},
-  "torch.Tensor.align_as": {},
-  "torch.Tensor.align_to": {},
-  "torch.Tensor.refine_names": {},
-  "torch.Tensor.rename": {},
-  "torch.Tensor.rename_": {},
-  "torch.Tensor.unflatten": {
-    "Matcher": "UnflattenMatcher",
-    "args_list": [
-      "dim",
-      "sizes"
-    ]
-  },
-  "torch.Tensor.cov": {
-    "Matcher": "CovMatcher",
-    "args_list": [
-      "correction",
-      "fweight",
-      "aweight"
-    ]
-  },
-  "torch.Tensor.bitwise_left_shift_": {},
-  "torch.Tensor.conj_physical": {},
-  "torch.Tensor.bitwise_right_shift_": {},
-  "torch.Tensor.is_conj": {},
-  "torch.Tensor.histc": {
-    "Matcher": "TensorHistcMatcher",
-    "args_list": [
-      "bins",
-      "min",
-      "max"
-    ]
-  },
-  "torch.Tensor.histogram": {},
-  "torch.Tensor.retains_grad": {},
-  "torch.Tensor.is_inference": {},
-  "torch.Tensor.corrcoef": {},
-  "torch.Tensor.resolve_neg": {},
-  "torch.Tensor.conj_physical_": {},
-  "torch.Tensor.bitwise_left_shift": {},
-  "torch.Tensor.resolve_conj": {},
-  "torch.Tensor.aminmax": {
-    "Matcher": "AMinMaxMatcher",
-    "args_list": [
-      "dim",
-      "keepdim"
-    ]
-  },
-  "torch.Tensor.dsplit": {},
-  "torch.Tensor.bitwise_right_shift": {},
-  "torch.Tensor.frexp": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.frexp"
-  },
-  "torch.Tensor.to_dense": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.to_dense"
-  },
-  "torch.Tensor.vsplit": {},
-  "torch.Tensor.hsplit": {},
-  "torch.Tensor.is_coalesced": {},
-  "torch.Tensor.sparse_resize_": {},
-  "torch.Tensor.positive": {},
-  "torch.Tensor.coalesce": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.coalesce"
-  },
-  "torch.Tensor.take_along_dim": {},
-  "torch.Tensor.sparse_resize_and_clear_": {},
-  "torch.transpose": {
-    "Matcher": "TransposeMatcher",
-    "args_list": [
-      "input",
-      "dim0",
-      "dim1"
-    ]
-  },
-  "torch.rand": {
-    "Matcher": "CreateMatcher",
-    "paddle_api": "paddle.rand"
-  },
-  "torch.randn": {
-    "Matcher": "CreateMatcher",
-    "paddle_api": "paddle.randn"
-  },
-  "torch.zeros": {
-    "Matcher": "CreateMatcher",
-    "paddle_api": "paddle.zeros"
-  },
-  "torch.ones": {
-    "Matcher": "CreateMatcher",
-    "paddle_api": "paddle.ones"
-  },
-  "torch.full": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.full",
-    "args_list": [
-      "size",
-      "fill_value",
-      "dtype",
-      "layout",
-      "device",
-      "requires_grad"
-    ],
-    "kwargs_change": {
-      "size": "shape"
-    }
-  },
-  "torch.nn.Sequential": {
-    "Matcher": "SequentialMatcher",
-    "paddle_api": "paddle.nn.Sequential"
-  },
-  "torch.cuda.Event": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.device.cuda.Event",
-    "args_list": [
-      "enable_timing",
-      "blocking",
-      "interprocess"
-    ]
-  },
-  "torch.cuda.current_stream": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.device.cuda.current_stream",
-    "args_list": [
-      "device"
-    ],
-    "kwargs_change": {
-      "device": "device"
-    }
-  },
-  "torch.cuda.device_count": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.device.cuda.device_count"
-  },
-  "torch.cuda.get_device_capability": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.device.cuda.get_device_capability",
-    "args_list": [
-      "device"
-    ],
-    "kwargs_change": {
-      "device": "device"
-    }
-  },
-  "torch.cuda.get_device_properties": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.device.cuda.get_device_properties",
-    "args_list": [
-      "device"
-    ],
-    "kwargs_change": {
-      "device": "device"
-    }
-  },
-  "torch.cuda.set_device": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.device.set_device",
-    "args_list": [
-      "device"
-    ],
-    "kwargs_change": {
-      "device": "device"
-    }
-  },
-  "torch.cuda.manual_seed": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.seed",
-    "args_list": [
-      "seed"
-    ]
-  },
-  "torch.cuda.empty_cache": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.device.cuda.empty_cache"
-  },
-  "torch.cuda.synchronize": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.device.cuda.synchronize",
-    "args_list": [
-      "device"
-    ]
-  },
-  "torch.cuda.memory_allocated": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.device.cuda.memory_allocated",
-    "args_list": [
-      "device"
-    ],
-    "kwargs_change": {
-      "device": "device"
-    }
-  },
-  "torch.cuda.memory_reserved": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.device.cuda.memory_reserved",
-    "args_list": [
-      "device"
-    ],
-    "kwargs_change": {
-      "device": "device"
-    }
-  },
-  "torch.cuda.max_memory_reserved": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.device.cuda.max_memory_reserved",
-    "args_list": [
-      "device"
-    ],
-    "kwargs_change": {
-      "device": "device"
-    }
-  },
-  "torch.cuda.is_available": {
-    "Matcher": "CudaIsAvailableMatcher",
-    "paddle_api": "paddle.device.cuda.device_count"
-  },
-  "torch.backends.cudnn.version": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.device.get_cudnn_version"
-  },
-  "torch.backends.cudnn.is_available": {
-    "Matcher": "CudnnIsAvailableMatcher"
-  },
-  "torch.backends.cuda.is_built": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.device.is_compiled_with_cuda"
-  },
-  "torch.fft.fft": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.fft.fft",
-    "args_list": [
-      "input",
-      "n",
-      "dim",
-      "norm",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.fft.ifft": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.fft.ifft",
-    "args_list": [
-      "input",
-      "n",
-      "dim",
-      "norm",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.fft.fft2": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.fft.fft2",
-    "args_list": [
-      "input",
-      "s",
-      "dim",
-      "norm",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axes"
-    }
-  },
-  "torch.fft.ifft2": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.fft.ifft2",
-    "args_list": [
-      "input",
-      "s",
-      "dim",
-      "norm",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axes"
-    }
-  },
-  "torch.fft.fftn": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.fft.fftn",
-    "args_list": [
-      "input",
-      "s",
-      "dim",
-      "norm",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axes"
-    }
-  },
-  "torch.fft.ifftn": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.fft.ifftn",
-    "args_list": [
-      "input",
-      "s",
-      "dim",
-      "norm",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axes"
-    }
-  },
-  "torch.fft.rfft": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.fft.rfft",
-    "args_list": [
-      "input",
-      "n",
-      "dim",
-      "norm",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.fft.irfft": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.fft.irfft",
-    "args_list": [
-      "input",
-      "n",
-      "dim",
-      "norm",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.fft.rfft2": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.fft.rfft2",
-    "args_list": [
-      "input",
-      "s",
-      "dim",
-      "norm",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axes"
-    }
-  },
-  "torch.fft.irfft2": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.fft.irfft2",
-    "args_list": [
-      "input",
-      "s",
-      "dim",
-      "norm",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axes"
-    }
-  },
-  "torch.fft.rfftn": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.fft.rfftn",
-    "args_list": [
-      "input",
-      "s",
-      "dim",
-      "norm",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axes"
-    }
-  },
-  "torch.fft.fftshift": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.fft.fftshift",
-    "args_list": [
-      "input",
-      "dim"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axes"
-    }
-  },
-  "torch.fft.ifftshift": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.fft.ifftshift",
-    "args_list": [
-      "input",
-      "dim"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axes"
-    }
-  },
-  "torch.fft.irfftn": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.fft.irfftn",
-    "args_list": [
-      "input",
-      "s",
-      "dim",
-      "norm",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axes"
-    }
-  },
-  "torch.fft.hfft": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.fft.hfft",
-    "args_list": [
-      "input",
-      "n",
-      "dim",
-      "norm",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.fft.ihfft": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.fft.ihfft",
-    "args_list": [
-      "input",
-      "n",
-      "dim",
-      "norm",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.fft.fftfreq": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.fft.fftfreq",
-    "args_list": [
-      "n",
-      "d",
-      "dtype",
-      "layout",
-      "device",
-      "requires_grad"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.fft.rfftfreq": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.fft.rfftfreq",
-    "args_list": [
-      "n",
-      "d",
-      "dtype",
-      "layout",
-      "device",
-      "requires_grad"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
-  },
-  "torch.optim.Optimizer": {
-    "Matcher": "OptimOptimizerMatcher",
-    "args_list": [
-      "params",
-      "defaults"
-    ]
-  },
-  "torch.optim.Optimizer.add_param_group": {},
-  "torch.optim.Optimizer.zero_grad": {},
-  "torch.optim.Optimizer.state_dict": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.optimizer.Optimizer.state_dict"
-  },
-  "torch.optim.Optimizer.load_state_dict": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.optimizer.Optimizer.set_state_dict",
-    "args_list": [
-      "state_dict"
-    ]
-  },
-  "torch.optim.Optimizer.step": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.optimizer.Optimizer.step"
-  },
-  "torch.nn.Module.register_buffer": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Layer.register_buffer",
-    "args_list": [
-      "name",
-      "tensor",
-      "persistent"
-    ],
-    "kwargs_change": {
-      "persistent": "persistable"
-    }
-  },
-  "torch.nn.Module.register_parameter": {},
-  "torch.nn.Module.add_module": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Layer.add_sublayer",
-    "args_list": [
-      "name",
-      "module"
-    ],
-    "kwargs_change": {
-      "module": "sublayer"
-    }
-  },
-  "torch.nn.Module.register_module": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Layer.add_sublayer",
-    "args_list": [
-      "name",
-      "module"
-    ],
-    "kwargs_change": {
-      "module": "sublayer"
-    }
-  },
-  "torch.nn.Module.get_submodule": {},
-  "torch.nn.Module.get_parameter": {},
-  "torch.nn.Module.get_buffer": {},
-  "torch.nn.Module.get_extra_state": {},
-  "torch.nn.Module.set_extra_state": {},
-  "torch.nn.Module.apply": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.nn.Module.cuda": {},
-  "torch.nn.Module.ipu": {},
-  "torch.nn.Module.xpu": {},
-  "torch.nn.Module.cpu": {},
-  "torch.nn.Module.type": {},
-  "torch.nn.Module.float": {},
-  "torch.nn.Module.double": {},
-  "torch.nn.Module.half": {},
-  "torch.nn.Module.bfloat16": {},
-  "torch.nn.Module.to_empty": {},
-  "torch.nn.Module.to": {},
-  "torch.nn.Module.register_full_backward_pre_hook": {},
-  "torch.nn.Module.register_backward_hook": {},
-  "torch.nn.Module.register_full_backward_hook": {},
-  "torch.nn.Module.register_forward_pre_hook": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Layer.register_forward_pre_hook",
-    "args_list": [
-      "hook",
-      "prepend",
-      "with_kwargs"
-    ],
-    "unsupport_args": [
-      "prepend",
-      "with_kwargs"
-    ]
-  },
-  "torch.nn.Module.register_forward_hook": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Layer.register_forward_post_hook",
-    "args_list": [
-      "hook",
-      "prepend",
-      "with_kwargs"
-    ],
-    "unsupport_args": [
-      "prepend",
-      "with_kwargs"
-    ]
-  },
-  "torch.nn.Module.state_dict": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Layer.state_dict",
-    "args_list": [
-      "destination",
-      "prefix",
-      "keep_vars"
-    ],
-    "unsupport_args": [
-      "destination",
-      "prefix",
-      "keep_vars"
-    ]
-  },
-  "torch.nn.Module.load_state_dict": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Layer.set_state_dict",
-    "args_list": [
-      "state_dict",
-      "strict"
-    ],
-    "kwargs_change": {
-      "strict": "use_structured_name"
-    }
-  },
-  "torch.nn.Module.register_load_state_dict_post_hook": {},
-  "torch.nn.Module.parameters": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Layer.parameters",
-    "args_list": [
-      "recurse"
-    ],
-    "kwargs_change": {
-      "recurse": "include_sublayers"
-    }
-  },
-  "torch.nn.Module.named_parameters": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Layer.named_parameters",
-    "args_list": [
-      "prefix",
-      "recurse",
-      "remove_duplicate"
-    ],
-    "kwargs_change": {
-      "recurse": "include_sublayers",
-      "remove_duplicate": ""
-    }
-  },
-  "torch.nn.Module.buffers": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Layer.buffers",
-    "args_list": [
-      "recurse"
-    ],
-    "kwargs_change": {
-      "recurse": "include_sublayers"
-    }
-  },
-  "torch.nn.Module.named_buffers": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Layer.named_buffers",
-    "args_list": [
-      "prefix",
-      "recurse",
-      "remove_duplicate"
-    ],
-    "kwargs_change": {
-      "recurse": "include_sublayers",
-      "remove_duplicate": ""
-    }
-  },
-  "torch.nn.Module.children": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Layer.children"
-  },
-  "torch.nn.Module.named_children": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Layer.named_children"
-  },
-  "torch.nn.Module.modules": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Layer.sublayers"
-  },
-  "torch.nn.Module.named_modules": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Layer.named_sublayers",
-    "args_list": [
-      "memo",
-      "prefix",
-      "remove_duplicate"
-    ],
-    "unsupport_args": [
-      "memo",
-      "remove_duplicate"
-    ]
-  },
-  "torch.nn.Module.train": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.Layer.train"
-  },
-  "torch.nn.Module.eval": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.nn.Module.requires_grad_": {},
-  "torch.nn.Module.zero_grad": {},
-  "torch.nn.Module.share_memory": {},
-  "torch.nn.modules.utils._ntuple": {
-    "Matcher": "NTupleMatcher",
-    "args_list": [
-      "n",
-      "name"
-    ]
-  },
-  "torch.nn.modules.utils._pair": {
-    "Matcher": "NTupleMatcher",
-    "args_list": [
-      "x"
-    ],
-    "paddle_default_kwargs": {
-      "n": 2
-    }
-  },
-  "torch.nn.NLLLoss": {
-    "Matcher": "SizeAverageMatcher",
-    "paddle_api": "paddle.nn.NLLLoss",
-    "args_list": [
-      "weight",
-      "size_average",
-      "ignore_index",
-      "reduce",
-      "reduction"
-    ]
   },
   "torch.nn.CrossEntropyLoss": {
     "Matcher": "SizeAverageMatcher",
@@ -8383,234 +5611,91 @@
       "label_smoothing"
     ]
   },
-  "torch.nn.LayerNorm": {
+  "torch.nn.Dropout": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.LayerNorm",
+    "paddle_api": "paddle.nn.Dropout",
     "args_list": [
-      "normalized_shape",
-      "eps",
-      "elementwise_affine",
-      "device",
-      "dtype"
-    ],
-    "kwargs_change": {
-      "eps": "epsilon",
-      "dtype": "",
-      "elementwise_affine": [
-        "weight_attr",
-        "bias_attr"
-      ]
-    }
-  },
-  "torch.nn.GroupNorm": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.GroupNorm",
-    "args_list": [
-      "num_groups",
-      "num_channels",
-      "eps",
-      "affine",
-      "device",
-      "dtype"
-    ],
-    "kwargs_change": {
-      "eps": "epsilon",
-      "dtype": "",
-      "affine": [
-        "weight_attr",
-        "bias_attr"
-      ]
-    }
-  },
-  "torch.nn.BatchNorm1d": {
-    "Matcher": "BatchNormMatcher",
-    "paddle_api": "paddle.nn.BatchNorm1D",
-    "args_list": [
-      "num_features",
-      "eps",
-      "momentum",
-      "affine",
-      "track_running_stats",
-      "device",
-      "dtype"
-    ],
-    "kwargs_change": {
-      "eps": "epsilon",
-      "dtype": ""
-    }
-  },
-  "torch.nn.BatchNorm2d": {
-    "Matcher": "BatchNormMatcher",
-    "paddle_api": "paddle.nn.BatchNorm2D",
-    "args_list": [
-      "num_features",
-      "eps",
-      "momentum",
-      "affine",
-      "track_running_stats",
-      "device",
-      "dtype"
-    ],
-    "kwargs_change": {
-      "eps": "epsilon",
-      "dtype": ""
-    }
-  },
-  "torch.nn.BatchNorm3d": {
-    "Matcher": "BatchNormMatcher",
-    "paddle_api": "paddle.nn.BatchNorm3D",
-    "args_list": [
-      "num_features",
-      "eps",
-      "momentum",
-      "affine",
-      "track_running_stats",
-      "device",
-      "dtype"
-    ],
-    "kwargs_change": {
-      "eps": "epsilon",
-      "dtype": ""
-    }
-  },
-  "torch.nn.SyncBatchNorm": {
-    "Matcher": "BatchNormMatcher",
-    "paddle_api": "paddle.nn.SyncBatchNorm",
-    "args_list": [
-      "num_features",
-      "eps",
-      "momentum",
-      "affine",
-      "track_running_stats",
-      "process_group",
-      "device",
-      "dtype"
-    ],
-    "kwargs_change": {
-      "eps": "epsilon",
-      "dtype": ""
-    }
-  },
-  "torch.nn.SyncBatchNorm.convert_sync_batchnorm": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.SyncBatchNorm.convert_sync_batchnorm",
-    "args_list": [
-      "module",
-      "process_group"
-    ],
-    "kwargs_change": {
-      "module": "layer"
-    },
-    "unsupport_args": [
-      "process_group"
+      "p",
+      "inplace"
     ]
   },
-  "torch.nn.RNNCell": {
+  "torch.nn.Dropout2d": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.SimpleRNNCell",
+    "paddle_api": "paddle.nn.Dropout2D",
     "args_list": [
-      "input_size",
-      "hidden_size",
-      "bias",
-      "nonlinearity",
-      "device",
-      "dtype"
-    ],
-    "kwargs_change": {
-      "dtype": "",
-      "device": "",
-      "nonlinearity": "activation",
-      "bias": [
-        "bias_ih_attr",
-        "bias_hh_attr"
-      ]
-    }
-  },
-  "torch.nn.LSTMCell": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.LSTMCell",
-    "args_list": [
-      "input_size",
-      "hidden_size",
-      "bias",
-      "device",
-      "dtype"
-    ],
-    "kwargs_change": {
-      "dtype": "",
-      "device": "",
-      "bias": [
-        "bias_ih_attr",
-        "bias_hh_attr"
-      ]
-    }
-  },
-  "torch.nn.GRUCell": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.GRUCell",
-    "args_list": [
-      "input_size",
-      "hidden_size",
-      "bias",
-      "device",
-      "dtype"
-    ],
-    "kwargs_change": {
-      "dtype": "",
-      "device": "",
-      "nonlinearity": "activation",
-      "bias": [
-        "bias_ih_attr",
-        "bias_hh_attr"
-      ]
-    }
-  },
-  "torch.nn.RNN": {
-    "Matcher": "RNNMatcher",
-    "paddle_api": "paddle.nn.SimpleRNN",
-    "args_list": [
-      "input_size",
-      "hidden_size",
-      "num_layers",
-      "nonlinearity",
-      "bias",
-      "batch_first",
-      "dropout",
-      "bidirectional"
-    ],
-    "kwargs_change": {
-      "nonlinearity": "activation",
-      "bias": [
-        "bias_ih_attr",
-        "bias_hh_attr"
-      ]
-    },
-    "unsupport_args": [
-      "proj_size"
+      "p",
+      "inplace"
     ]
   },
-  "torch.nn.LSTM": {
-    "Matcher": "RNNMatcher",
-    "paddle_api": "paddle.nn.LSTM",
+  "torch.nn.Dropout3d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Dropout3D",
     "args_list": [
-      "input_size",
-      "hidden_size",
-      "num_layers",
-      "bias",
-      "batch_first",
-      "dropout",
-      "bidirectional",
-      "proj_size"
+      "p",
+      "inplace"
+    ]
+  },
+  "torch.nn.ELU": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.ELU",
+    "args_list": [
+      "alpha",
+      "inplace"
+    ]
+  },
+  "torch.nn.Embedding": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Embedding",
+    "args_list": [
+      "num_embeddings",
+      "embedding_dim",
+      "padding_idx",
+      "max_norm",
+      "norm_type",
+      "scale_grad_by_freq",
+      "sparse"
+    ],
+    "unsupport_args": [
+      "max_norm",
+      "norm_type",
+      "scale_grad_by_freq"
+    ]
+  },
+  "torch.nn.Flatten": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Flatten",
+    "args_list": [
+      "start_dim",
+      "end_dim"
     ],
     "kwargs_change": {
-      "nonlinearity": "activation",
-      "bias": [
-        "bias_ih_attr",
-        "bias_hh_attr"
-      ]
-    },
-    "unsupport_args": [
-      "proj_size"
+      "start_dim": "start_axis",
+      "end_dim": "stop_axis"
+    }
+  },
+  "torch.nn.Fold": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Fold",
+    "args_list": [
+      "output_size",
+      "kernel_size",
+      "stride",
+      "padding",
+      "dilation"
+    ],
+    "kwargs_change": {
+      "output_size": "output_sizes",
+      "kernel_size": "kernel_sizes",
+      "stride": "strides",
+      "padding": "paddings",
+      "dilation": "dilations"
+    }
+  },
+  "torch.nn.GELU": {
+    "Matcher": "GeluMatcher",
+    "paddle_api": "paddle.nn.GELU",
+    "args_list": [
+      "approximate"
     ]
   },
   "torch.nn.GRU": {
@@ -8635,30 +5720,253 @@
       "proj_size"
     ]
   },
-  "torch.nn.MultiheadAttention": {
+  "torch.nn.GRUCell": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.nn.MultiHeadAttention",
+    "paddle_api": "paddle.nn.GRUCell",
     "args_list": [
-      "embed_dim",
-      "num_heads",
-      "dropout",
+      "input_size",
+      "hidden_size",
       "bias",
-      "add_bias_kv",
-      "add_zero_attn",
-      "kdim",
-      "vdim",
-      "batch_first",
       "device",
       "dtype"
     ],
-    "unsupport_args": [
-      "batch_first",
-      "add_bias_kv",
-      "add_zero_attn",
+    "kwargs_change": {
+      "bias": [
+        "bias_ih_attr",
+        "bias_hh_attr"
+      ],
+      "device": "",
+      "dtype": "",
+      "nonlinearity": "activation"
+    }
+  },
+  "torch.nn.GroupNorm": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.GroupNorm",
+    "args_list": [
+      "num_groups",
+      "num_channels",
+      "eps",
+      "affine",
+      "device",
       "dtype"
     ],
     "kwargs_change": {
-      "bias": "bias_attr"
+      "eps": "epsilon",
+      "affine": [
+        "weight_attr",
+        "bias_attr"
+      ],
+      "dtype": ""
+    }
+  },
+  "torch.nn.Hardshrink": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Hardshrink",
+    "args_list": [
+      "lambd"
+    ],
+    "kwargs_change": {
+      "lambd": "threshold"
+    }
+  },
+  "torch.nn.Hardsigmoid": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Hardsigmoid",
+    "args_list": [
+      "inplace"
+    ]
+  },
+  "torch.nn.Hardswish": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Hardswish",
+    "args_list": [
+      "inplace"
+    ]
+  },
+  "torch.nn.Hardtanh": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Hardtanh",
+    "args_list": [
+      "min_val",
+      "max_val",
+      "inplace"
+    ],
+    "kwargs_change": {
+      "min_val": "min",
+      "max_val": "max"
+    }
+  },
+  "torch.nn.Identity": {
+    "Matcher": "IdentityMatcher",
+    "paddle_api": "paddle.nn.Identity"
+  },
+  "torch.nn.InstanceNorm1d": {
+    "Matcher": "InstanceNormMatcher",
+    "paddle_api": "paddle.nn.InstanceNorm1D",
+    "args_list": [
+      "num_features",
+      "eps",
+      "momentum",
+      "affine",
+      "track_running_stats",
+      "device",
+      "dtype"
+    ],
+    "kwargs_change": {
+      "eps": "epsilon",
+      "affine": [
+        "weight_attr",
+        "bias_attr"
+      ],
+      "dtype": ""
+    }
+  },
+  "torch.nn.InstanceNorm2d": {
+    "Matcher": "InstanceNormMatcher",
+    "paddle_api": "paddle.nn.InstanceNorm2D",
+    "args_list": [
+      "num_features",
+      "eps",
+      "momentum",
+      "affine",
+      "track_running_stats",
+      "device",
+      "dtype"
+    ],
+    "kwargs_change": {
+      "eps": "epsilon",
+      "affine": [
+        "weight_attr",
+        "bias_attr"
+      ],
+      "dtype": ""
+    }
+  },
+  "torch.nn.InstanceNorm3d": {
+    "Matcher": "InstanceNormMatcher",
+    "paddle_api": "paddle.nn.InstanceNorm3D",
+    "args_list": [
+      "num_features",
+      "eps",
+      "momentum",
+      "affine",
+      "track_running_stats",
+      "device",
+      "dtype"
+    ],
+    "kwargs_change": {
+      "eps": "epsilon",
+      "affine": [
+        "weight_attr",
+        "bias_attr"
+      ],
+      "dtype": ""
+    }
+  },
+  "torch.nn.LSTM": {
+    "Matcher": "RNNMatcher",
+    "paddle_api": "paddle.nn.LSTM",
+    "args_list": [
+      "input_size",
+      "hidden_size",
+      "num_layers",
+      "bias",
+      "batch_first",
+      "dropout",
+      "bidirectional",
+      "proj_size"
+    ],
+    "kwargs_change": {
+      "bias": [
+        "bias_ih_attr",
+        "bias_hh_attr"
+      ],
+      "nonlinearity": "activation"
+    },
+    "unsupport_args": [
+      "proj_size"
+    ]
+  },
+  "torch.nn.LSTMCell": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.LSTMCell",
+    "args_list": [
+      "input_size",
+      "hidden_size",
+      "bias",
+      "device",
+      "dtype"
+    ],
+    "kwargs_change": {
+      "bias": [
+        "bias_ih_attr",
+        "bias_hh_attr"
+      ],
+      "device": "",
+      "dtype": ""
+    }
+  },
+  "torch.nn.LayerNorm": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.LayerNorm",
+    "args_list": [
+      "normalized_shape",
+      "eps",
+      "elementwise_affine",
+      "device",
+      "dtype"
+    ],
+    "kwargs_change": {
+      "eps": "epsilon",
+      "elementwise_affine": [
+        "weight_attr",
+        "bias_attr"
+      ],
+      "dtype": ""
+    }
+  },
+  "torch.nn.LeakyReLU": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.LeakyReLU",
+    "args_list": [
+      "negative_slope",
+      "inplace"
+    ]
+  },
+  "torch.nn.Linear": {
+    "Matcher": "LayerMatcher",
+    "paddle_api": "paddle.nn.Linear",
+    "args_list": [
+      "in_features",
+      "out_features",
+      "bias",
+      "device",
+      "dtype"
+    ]
+  },
+  "torch.nn.LocalResponseNorm": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.LocalResponseNorm",
+    "args_list": [
+      "size",
+      "alpha",
+      "beta",
+      "k"
+    ]
+  },
+  "torch.nn.LogSigmoid": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.LogSigmoid"
+  },
+  "torch.nn.LogSoftmax": {
+    "Matcher": "SoftmaxMatcher",
+    "paddle_api": "paddle.nn.LogSoftmax",
+    "args_list": [
+      "dim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
     }
   },
   "torch.nn.MaxPool1d": {
@@ -8706,6 +6014,2053 @@
       "return_indices": "return_mask"
     }
   },
+  "torch.nn.MaxUnpool1d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.MaxUnPool1D",
+    "args_list": [
+      "kernel_size",
+      "stride",
+      "padding"
+    ]
+  },
+  "torch.nn.MaxUnpool2d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.MaxUnPool2D",
+    "args_list": [
+      "kernel_size",
+      "stride",
+      "padding"
+    ]
+  },
+  "torch.nn.MaxUnpool3d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.MaxUnPool3D",
+    "args_list": [
+      "kernel_size",
+      "stride",
+      "padding"
+    ]
+  },
+  "torch.nn.Module": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Layer"
+  },
+  "torch.nn.Module.add_module": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Layer.add_sublayer",
+    "args_list": [
+      "name",
+      "module"
+    ],
+    "kwargs_change": {
+      "module": "sublayer"
+    }
+  },
+  "torch.nn.Module.apply": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.nn.Module.bfloat16": {},
+  "torch.nn.Module.buffers": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Layer.buffers",
+    "args_list": [
+      "recurse"
+    ],
+    "kwargs_change": {
+      "recurse": "include_sublayers"
+    }
+  },
+  "torch.nn.Module.children": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Layer.children"
+  },
+  "torch.nn.Module.cpu": {},
+  "torch.nn.Module.cuda": {},
+  "torch.nn.Module.double": {},
+  "torch.nn.Module.eval": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.nn.Module.float": {},
+  "torch.nn.Module.get_buffer": {},
+  "torch.nn.Module.get_extra_state": {},
+  "torch.nn.Module.get_parameter": {},
+  "torch.nn.Module.get_submodule": {},
+  "torch.nn.Module.half": {},
+  "torch.nn.Module.ipu": {},
+  "torch.nn.Module.load_state_dict": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Layer.set_state_dict",
+    "args_list": [
+      "state_dict",
+      "strict"
+    ],
+    "kwargs_change": {
+      "strict": "use_structured_name"
+    }
+  },
+  "torch.nn.Module.modules": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Layer.sublayers"
+  },
+  "torch.nn.Module.named_buffers": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Layer.named_buffers",
+    "args_list": [
+      "prefix",
+      "recurse",
+      "remove_duplicate"
+    ],
+    "kwargs_change": {
+      "recurse": "include_sublayers",
+      "remove_duplicate": ""
+    }
+  },
+  "torch.nn.Module.named_children": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Layer.named_children"
+  },
+  "torch.nn.Module.named_modules": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Layer.named_sublayers",
+    "args_list": [
+      "memo",
+      "prefix",
+      "remove_duplicate"
+    ],
+    "unsupport_args": [
+      "memo",
+      "remove_duplicate"
+    ]
+  },
+  "torch.nn.Module.named_parameters": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Layer.named_parameters",
+    "args_list": [
+      "prefix",
+      "recurse",
+      "remove_duplicate"
+    ],
+    "kwargs_change": {
+      "recurse": "include_sublayers",
+      "remove_duplicate": ""
+    }
+  },
+  "torch.nn.Module.parameters": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Layer.parameters",
+    "args_list": [
+      "recurse"
+    ],
+    "kwargs_change": {
+      "recurse": "include_sublayers"
+    }
+  },
+  "torch.nn.Module.register_backward_hook": {},
+  "torch.nn.Module.register_buffer": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Layer.register_buffer",
+    "args_list": [
+      "name",
+      "tensor",
+      "persistent"
+    ],
+    "kwargs_change": {
+      "persistent": "persistable"
+    }
+  },
+  "torch.nn.Module.register_forward_hook": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Layer.register_forward_post_hook",
+    "args_list": [
+      "hook",
+      "prepend",
+      "with_kwargs"
+    ],
+    "unsupport_args": [
+      "prepend",
+      "with_kwargs"
+    ]
+  },
+  "torch.nn.Module.register_forward_pre_hook": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Layer.register_forward_pre_hook",
+    "args_list": [
+      "hook",
+      "prepend",
+      "with_kwargs"
+    ],
+    "unsupport_args": [
+      "prepend",
+      "with_kwargs"
+    ]
+  },
+  "torch.nn.Module.register_full_backward_hook": {},
+  "torch.nn.Module.register_full_backward_pre_hook": {},
+  "torch.nn.Module.register_load_state_dict_post_hook": {},
+  "torch.nn.Module.register_module": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Layer.add_sublayer",
+    "args_list": [
+      "name",
+      "module"
+    ],
+    "kwargs_change": {
+      "module": "sublayer"
+    }
+  },
+  "torch.nn.Module.register_parameter": {},
+  "torch.nn.Module.requires_grad_": {},
+  "torch.nn.Module.set_extra_state": {},
+  "torch.nn.Module.share_memory": {},
+  "torch.nn.Module.state_dict": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Layer.state_dict",
+    "args_list": [
+      "destination",
+      "prefix",
+      "keep_vars"
+    ],
+    "unsupport_args": [
+      "destination",
+      "prefix",
+      "keep_vars"
+    ]
+  },
+  "torch.nn.Module.to": {},
+  "torch.nn.Module.to_empty": {},
+  "torch.nn.Module.train": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Layer.train"
+  },
+  "torch.nn.Module.type": {},
+  "torch.nn.Module.xpu": {},
+  "torch.nn.Module.zero_grad": {},
+  "torch.nn.ModuleDict": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.LayerDict",
+    "args_list": [
+      "modules"
+    ],
+    "kwargs_change": {
+      "modules": "sublayers"
+    }
+  },
+  "torch.nn.ModuleList": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.LayerList",
+    "args_list": [
+      "modules"
+    ],
+    "kwargs_change": {
+      "modules": "sublayers"
+    }
+  },
+  "torch.nn.MultiheadAttention": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.MultiHeadAttention",
+    "args_list": [
+      "embed_dim",
+      "num_heads",
+      "dropout",
+      "bias",
+      "add_bias_kv",
+      "add_zero_attn",
+      "kdim",
+      "vdim",
+      "batch_first",
+      "device",
+      "dtype"
+    ],
+    "unsupport_args": [
+      "batch_first",
+      "add_bias_kv",
+      "add_zero_attn",
+      "dtype"
+    ],
+    "kwargs_change": {
+      "bias": "bias_attr"
+    }
+  },
+  "torch.nn.NLLLoss": {
+    "Matcher": "SizeAverageMatcher",
+    "paddle_api": "paddle.nn.NLLLoss",
+    "args_list": [
+      "weight",
+      "size_average",
+      "ignore_index",
+      "reduce",
+      "reduction"
+    ]
+  },
+  "torch.nn.PReLU": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.PReLU",
+    "args_list": [
+      "num_parameters",
+      "init",
+      "device",
+      "dtype"
+    ],
+    "kwargs_change": {
+      "dtype": ""
+    }
+  },
+  "torch.nn.PairwiseDistance": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.PairwiseDistance",
+    "args_list": [
+      "p",
+      "eps",
+      "keepdim"
+    ],
+    "kwargs_change": {
+      "eps": "epsilon"
+    }
+  },
+  "torch.nn.Parameter": {
+    "Matcher": "ParameterMatcher",
+    "args_list": [
+      "data",
+      "requires_grad"
+    ]
+  },
+  "torch.nn.ParameterList": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.ParameterList",
+    "args_list": [
+      "values"
+    ],
+    "kwargs_change": {
+      "values": "parameters"
+    }
+  },
+  "torch.nn.PixelShuffle": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.PixelShuffle",
+    "args_list": [
+      "upscale_factor"
+    ]
+  },
+  "torch.nn.PixelUnshuffle": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.PixelUnshuffle",
+    "args_list": [
+      "downscale_factor"
+    ]
+  },
+  "torch.nn.RNN": {
+    "Matcher": "RNNMatcher",
+    "paddle_api": "paddle.nn.SimpleRNN",
+    "args_list": [
+      "input_size",
+      "hidden_size",
+      "num_layers",
+      "nonlinearity",
+      "bias",
+      "batch_first",
+      "dropout",
+      "bidirectional"
+    ],
+    "kwargs_change": {
+      "nonlinearity": "activation",
+      "bias": [
+        "bias_ih_attr",
+        "bias_hh_attr"
+      ]
+    },
+    "unsupport_args": [
+      "proj_size"
+    ]
+  },
+  "torch.nn.RNNCell": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.SimpleRNNCell",
+    "args_list": [
+      "input_size",
+      "hidden_size",
+      "bias",
+      "nonlinearity",
+      "device",
+      "dtype"
+    ],
+    "kwargs_change": {
+      "bias": [
+        "bias_ih_attr",
+        "bias_hh_attr"
+      ],
+      "nonlinearity": "activation",
+      "device": "",
+      "dtype": ""
+    }
+  },
+  "torch.nn.RReLU": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.RReLU",
+    "args_list": [
+      "lower",
+      "upper",
+      "inplace"
+    ]
+  },
+  "torch.nn.ReLU": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.ReLU",
+    "args_list": [
+      "inplace"
+    ]
+  },
+  "torch.nn.ReLU6": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.ReLU6",
+    "args_list": [
+      "inplace"
+    ]
+  },
+  "torch.nn.ReflectionPad1d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Pad1D",
+    "args_list": [
+      "padding"
+    ],
+    "paddle_default_kwargs": {
+      "mode": "'reflect'"
+    }
+  },
+  "torch.nn.ReflectionPad2d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Pad2D",
+    "args_list": [
+      "padding"
+    ],
+    "paddle_default_kwargs": {
+      "mode": "'reflect'"
+    }
+  },
+  "torch.nn.ReflectionPad3d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Pad3D",
+    "args_list": [
+      "padding"
+    ],
+    "paddle_default_kwargs": {
+      "mode": "'reflect'"
+    }
+  },
+  "torch.nn.ReplicationPad1d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Pad1D",
+    "args_list": [
+      "padding"
+    ],
+    "paddle_default_kwargs": {
+      "mode": "'replicate'"
+    }
+  },
+  "torch.nn.ReplicationPad2d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Pad2D",
+    "args_list": [
+      "padding"
+    ],
+    "paddle_default_kwargs": {
+      "mode": "'replicate'"
+    }
+  },
+  "torch.nn.ReplicationPad3d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Pad3D",
+    "args_list": [
+      "padding"
+    ],
+    "paddle_default_kwargs": {
+      "mode": "'replicate'"
+    }
+  },
+  "torch.nn.SELU": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.SELU",
+    "args_list": [
+      "inplace"
+    ]
+  },
+  "torch.nn.Sequential": {
+    "Matcher": "SequentialMatcher",
+    "paddle_api": "paddle.nn.Sequential"
+  },
+  "torch.nn.SiLU": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Silu",
+    "args_list": [
+      "inplace"
+    ]
+  },
+  "torch.nn.Sigmoid": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Sigmoid"
+  },
+  "torch.nn.Softmax": {
+    "Matcher": "SoftmaxMatcher",
+    "paddle_api": "paddle.nn.Softmax",
+    "args_list": [
+      "dim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.nn.Softplus": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Softplus",
+    "args_list": [
+      "beta",
+      "threshold"
+    ]
+  },
+  "torch.nn.Softshrink": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Softshrink",
+    "args_list": [
+      "lambd"
+    ],
+    "kwargs_change": {
+      "lambd": "threshold"
+    }
+  },
+  "torch.nn.Softsign": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Softsign"
+  },
+  "torch.nn.SyncBatchNorm": {
+    "Matcher": "BatchNormMatcher",
+    "paddle_api": "paddle.nn.SyncBatchNorm",
+    "args_list": [
+      "num_features",
+      "eps",
+      "momentum",
+      "affine",
+      "track_running_stats",
+      "process_group",
+      "device",
+      "dtype"
+    ],
+    "kwargs_change": {
+      "eps": "epsilon",
+      "dtype": ""
+    }
+  },
+  "torch.nn.SyncBatchNorm.convert_sync_batchnorm": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.SyncBatchNorm.convert_sync_batchnorm",
+    "args_list": [
+      "module",
+      "process_group"
+    ],
+    "kwargs_change": {
+      "module": "layer"
+    },
+    "unsupport_args": [
+      "process_group"
+    ]
+  },
+  "torch.nn.Tanh": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Tanh"
+  },
+  "torch.nn.Tanhshrink": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Tanhshrink"
+  },
+  "torch.nn.TransformerDecoder": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.TransformerDecoder",
+    "args_list": [
+      "decoder_layer",
+      "num_layers",
+      "norm"
+    ]
+  },
+  "torch.nn.TripletMarginWithDistanceLoss": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.TripletMarginWithDistanceLoss",
+    "args_list": [
+      "margin",
+      "swap",
+      "reduction"
+    ]
+  },
+  "torch.nn.Unflatten": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Unflatten",
+    "args_list": [
+      "dim",
+      "unflattened_size"
+    ],
+    "kwargs_change": {
+      "dim": "axis",
+      "unflattened_size": "shape"
+    }
+  },
+  "torch.nn.UpsamplingBilinear2d": {
+    "Matcher": "UpsampleMatcher",
+    "paddle_api": "paddle.nn.UpsamplingBilinear2D",
+    "args_list": [
+      "size",
+      "scale_factor"
+    ]
+  },
+  "torch.nn.UpsamplingNearest2d": {
+    "Matcher": "UpsampleMatcher",
+    "paddle_api": "paddle.nn.UpsamplingNearest2D",
+    "args_list": [
+      "size",
+      "scale_factor"
+    ]
+  },
+  "torch.nn.ZeroPad2d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.ZeroPad2D",
+    "args_list": [
+      "padding"
+    ]
+  },
+  "torch.nn.functional._Reduction.get_enum": {
+    "Matcher": "Get_EnumMatcher",
+    "args_list": [
+      "reduction"
+    ]
+  },
+  "torch.nn.functional.adaptive_avg_pool1d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.adaptive_avg_pool1d",
+    "args_list": [
+      "input",
+      "output_size"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.adaptive_avg_pool2d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.adaptive_avg_pool2d",
+    "args_list": [
+      "input",
+      "output_size"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.adaptive_avg_pool3d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.adaptive_avg_pool3d",
+    "args_list": [
+      "input",
+      "output_size"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.adaptive_max_pool1d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.adaptive_max_pool1d",
+    "args_list": [
+      "input",
+      "output_size",
+      "return_indices"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "return_indices": "return_mask"
+    }
+  },
+  "torch.nn.functional.adaptive_max_pool2d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.adaptive_max_pool2d",
+    "args_list": [
+      "input",
+      "output_size",
+      "return_indices"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "return_indices": "return_mask"
+    }
+  },
+  "torch.nn.functional.adaptive_max_pool3d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.adaptive_max_pool3d",
+    "args_list": [
+      "input",
+      "output_size",
+      "return_indices"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "return_indices": "return_mask"
+    }
+  },
+  "torch.nn.functional.affine_grid": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.affine_grid",
+    "args_list": [
+      "theta",
+      "size",
+      "align_corners"
+    ],
+    "kwargs_change": {
+      "size": "out_shape"
+    }
+  },
+  "torch.nn.functional.alpha_dropout": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.alpha_dropout",
+    "args_list": [
+      "input",
+      "p",
+      "training",
+      "inplace"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.avg_pool1d": {
+    "Matcher": "AvgPoolMatcher",
+    "paddle_api": "paddle.nn.functional.avg_pool1d",
+    "args_list": [
+      "input",
+      "kernel_size",
+      "stride",
+      "padding",
+      "ceil_mode",
+      "count_include_pad"
+    ]
+  },
+  "torch.nn.functional.avg_pool2d": {
+    "Matcher": "AvgPoolMatcher",
+    "paddle_api": "paddle.nn.functional.avg_pool2d",
+    "args_list": [
+      "input",
+      "kernel_size",
+      "stride",
+      "padding",
+      "ceil_mode",
+      "count_include_pad",
+      "divisor_override"
+    ]
+  },
+  "torch.nn.functional.avg_pool3d": {
+    "Matcher": "AvgPoolMatcher",
+    "paddle_api": "paddle.nn.functional.avg_pool3d",
+    "args_list": [
+      "input",
+      "kernel_size",
+      "stride",
+      "padding",
+      "ceil_mode",
+      "count_include_pad",
+      "divisor_override"
+    ]
+  },
+  "torch.nn.functional.batch_norm": {
+    "Matcher": "FBatchNormMatcher",
+    "paddle_api": "paddle.nn.functional.batch_norm",
+    "args_list": [
+      "input",
+      "running_mean",
+      "running_var",
+      "weight",
+      "bias",
+      "training",
+      "momentum",
+      "eps"
+    ]
+  },
+  "torch.nn.functional.bilinear": {
+    "Matcher": "FunctionalBilinearMatcher",
+    "paddle_api": "paddle.nn.functional.bilinear",
+    "args_list": [
+      "input1",
+      "input2",
+      "weight",
+      "bias"
+    ],
+    "kwargs_change": {
+      "input1": "x1",
+      "input2": "x2"
+    }
+  },
+  "torch.nn.functional.binary_cross_entropy_with_logits": {
+    "Matcher": "SizeAverageMatcher",
+    "paddle_api": "paddle.nn.functional.binary_cross_entropy_with_logits",
+    "args_list": [
+      "input",
+      "target",
+      "weight",
+      "size_average",
+      "reduce",
+      "reduction",
+      "pos_weight"
+    ]
+  },
+  "torch.nn.functional.celu": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.celu",
+    "args_list": [
+      "input",
+      "alpha",
+      "inplace"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.conv1d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.conv1d",
+    "args_list": [
+      "input",
+      "weight",
+      "bias",
+      "stride",
+      "padding",
+      "dilation",
+      "groups"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.conv2d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.conv2d",
+    "args_list": [
+      "input",
+      "weight",
+      "bias",
+      "stride",
+      "padding",
+      "dilation",
+      "groups"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.conv3d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.conv3d",
+    "args_list": [
+      "input",
+      "weight",
+      "bias",
+      "stride",
+      "padding",
+      "dilation",
+      "groups"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.conv_transpose1d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.conv1d_transpose",
+    "args_list": [
+      "input",
+      "weight",
+      "bias",
+      "stride",
+      "padding",
+      "output_padding",
+      "dilation",
+      "groups"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.conv_transpose2d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.conv2d_transpose",
+    "args_list": [
+      "input",
+      "weight",
+      "bias",
+      "stride",
+      "padding",
+      "output_padding",
+      "dilation",
+      "groups"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.conv_transpose3d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.conv3d_transpose",
+    "args_list": [
+      "input",
+      "weight",
+      "bias",
+      "stride",
+      "padding",
+      "output_padding",
+      "dilation",
+      "groups"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.cosine_similarity": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.cosine_similarity",
+    "args_list": [
+      "x1",
+      "x2",
+      "dim",
+      "eps"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.nn.functional.cross_entropy": {
+    "Matcher": "SizeAverageMatcher",
+    "paddle_api": "paddle.nn.functional.cross_entropy",
+    "args_list": [
+      "input",
+      "label",
+      "weight",
+      "size_average",
+      "ignore_index",
+      "reduce",
+      "reduction",
+      "label_smoothing"
+    ],
+    "kwargs_change": {
+      "label_smoothing": "soft_label"
+    }
+  },
+  "torch.nn.functional.dropout": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.dropout",
+    "args_list": [
+      "input",
+      "p",
+      "training",
+      "inplace"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.dropout2d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.dropout2d",
+    "args_list": [
+      "input",
+      "p",
+      "training",
+      "inplace"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.dropout3d": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.dropout3d",
+    "args_list": [
+      "input",
+      "p",
+      "training",
+      "inplace"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.elu": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.elu",
+    "args_list": [
+      "input",
+      "alpha",
+      "inplace"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.elu_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.elu_",
+    "args_list": [
+      "input",
+      "alpha"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.embedding": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.embedding",
+    "args_list": [
+      "input",
+      "weight",
+      "padding_idx",
+      "max_norm",
+      "norm_type",
+      "scale_grad_by_freq",
+      "sparse"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    },
+    "unsupport_args": [
+      "max_norm",
+      "norm_type",
+      "scale_grad_by_freq"
+    ]
+  },
+  "torch.nn.functional.fold": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.fold",
+    "args_list": [
+      "input",
+      "output_size",
+      "kernel_size",
+      "stride",
+      "padding",
+      "dilation"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "output_size": "output_sizes",
+      "kernel_size": "kernel_sizes",
+      "stride": "strides",
+      "padding": "paddings",
+      "dilation": "dilations"
+    }
+  },
+  "torch.nn.functional.gelu": {
+    "Matcher": "GeluMatcher",
+    "paddle_api": "paddle.nn.functional.gelu",
+    "args_list": [
+      "input",
+      "approximate"
+    ]
+  },
+  "torch.nn.functional.glu": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.glu",
+    "args_list": [
+      "input",
+      "dim"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.nn.functional.grid_sample": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.grid_sample",
+    "args_list": [
+      "input",
+      "grid",
+      "mode",
+      "align_corners",
+      "padding_mode"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.hardshrink": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.hardshrink",
+    "args_list": [
+      "input",
+      "lambd"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "lambd": "threshold"
+    }
+  },
+  "torch.nn.functional.hardsigmoid": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.hardsigmoid",
+    "args_list": [
+      "input",
+      "inplace"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.hardswish": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.hardswish",
+    "args_list": [
+      "input",
+      "inplace"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.hardtanh": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.hardtanh",
+    "args_list": [
+      "input",
+      "min_val",
+      "max_val",
+      "inplace"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "min_val": "min",
+      "max_val": "max"
+    }
+  },
+  "torch.nn.functional.instance_norm": {
+    "Matcher": "FInstanceNormMatcher",
+    "paddle_api": "paddle.nn.functional.instance_norm",
+    "args_list": [
+      "input",
+      "running_mean",
+      "running_var",
+      "weight",
+      "bias",
+      "use_input_stats",
+      "eps",
+      "momentum"
+    ]
+  },
+  "torch.nn.functional.interpolate": {
+    "Matcher": "FunctionInterpolateMatcher",
+    "paddle_api": "paddle.nn.functional.interpolate",
+    "args_list": [
+      "input",
+      "size",
+      "scale_factor",
+      "mode",
+      "align_corners",
+      "recompute_scale_factor",
+      "antialias"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.kl_div": {
+    "Matcher": "FunctionalKLDivMatcher",
+    "paddle_api": "paddle.nn.functional.kl_div",
+    "args_list": [
+      "input",
+      "target",
+      "size_average",
+      "reduce",
+      "reduction",
+      "log_target"
+    ]
+  },
+  "torch.nn.functional.l1_loss": {
+    "Matcher": "SizeAverageMatcher",
+    "paddle_api": "paddle.nn.functional.l1_loss",
+    "args_list": [
+      "input",
+      "target",
+      "size_average",
+      "reduce",
+      "reduction"
+    ]
+  },
+  "torch.nn.functional.layer_norm": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.layer_norm",
+    "args_list": [
+      "input",
+      "normalized_shape",
+      "weight",
+      "bias",
+      "eps"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "eps": "epsilon"
+    }
+  },
+  "torch.nn.functional.leaky_relu": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.leaky_relu",
+    "args_list": [
+      "input",
+      "negative_slope",
+      "inplace"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.linear": {
+    "Matcher": "FunctionalLinearMatcher",
+    "paddle_api": "paddle.nn.functional.linear",
+    "args_list": [
+      "input",
+      "weight",
+      "bias"
+    ]
+  },
+  "torch.nn.functional.local_response_norm": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.local_response_norm",
+    "args_list": [
+      "input",
+      "size",
+      "alpha",
+      "beta",
+      "k"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.log_softmax": {
+    "paddle_api": "paddle.nn.functional.log_softmax",
+    "args_list": [
+      "input",
+      "dim",
+      "dtype",
+      "_stacklevel"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis",
+      "_stacklevel": ""
+    }
+  },
+  "torch.nn.functional.logsigmoid": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.log_sigmoid",
+    "args_list": [
+      "input"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.margin_ranking_loss": {
+    "Matcher": "SizeAverageMatcher",
+    "paddle_api": "paddle.nn.functional.margin_ranking_loss",
+    "args_list": [
+      "input1",
+      "input2",
+      "target",
+      "margin",
+      "size_average",
+      "reduce",
+      "reduction"
+    ],
+    "kwargs_change": {
+      "input1": "input",
+      "input2": "other",
+      "target": "label"
+    }
+  },
+  "torch.nn.functional.max_pool2d": {
+    "Matcher": "FunctionalMaxPool2DMatcher",
+    "paddle_api": "paddle.nn.functional.max_pool2d",
+    "args_list": [
+      "input",
+      "kernel_size",
+      "stride",
+      "padding",
+      "dilation",
+      "ceil_mode",
+      "return_indices"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "return_indices": "return_mask"
+    }
+  },
+  "torch.nn.functional.max_unpool1d": {
+    "Matcher": "UnpoolMatcher",
+    "paddle_api": "paddle.nn.functional.max_unpool1d",
+    "args_list": [
+      "input",
+      "indices",
+      "kernel_size",
+      "stride",
+      "padding",
+      "output_size"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    },
+    "unsupport_args": [
+      "output_size"
+    ]
+  },
+  "torch.nn.functional.max_unpool2d": {
+    "Matcher": "UnpoolMatcher",
+    "paddle_api": "paddle.nn.functional.max_unpool2d",
+    "args_list": [
+      "input",
+      "indices",
+      "kernel_size",
+      "stride",
+      "padding",
+      "output_size"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.max_unpool3d": {
+    "Matcher": "UnpoolMatcher",
+    "paddle_api": "paddle.nn.functional.max_unpool3d",
+    "args_list": [
+      "input",
+      "indices",
+      "kernel_size",
+      "stride",
+      "padding",
+      "output_size"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.mse_loss": {
+    "Matcher": "SizeAverageMatcher",
+    "paddle_api": "paddle.nn.functional.mse_loss",
+    "args_list": [
+      "input",
+      "target",
+      "size_average",
+      "reduce",
+      "reduction"
+    ],
+    "kwargs_change": {
+      "target": "label"
+    }
+  },
+  "torch.nn.functional.multi_margin_loss": {
+    "Matcher": "SizeAverageMatcher",
+    "paddle_api": "paddle.nn.functional.multi_margin_loss",
+    "args_list": [
+      "input",
+      "target",
+      "p",
+      "margin",
+      "weight",
+      "size_average",
+      "reduce",
+      "reduction"
+    ],
+    "kwargs_change": {
+      "target": "label"
+    }
+  },
+  "torch.nn.functional.multilabel_soft_margin_loss": {
+    "Matcher": "SizeAverageMatcher",
+    "paddle_api": "paddle.nn.functional.multi_label_soft_margin_loss",
+    "args_list": [
+      "input",
+      "target",
+      "weight",
+      "size_average",
+      "reduce",
+      "reduction"
+    ],
+    "kwargs_change": {
+      "target": "label"
+    }
+  },
+  "torch.nn.functional.nll_loss": {
+    "Matcher": "SizeAverageMatcher",
+    "paddle_api": "paddle.nn.functional.nll_loss",
+    "args_list": [
+      "input",
+      "target",
+      "weight",
+      "size_average",
+      "ignore_index",
+      "reduce",
+      "reduction"
+    ],
+    "kwargs_change": {
+      "target": "label"
+    }
+  },
+  "torch.nn.functional.normalize": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.normalize",
+    "args_list": [
+      "input",
+      "p",
+      "dim",
+      "eps",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis",
+      "eps": "epsilon"
+    }
+  },
+  "torch.nn.functional.one_hot": {
+    "Matcher": "FunctionalOneHotMatcher",
+    "paddle_api": "paddle.nn.functional.one_hot",
+    "args_list": [
+      "input",
+      "num_classes"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.pad": {
+    "paddle_api": "paddle.nn.functional.pad",
+    "args_list": [
+      "input",
+      "pad",
+      "mode",
+      "value"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.pixel_shuffle": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.pixel_shuffle",
+    "args_list": [
+      "input",
+      "upscale_factor"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.pixel_unshuffle": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.pixel_unshuffle",
+    "args_list": [
+      "input",
+      "downscale_factor"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.prelu": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.prelu",
+    "args_list": [
+      "input",
+      "weight"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.relu": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.relu",
+    "args_list": [
+      "input",
+      "inplace"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.relu6": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.relu6",
+    "args_list": [
+      "input",
+      "inplace"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.relu_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.relu_",
+    "args_list": [
+      "input"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.rrelu": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.rrelu",
+    "args_list": [
+      "input",
+      "lower",
+      "upper",
+      "training",
+      "inplace"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.rrelu_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.rrelu",
+    "args_list": [
+      "input",
+      "lower",
+      "upper",
+      "training"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.selu": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.selu",
+    "args_list": [
+      "input",
+      "inplace"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.sigmoid": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.sigmoid",
+    "args_list": [
+      "input"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.silu": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.silu",
+    "args_list": [
+      "input",
+      "inplace"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.smooth_l1_loss": {
+    "Matcher": "FunctionalSmoothL1LossMatcher",
+    "paddle_api": "paddle.nn.functional.smooth_l1_loss",
+    "args_list": [
+      "input",
+      "target",
+      "size_average",
+      "reduce",
+      "reduction",
+      "beta"
+    ],
+    "kwargs_change": {
+      "target": "label"
+    }
+  },
+  "torch.nn.functional.soft_margin_loss": {
+    "Matcher": "SizeAverageMatcher",
+    "paddle_api": "paddle.nn.functional.soft_margin_loss",
+    "args_list": [
+      "input",
+      "target",
+      "size_average",
+      "reduce",
+      "reduction"
+    ],
+    "kwargs_change": {
+      "target": "label"
+    }
+  },
+  "torch.nn.functional.softmax": {
+    "Matcher": "FunctionalSoftmaxMatcher",
+    "paddle_api": "paddle.nn.functional.softmax",
+    "args_list": [
+      "input",
+      "dim",
+      "_stacklevel",
+      "dtype"
+    ]
+  },
+  "torch.nn.functional.softmin": {
+    "Matcher": "FSoftMinMatcher",
+    "args_list": [
+      "input",
+      "dim",
+      "_stacklevel",
+      "dtype"
+    ]
+  },
+  "torch.nn.functional.softplus": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.softplus",
+    "args_list": [
+      "input",
+      "beta",
+      "threshold"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.softshrink": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.softshrink",
+    "args_list": [
+      "input",
+      "lambd"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "lambd": "threshold"
+    }
+  },
+  "torch.nn.functional.softsign": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.softsign",
+    "args_list": [
+      "input"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.tanh": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.tanh",
+    "args_list": [
+      "input"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.tanhshrink": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.tanhshrink",
+    "args_list": [
+      "input"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.triplet_margin_with_distance_loss": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.triplet_margin_with_distance_loss",
+    "args_list": [
+      "anchor",
+      "positive",
+      "negative",
+      "distance_function",
+      "margin",
+      "swap",
+      "reduction"
+    ]
+  },
+  "torch.nn.functional.upsample": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.upsample",
+    "args_list": [
+      "input",
+      "size",
+      "scale_factor",
+      "mode",
+      "align_corners"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.nn.functional.upsample_bilinear": {
+    "Matcher": "FUpsampleBilinearMatcher",
+    "args_list": [
+      "input",
+      "size",
+      "scale_factor"
+    ]
+  },
+  "torch.nn.functional.upsample_nearest": {
+    "Matcher": "FUpsampleNearestMatcher",
+    "args_list": [
+      "input",
+      "size",
+      "scale_factor"
+    ]
+  },
+  "torch.nn.modules.batchnorm._BatchNorm": {
+    "Matcher": "Modules_BatchNormBaseMatcher",
+    "paddle_api": "paddle.nn.layer.norm._BatchNormBase",
+    "args_list": [
+      "num_features",
+      "eps",
+      "momentum",
+      "affine",
+      "track_running_stats",
+      "device",
+      "dtype"
+    ],
+    "kwargs_change": {
+      "eps": "epsilon"
+    }
+  },
+  "torch.nn.modules.utils._ntuple": {
+    "Matcher": "NTupleMatcher",
+    "args_list": [
+      "n",
+      "name"
+    ]
+  },
+  "torch.nn.modules.utils._pair": {
+    "Matcher": "NTupleMatcher",
+    "args_list": [
+      "x"
+    ],
+    "paddle_default_kwargs": {
+      "n": 2
+    }
+  },
+  "torch.nn.utils.parameters_to_vector": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.utils.parameters_to_vector",
+    "args_list": [
+      "parameters"
+    ]
+  },
+  "torch.nn.utils.remove_weight_norm": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.utils.remove_weight_norm",
+    "args_list": [
+      "module",
+      "name"
+    ],
+    "kwargs_change": {
+      "module": "Layer"
+    }
+  },
+  "torch.nn.utils.spectral_norm": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.utils.spectral_norm",
+    "args_list": [
+      "module",
+      "name",
+      "n_power_iterations",
+      "eps"
+    ],
+    "kwargs_change": {
+      "module": "Layer"
+    }
+  },
+  "torch.nn.utils.vector_to_parameters": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.utils.vector_to_parameters",
+    "args_list": [
+      "vec",
+      "parameters"
+    ]
+  },
+  "torch.nn.utils.weight_norm": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.utils.weight_norm",
+    "args_list": [
+      "module",
+      "name",
+      "dim"
+    ],
+    "kwargs_change": {
+      "module": "Layer"
+    }
+  },
+  "torch.no_grad": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.no_grad"
+  },
+  "torch.nonzero": {
+    "Matcher": "NonzeroMatcher",
+    "paddle_api": "paddle.nonzero",
+    "args_list": [
+      "input",
+      "as_tuple",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.norm": {
+    "Matcher": "NormMatcher",
+    "paddle_api": "paddle.linalg.norm",
+    "args_list": [
+      "input",
+      "ord",
+      "dim",
+      "keepdim",
+      "out",
+      "dtype"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.normal": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.normal",
+    "args_list": [
+      "mean",
+      "std",
+      "generator",
+      "out"
+    ],
+    "kwargs_change": {
+      "size": "shape"
+    }
+  },
+  "torch.not_equal": {
+    "Matcher": "Num2TensorBinaryMatcher",
+    "paddle_api": "paddle.not_equal",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "other": "y"
+    }
+  },
+  "torch.numel": {
+    "Matcher": "NumelMatcher",
+    "args_list": [
+      "input"
+    ]
+  },
+  "torch.ones": {
+    "Matcher": "CreateMatcher",
+    "paddle_api": "paddle.ones"
+  },
+  "torch.ones_like": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.ones_like",
+    "args_list": [
+      "input",
+      "dtype",
+      "layout",
+      "device",
+      "requires_grad",
+      "memory_format"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.optim.Optimizer": {
+    "Matcher": "OptimOptimizerMatcher",
+    "args_list": [
+      "params",
+      "defaults"
+    ]
+  },
+  "torch.optim.Optimizer.add_param_group": {},
+  "torch.optim.Optimizer.load_state_dict": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.optimizer.Optimizer.set_state_dict",
+    "args_list": [
+      "state_dict"
+    ]
+  },
+  "torch.optim.Optimizer.state_dict": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.optimizer.Optimizer.state_dict"
+  },
+  "torch.optim.Optimizer.step": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.optimizer.Optimizer.step"
+  },
+  "torch.optim.Optimizer.zero_grad": {},
+  "torch.outer": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.outer",
+    "args_list": [
+      "input",
+      "vec2",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "vec2": "y"
+    }
+  },
+  "torch.permute": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.transpose",
+    "args_list": [
+      "input",
+      "dims"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dims": "perm"
+    }
+  },
+  "torch.pinverse": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.linalg.pinv",
+    "args_list": [
+      "input",
+      "rcond"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.poisson": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.poisson",
+    "args_list": [
+      "input",
+      "generator"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.polar": {
+    "Matcher": "PolarMatcher",
+    "args_list": [
+      "abs",
+      "angle",
+      "out"
+    ]
+  },
+  "torch.pow": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.pow",
+    "args_list": [
+      "input",
+      "exponent",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "exponent": "y"
+    }
+  },
+  "torch.prod": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.prod",
+    "args_list": [
+      "input",
+      "dim",
+      "keepdim",
+      "dtype",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.rad2deg": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.rad2deg",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.rand": {
+    "Matcher": "CreateMatcher",
+    "paddle_api": "paddle.rand"
+  },
+  "torch.rand_like": {
+    "Matcher": "RandLikeMatcher",
+    "paddle_api": "paddle.rand",
+    "args_list": [
+      "input",
+      "dtype",
+      "layout",
+      "device",
+      "requires_grad",
+      "memory_format"
+    ]
+  },
+  "torch.randint": {
+    "Matcher": "RandintMatcher",
+    "paddle_api": "paddle.randint",
+    "args_list": [
+      "low",
+      "high",
+      "size"
+    ],
+    "kwargs_change": {
+      "size": "shape"
+    }
+  },
+  "torch.randint_like": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.randint_like",
+    "args_list": [
+      "input",
+      "low",
+      "high",
+      "dtype",
+      "layout",
+      "device",
+      "requires_grad",
+      "memory_format"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.randn": {
+    "Matcher": "CreateMatcher",
+    "paddle_api": "paddle.randn"
+  },
+  "torch.randn_like": {
+    "Matcher": "RandLikeMatcher",
+    "paddle_api": "paddle.randn",
+    "args_list": [
+      "input",
+      "dtype",
+      "layout",
+      "device",
+      "requires_grad",
+      "memory_format"
+    ]
+  },
+  "torch.random.get_rng_state": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.get_cuda_rng_state"
+  },
   "torch.random.manual_seed": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.seed",
@@ -8713,18 +8068,188 @@
       "seed"
     ]
   },
-  "torch.load": {
-    "Matcher": "LoadMatcher",
-    "paddle_api": "paddle.load",
+  "torch.random.seed": {
+    "Matcher": "SeedMatcher"
+  },
+  "torch.random.set_rng_state": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.set_cuda_rng_state",
     "args_list": [
-      "f",
-      "map_location",
-      "pickle_module",
-      "weights_only",
-      "pickle_load_args"
+      "new_state"
     ],
     "kwargs_change": {
-      "f": "path"
+      "new_state": "state_list"
+    }
+  },
+  "torch.randperm": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.randperm",
+    "args_list": [
+      "n",
+      "generator",
+      "out",
+      "dtype",
+      "layout",
+      "device",
+      "requires_grad",
+      "pin_memory"
+    ]
+  },
+  "torch.range": {
+    "Matcher": "RangeMatcher",
+    "paddle_api": "paddle.arange",
+    "args_list": [
+      "start",
+      "end",
+      "step",
+      "out",
+      "dtype",
+      "layout",
+      "device",
+      "requires_grad"
+    ]
+  },
+  "torch.ravel": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.flatten",
+    "args_list": [
+      "input"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.real": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.real",
+    "args_list": [
+      "input"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.reciprocal": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.reciprocal",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.relu": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.relu",
+    "args_list": [
+      "input"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.remainder": {
+    "Matcher": "Num2TensorBinaryMatcher",
+    "paddle_api": "paddle.remainder",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ]
+  },
+  "torch.renorm": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.renorm",
+    "args_list": [
+      "input",
+      "p",
+      "dim",
+      "maxnorm",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis",
+      "maxnorm": "max_norm"
+    }
+  },
+  "torch.repeat_interleave": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.repeat_interleave",
+    "args_list": [
+      "input",
+      "repeats",
+      "dim",
+      "output_size"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.reshape": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.reshape",
+    "args_list": [
+      "input",
+      "shape"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.roll": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.roll",
+    "args_list": [
+      "input",
+      "shifts",
+      "dims"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dims": "axis"
+    }
+  },
+  "torch.rot90": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.rot90",
+    "args_list": [
+      "input",
+      "k",
+      "dims"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dims": "axes"
+    }
+  },
+  "torch.round": {
+    "Matcher": "RoundMatcher",
+    "args_list": [
+      "input",
+      "decimals",
+      "out"
+    ]
+  },
+  "torch.row_stack": {
+    "Matcher": "VStackMatcher",
+    "args_list": [
+      "tensors",
+      "out"
+    ]
+  },
+  "torch.rsqrt": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.rsqrt",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
     }
   },
   "torch.save": {
@@ -8742,21 +8267,265 @@
       "pickle_protocol": "protocol"
     }
   },
-  "torch.div": {
-    "Matcher": "DivMatcher",
+  "torch.seed": {
+    "Matcher": "SeedMatcher"
+  },
+  "torch.select": {
+    "Matcher": "SelectMatcher",
     "args_list": [
       "input",
-      "other",
-      "rounding_mode",
+      "dim",
+      "index"
+    ]
+  },
+  "torch.set_default_dtype": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.set_default_dtype",
+    "args_list": [
+      "d"
+    ]
+  },
+  "torch.set_grad_enabled": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.set_grad_enabled",
+    "args_list": [
+      "mode"
+    ]
+  },
+  "torch.set_printoptions": {
+    "Matcher": "SetPrintOptionsMatcher",
+    "args_list": [
+      "precision",
+      "threshold",
+      "edgeitems",
+      "linewidth",
+      "profile",
+      "sci_mode"
+    ],
+    "paddle_default_kwargs": {
+      "precision": 4
+    }
+  },
+  "torch.set_rng_state": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.set_cuda_rng_state",
+    "args_list": [
+      "new_state"
+    ],
+    "kwargs_change": {
+      "new_state": "state_list"
+    }
+  },
+  "torch.sgn": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.sgn",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.short": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "'int16'"
+  },
+  "torch.sigmoid": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.sigmoid",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.sign": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.sign",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.sin": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.sin",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.sinc": {
+    "Matcher": "SincMatcher",
+    "args_list": [
+      "input",
       "out"
     ]
   },
-  "torch.divide": {
-    "Matcher": "DivMatcher",
+  "torch.sinh": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.sinh",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.slogdet": {
+    "Matcher": "SLogDetMatcher",
+    "paddle_api": "paddle.linalg.slogdet",
+    "args_list": [
+      "input"
+    ]
+  },
+  "torch.softmax": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.functional.softmax",
+    "args_list": [
+      "input",
+      "dim",
+      "dtype"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.sort": {
+    "Matcher": "SortMatcher",
+    "paddle_api": "paddle.sort",
+    "args_list": [
+      "input",
+      "dim",
+      "descending",
+      "stable",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis",
+      "stable": ""
+    }
+  },
+  "torch.sparse.sum": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.sparse.sum",
+    "args_list": [
+      "input",
+      "dim",
+      "dtype"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    },
+    "unsupport_args": [
+      "dtype"
+    ]
+  },
+  "torch.sparse_coo_tensor": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.sparse.sparse_coo_tensor",
+    "args_list": [
+      "indices",
+      "values",
+      "size",
+      "dtype",
+      "device",
+      "requires_grad"
+    ],
+    "kwargs_change": {
+      "size": "shape"
+    }
+  },
+  "torch.special.digamma": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.digamma",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.special.erf": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.erf",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.special.log1p": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.log1p",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.special.logsumexp": {
+    "Matcher": "LogsumexpMatcher",
+    "paddle_api": "paddle.logsumexp",
+    "args_list": [
+      "input",
+      "dim",
+      "keepdim",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.special.ndtri": {
+    "Matcher": "SpecialNdtriMatcher",
+    "args_list": [
+      "input",
+      "out"
+    ]
+  },
+  "torch.special.psi": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.digamma",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.special.sinc": {
+    "Matcher": "SincMatcher",
+    "args_list": [
+      "input",
+      "out"
+    ]
+  },
+  "torch.special.xlog1py": {
+    "Matcher": "SpecialXLog1pYMatcher",
     "args_list": [
       "input",
       "other",
-      "rounding_mode",
       "out"
     ]
   },
@@ -8769,42 +8538,384 @@
       "dim"
     ]
   },
-  "torch.range": {
-    "Matcher": "RangeMatcher",
-    "paddle_api": "paddle.arange",
+  "torch.sqrt": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.sqrt",
     "args_list": [
-      "start",
-      "end",
-      "step",
-      "out",
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.square": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.square",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.squeeze": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.squeeze",
+    "args_list": [
+      "input",
+      "dim"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.stack": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.stack",
+    "args_list": [
+      "tensor",
+      "dim",
+      "out"
+    ],
+    "kwargs_change": {
+      "tensor": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.std": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.std",
+    "args_list": [
+      "input",
+      "dim",
+      "unbiased",
+      "keepdim",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.std_mean": {
+    "Matcher": "StdMeanMatcher",
+    "args_list": [
+      "input",
+      "dim",
+      "correction",
+      "keepdim",
+      "out"
+    ]
+  },
+  "torch.sub": {
+    "Matcher": "SubMatcher",
+    "args_list": [
+      "input",
+      "other",
+      "alpha",
+      "out"
+    ]
+  },
+  "torch.subtract": {
+    "Matcher": "SubMatcher",
+    "args_list": [
+      "input",
+      "other",
+      "alpha",
+      "out"
+    ]
+  },
+  "torch.sum": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.sum",
+    "args_list": [
+      "input",
+      "dim",
+      "keepdim",
+      "dtype"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.swapaxes": {
+    "Matcher": "SwapAxesMatcher",
+    "args_list": [
+      "input",
+      "axis0",
+      "axis1"
+    ]
+  },
+  "torch.swapdims": {
+    "Matcher": "TransposeMatcher",
+    "args_list": [
+      "input",
+      "dim0",
+      "dim1"
+    ]
+  },
+  "torch.t": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.t",
+    "args_list": [
+      "input"
+    ]
+  },
+  "torch.take": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.take",
+    "args_list": [
+      "input",
+      "index"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.tan": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.tan",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.tanh": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.tanh",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.tensor": {
+    "Matcher": "TorchTensorMatcher",
+    "paddle_api": "paddle.to_tensor",
+    "args_list": [
+      "data",
       "dtype",
-      "layout",
       "device",
-      "requires_grad"
+      "requires_grad",
+      "pin_memory"
     ]
   },
-  "torch.meshgrid": {
-    "Matcher": "MeshgridMatcher",
-    "paddle_api": "paddle.meshgrid",
+  "torch.tensordot": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.tensordot",
     "args_list": [
-      "tensors",
-      "indexing"
-    ]
+      "a",
+      "b",
+      "dims",
+      "out"
+    ],
+    "kwargs_change": {
+      "a": "x",
+      "b": "y",
+      "dims": "axes"
+    }
   },
-  "torch.utils.data.Dataset": {
+  "torch.tile": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.io.Dataset"
-  },
-  "torch.utils.data.Sampler": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.io.Sampler",
+    "paddle_api": "paddle.tile",
     "args_list": [
-      "data_source"
+      "input",
+      "dims"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dims": "repeat_times"
+    }
+  },
+  "torch.topk": {
+    "Matcher": "TupleAssignMatcher",
+    "paddle_api": "paddle.topk",
+    "args_list": [
+      "input",
+      "k",
+      "dim",
+      "largest",
+      "sorted",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.trace": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.trace",
+    "args_list": [
+      "input"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.transpose": {
+    "Matcher": "TransposeMatcher",
+    "args_list": [
+      "input",
+      "dim0",
+      "dim1"
     ]
   },
-  "torch.utils.cpp_extension.CUDA_HOME": {
+  "torch.triangular_solve": {
+    "Matcher": "TriangularSolveMatcher",
+    "paddle_api": "paddle.linalg.triangular_solve",
+    "args_list": [
+      "b",
+      "A",
+      "upper",
+      "transpose",
+      "unitriangular",
+      "out"
+    ],
+    "kwargs_change": {
+      "b": "y",
+      "A": "x"
+    }
+  },
+  "torch.tril": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.utils.cpp_extension.cpp_extension.CUDA_HOME"
+    "paddle_api": "paddle.tril",
+    "args_list": [
+      "input",
+      "diagonal",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.tril_indices": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.tril_indices",
+    "args_list": [
+      "row",
+      "col",
+      "offset",
+      "dtype",
+      "device",
+      "layout"
+    ]
+  },
+  "torch.triu": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.triu",
+    "args_list": [
+      "input",
+      "diagonal",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.triu_indices": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.triu_indices",
+    "args_list": [
+      "row",
+      "col",
+      "offset",
+      "dtype",
+      "device",
+      "layout"
+    ]
+  },
+  "torch.true_divide": {
+    "Matcher": "TrueDivideMatcher",
+    "args_list": [
+      "input",
+      "other",
+      "out"
+    ]
+  },
+  "torch.trunc": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.trunc",
+    "args_list": [
+      "input",
+      "out"
+    ]
+  },
+  "torch.uint8": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "'uint8'"
+  },
+  "torch.unbind": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.unbind",
+    "args_list": [
+      "input",
+      "dim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
+  "torch.unflatten": {
+    "Matcher": "UnflattenMatcher",
+    "args_list": [
+      "input",
+      "dim",
+      "sizes"
+    ]
+  },
+  "torch.unique": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.unique",
+    "args_list": [
+      "input",
+      "sorted",
+      "return_inverse",
+      "return_counts",
+      "dim"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    },
+    "unsupport_args": [
+      "sorted"
+    ]
+  },
+  "torch.unique_consecutive": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.unique_consecutive",
+    "args_list": [
+      "input",
+      "return_inverse",
+      "return_counts",
+      "dim"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
+  },
+  "torch.unsqueeze": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.unsqueeze",
+    "args_list": [
+      "input",
+      "dim"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "dim": "axis"
+    }
   },
   "torch.utils.cpp_extension.BuildExtension": {
     "Matcher": "GenericMatcher",
@@ -8816,6 +8927,39 @@
   "torch.utils.cpp_extension.BuildExtension.with_options": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.utils.cpp_extension.BuildExtension.with_options"
+  },
+  "torch.utils.cpp_extension.CUDA_HOME": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.utils.cpp_extension.cpp_extension.CUDA_HOME"
+  },
+  "torch.utils.data.BatchSampler": {
+    "Matcher": "TorchUtilDataBatchSampler",
+    "args_list": [
+      "sampler",
+      "batch_size",
+      "drop_last"
+    ]
+  },
+  "torch.utils.data.Dataset": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.io.Dataset"
+  },
+  "torch.utils.data.RandomSampler": {
+    "Matcher": "RandomSamplerMatcher",
+    "paddle_api": "paddle.io.RandomSampler",
+    "args_list": [
+      "data_source",
+      "replacement",
+      "num_samples",
+      "generator"
+    ]
+  },
+  "torch.utils.data.Sampler": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.io.Sampler",
+    "args_list": [
+      "data_source"
+    ]
   },
   "torch.utils.data.random_split": {
     "Matcher": "RandomSplitMatcher",
@@ -8846,250 +8990,106 @@
       "tensor": "x"
     }
   },
-  "torch.nn.functional.l1_loss": {
-    "Matcher": "SizeAverageMatcher",
-    "paddle_api": "paddle.nn.functional.l1_loss",
+  "torch.vander": {},
+  "torch.var": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.var",
     "args_list": [
       "input",
-      "target",
-      "size_average",
-      "reduce",
-      "reduction"
-    ]
-  },
-  "torch.nn.functional.binary_cross_entropy_with_logits": {
-    "Matcher": "SizeAverageMatcher",
-    "paddle_api": "paddle.nn.functional.binary_cross_entropy_with_logits",
-    "args_list": [
-      "input",
-      "target",
-      "weight",
-      "size_average",
-      "reduce",
-      "reduction",
-      "pos_weight"
-    ]
-  },
-  "torch.nn.functional.max_pool2d": {
-    "Matcher": "FunctionalMaxPool2DMatcher",
-    "paddle_api": "paddle.nn.functional.max_pool2d",
-    "args_list": [
-      "input",
-      "kernel_size",
-      "stride",
-      "padding",
-      "dilation",
-      "ceil_mode",
-      "return_indices"
+      "dim",
+      "unbiased",
+      "keepdim",
+      "out"
     ],
     "kwargs_change": {
       "input": "x",
-      "return_indices": "return_mask"
+      "dim": "axis"
     }
   },
-  "torch.cuda.max_memory_allocated": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.device.cuda.max_memory_allocated",
-    "args_list": [
-      "device"
-    ],
-    "kwargs_change": {
-      "device": "device"
-    }
-  },
-  "torch.nn.InstanceNorm1d": {
-    "Matcher": "InstanceNormMatcher",
-    "paddle_api": "paddle.nn.InstanceNorm1D",
-    "args_list": [
-      "num_features",
-      "eps",
-      "momentum",
-      "affine",
-      "track_running_stats",
-      "device",
-      "dtype"
-    ],
-    "kwargs_change": {
-      "eps": "epsilon",
-      "dtype": "",
-      "affine": [
-        "weight_attr",
-        "bias_attr"
-      ]
-    }
-  },
-  "torch.nn.InstanceNorm2d": {
-    "Matcher": "InstanceNormMatcher",
-    "paddle_api": "paddle.nn.InstanceNorm2D",
-    "args_list": [
-      "num_features",
-      "eps",
-      "momentum",
-      "affine",
-      "track_running_stats",
-      "device",
-      "dtype"
-    ],
-    "kwargs_change": {
-      "eps": "epsilon",
-      "dtype": "",
-      "affine": [
-        "weight_attr",
-        "bias_attr"
-      ]
-    }
-  },
-  "torch.nn.InstanceNorm3d": {
-    "Matcher": "InstanceNormMatcher",
-    "paddle_api": "paddle.nn.InstanceNorm3D",
-    "args_list": [
-      "num_features",
-      "eps",
-      "momentum",
-      "affine",
-      "track_running_stats",
-      "device",
-      "dtype"
-    ],
-    "kwargs_change": {
-      "eps": "epsilon",
-      "dtype": "",
-      "affine": [
-        "weight_attr",
-        "bias_attr"
-      ]
-    }
-  },
-  "torch.nn.BCEWithLogitsLoss": {
-    "Matcher": "SizeAverageMatcher",
-    "paddle_api": "paddle.nn.BCEWithLogitsLoss",
-    "args_list": [
-      "weight",
-      "size_average",
-      "reduce",
-      "reduction",
-      "pos_weight"
-    ]
-  },
-  "torch.nn.functional.multi_margin_loss": {
-    "Matcher": "SizeAverageMatcher",
-    "paddle_api": "paddle.nn.functional.multi_margin_loss",
+  "torch.var_mean": {
+    "Matcher": "VarMeanMatcher",
     "args_list": [
       "input",
-      "target",
-      "p",
-      "margin",
-      "weight",
-      "size_average",
-      "reduce",
-      "reduction"
-    ],
-    "kwargs_change": {
-      "target": "label"
-    }
-  },
-  "torch.utils.data.BatchSampler": {
-    "Matcher": "TorchUtilDataBatchSampler",
-    "args_list": [
-      "sampler",
-      "batch_size",
-      "drop_last"
+      "dim",
+      "correction",
+      "keepdim",
+      "out"
     ]
   },
-  "torch.utils.data.RandomSampler": {
-    "Matcher": "RandomSamplerMatcher",
-    "paddle_api": "paddle.io.RandomSampler",
-    "args_list": [
-      "data_source",
-      "replacement",
-      "num_samples",
-      "generator"
-    ]
-  },
-  "torch.Generator": {
-    "Matcher": "GeneratorMatcher",
-    "args_list": [
-      "device"
-    ]
-  },
-  "torch.Size": {
-    "Matcher": "SizeMatcher",
-    "paddle_api": "list",
-    "args_list": []
-  },
-  "torch.take": {
+  "torch.vdot": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.take",
+    "paddle_api": "paddle.dot",
     "args_list": [
       "input",
-      "index"
+      "other",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x",
+      "other": "y"
+    }
+  },
+  "torch.view_as_complex": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.as_complex",
+    "args_list": [
+      "input"
     ],
     "kwargs_change": {
       "input": "x"
     }
   },
-  "torch.nn.modules.batchnorm._BatchNorm": {
-    "Matcher": "Modules_BatchNormBaseMatcher",
-    "paddle_api": "paddle.nn.layer.norm._BatchNormBase",
-    "args_list": [
-      "num_features",
-      "eps",
-      "momentum",
-      "affine",
-      "track_running_stats",
-      "device",
-      "dtype"
-    ],
-    "kwargs_change": {
-      "eps": "epsilon"
-    }
-  },
-  "torch.lu": {
-    "Matcher": "LuMatcher",
-    "paddle_api": "paddle.linalg.lu",
-    "args_list": [
-      "A",
-      "pivot",
-      "get_infos",
-      "out"
-    ],
-    "kwargs_change": {
-      "A": "x"
-    }
-  },
-  "torch.autograd.grad": {
+  "torch.view_as_real": {
     "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.grad",
+    "paddle_api": "paddle.as_real",
     "args_list": [
-      "outputs",
-      "inputs",
-      "grad_outputs",
-      "retain_graph",
-      "create_graph",
-      "only_inputs",
-      "allow_unused",
-      "is_grads_batched"
+      "input"
     ],
     "kwargs_change": {
-      "is_grads_batched": ""
-    },
-    "unsupport_args": [
-      "only_inputs"
+      "input": "x"
+    }
+  },
+  "torch.vstack": {
+    "Matcher": "VStackMatcher",
+    "args_list": [
+      "tensors",
+      "out"
     ]
   },
-  "torch.nn.functional.multilabel_soft_margin_loss": {
-    "Matcher": "SizeAverageMatcher",
-    "paddle_api": "paddle.nn.functional.multi_label_soft_margin_loss",
+  "torch.where": {
+    "Matcher": "WhereMatcher",
+    "paddle_api": "paddle.where",
+    "args_list": [
+      "condition",
+      "x",
+      "y"
+    ]
+  },
+  "torch.xlogy": {
+    "Matcher": "XLogYMatcher",
     "args_list": [
       "input",
-      "target",
-      "weight",
-      "size_average",
-      "reduce",
-      "reduction"
+      "other",
+      "out"
+    ]
+  },
+  "torch.zeros": {
+    "Matcher": "CreateMatcher",
+    "paddle_api": "paddle.zeros"
+  },
+  "torch.zeros_like": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.zeros_like",
+    "args_list": [
+      "input",
+      "dtype",
+      "layout",
+      "device",
+      "requires_grad",
+      "memory_format"
     ],
     "kwargs_change": {
-      "target": "label"
+      "input": "x"
     }
   }
 }

--- a/paconvert/attribute_mapping.json
+++ b/paconvert/attribute_mapping.json
@@ -1,4 +1,8 @@
 {
+  "torch.Tensor.H": {},
+  "torch.Tensor.T": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
   "torch.Tensor.device": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.Tensor.place"
@@ -9,34 +13,30 @@
   "torch.Tensor.grad": {
     "Matcher": "TensorUnchangeMatcher"
   },
-  "torch.Tensor.ndim": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.T": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
-  "torch.Tensor.real": {
-    "Matcher": "TensorUnchangeMatcher"
-  },
   "torch.Tensor.imag": {
     "Matcher": "TensorUnchangeMatcher"
   },
+  "torch.Tensor.is_cuda": {},
   "torch.Tensor.is_leaf": {
     "Matcher": "TensorUnchangeMatcher"
   },
-  "torch.Tensor.shape": {
+  "torch.Tensor.is_meta": {},
+  "torch.Tensor.is_quantized": {},
+  "torch.Tensor.is_sparse": {},
+  "torch.Tensor.mH": {},
+  "torch.Tensor.mT": {},
+  "torch.Tensor.names": {},
+  "torch.Tensor.ndim": {
+    "Matcher": "TensorUnchangeMatcher"
+  },
+  "torch.Tensor.real": {
     "Matcher": "TensorUnchangeMatcher"
   },
   "torch.Tensor.requires_grad": {
     "Matcher": "TensorRequires_GradMatcher",
     "paddle_api": "paddle.Tensor.stop_gradient"
   },
-  "torch.Tensor.is_sparse": {},
-  "torch.Tensor.is_cuda": {},
-  "torch.Tensor.is_quantized": {},
-  "torch.Tensor.is_meta": {},
-  "torch.Tensor.H": {},
-  "torch.Tensor.mT": {},
-  "torch.Tensor.mH": {},
-  "torch.Tensor.names": {}
+  "torch.Tensor.shape": {
+    "Matcher": "TensorUnchangeMatcher"
+  }
 }

--- a/tools/codestyle/json.hook
+++ b/tools/codestyle/json.hook
@@ -15,9 +15,9 @@
 import argparse
 import re
 import sys
-import os
 import json
-from typing import Sequence, Mapping, Tuple
+
+NEED_SORT_API_KEYS = ['kwargs_change', 'paddle_default_kwargs']
 
 def _check_json_file(path):
     lang_type=re.compile(r"\.json$")
@@ -31,7 +31,7 @@ def _sort_dict_by_array(dictionary, key_array=None):
 
     # Sort keys present in key_array
     sorted_keys = [key for key in key_array if key in dictionary]
-    sorted_keys.sort(key=lambda x: key_array.index(x))
+    sorted_keys.sort(key=key_array.index)
 
     # Sort remaining keys in dictionary
     remaining_keys = [key for key in dictionary if key not in key_array]
@@ -50,12 +50,11 @@ def _get_pretty_api_format(value):
         return value
 
     new_value = value.copy()
-    SORT_KEYS = ['kwargs_change', 'paddle_default_kwargs']
 
     if 'args_list' in value and isinstance(value['args_list'], list):
-        for sk in SORT_KEYS:
-            if sk in new_value and isinstance(new_value[sk], dict):
-                new_value[sk] = _sort_dict_by_array(new_value[sk], value['args_list'])
+        for k in NEED_SORT_API_KEYS:
+            if k in new_value and isinstance(new_value[k], dict):
+                new_value[k] = _sort_dict_by_array(new_value[k], value['args_list'])
 
     return new_value
 
@@ -81,7 +80,7 @@ def _get_pretty_format(
 
 
 def _format_json_file(path):
-    with open(path, 'r') as file:
+    with open(path, 'r', encoding='UTF-8') as file:
         contents = file.read()
 
     new_contents = _get_pretty_format(contents, indent=2)
@@ -99,7 +98,6 @@ def main(argv=None):
     parser.add_argument('filenames', nargs='*', help='Filenames to check')
     args = parser.parse_args(argv)
 
-    retv = 0
     for path in args.filenames:
         is_json_file = _check_json_file(path)
         if is_json_file is None:
@@ -110,4 +108,4 @@ def main(argv=None):
 
 
 if __name__ == '__main__':
-    exit(main())
+    sys.exit(main())

--- a/tools/codestyle/json.hook
+++ b/tools/codestyle/json.hook
@@ -17,6 +17,7 @@ import re
 import sys
 import os
 import json
+from typing import Sequence, Mapping, Tuple
 
 def _check_json_file(path):
     lang_type=re.compile(r"\.json$")
@@ -25,21 +26,41 @@ def _check_json_file(path):
 
     return False
 
+def _get_pretty_format(
+    contents: str,
+    indent,
+    ensure_ascii: bool = True,
+    sort_keys: bool = True,
+) -> str:
+    def sort_dict(dictionary):
+        return dict(sorted(dictionary.items()))
+
+    json_data = json.loads(contents)
+
+    if sort_keys and isinstance(json_data, dict):
+        json_data = sort_dict(json_data)
+
+    json_pretty = json.dumps(
+        json_data,
+        indent=indent,
+        ensure_ascii=ensure_ascii
+    )
+
+    return f'{json_pretty}\n'
+
+
 def _format_json_file(path):
     with open(path, 'r') as file:
-        data = json.load(file)
+        contents = file.read()
 
-    with open(path, mode='w') as file:
-        json.dump(data, file, indent=2)
+    new_contents = _get_pretty_format(contents, indent=2)
 
-    # Read the file again and remove the trailing newline character
-    with open(path, 'r') as f:
-        content = f.read()
+    # Remove the trailing newline character
+    new_contents = new_contents.rstrip('\n') + '\n'
 
-    content = content.rstrip('\n') + '\n'
+    with open(path, mode='w', encoding='UTF-8') as file:
+        file.write(new_contents)
 
-    with open(path, 'w') as f:
-        f.write(content)
 
 def main(argv=None):
     parser = argparse.ArgumentParser(

--- a/tools/codestyle/json.hook
+++ b/tools/codestyle/json.hook
@@ -26,19 +26,50 @@ def _check_json_file(path):
 
     return False
 
+def _sort_dict_by_array(dictionary, key_array=None):
+    sorted_dict = {}
+
+    # Sort keys present in key_array
+    sorted_keys = [key for key in key_array if key in dictionary]
+    sorted_keys.sort(key=lambda x: key_array.index(x))
+
+    # Sort remaining keys in dictionary
+    remaining_keys = [key for key in dictionary if key not in key_array]
+    remaining_keys.sort()
+
+    # Create sorted dictionary
+    for key in sorted_keys:
+        sorted_dict[key] = dictionary[key]
+    for key in remaining_keys:
+        sorted_dict[key] = dictionary[key]
+
+    return sorted_dict
+
+def _get_pretty_api_format(value):
+    if not isinstance(value, dict):
+        return value
+
+    new_value = value.copy()
+    SORT_KEYS = ['kwargs_change', 'paddle_default_kwargs']
+
+    if 'args_list' in value and isinstance(value['args_list'], list):
+        for sk in SORT_KEYS:
+            if sk in new_value and isinstance(new_value[sk], dict):
+                new_value[sk] = _sort_dict_by_array(new_value[sk], value['args_list'])
+
+    return new_value
+
+
 def _get_pretty_format(
     contents: str,
     indent,
     ensure_ascii: bool = True,
     sort_keys: bool = True,
 ) -> str:
-    def sort_dict(dictionary):
-        return dict(sorted(dictionary.items()))
-
     json_data = json.loads(contents)
 
     if sort_keys and isinstance(json_data, dict):
-        json_data = sort_dict(json_data)
+        json_data = dict(sorted([(k, _get_pretty_api_format(v)) for (k, v) in json_data.items()]))
 
     json_pretty = json.dumps(
         json_data,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->

- 参考 @GreatV 意见

修改 `tools/codestyle/json.hook` ，以便在 `pre-commit` 时，对 json 文件进行排序，以减少后续的开发冲突。

排序规则：
- api 之间（最顶层）：按照字典序排序；
- api 内部（内层）：`kwargs_change` 和 `paddle_default_kwargs` 这两个键如果存在且为字典形式，则按照 `args_list` 的顺序排序。
- 其他：保持不变

### PR APIs
```bash
# Empty Line for PR Template
```