### PR TITLE
fix bug in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ torch.permute
       "dims": "perm"
     }
   },
-  "unsupport_args": {},
+  "unsupport_args": [],
   "paddle_default_kwargs": {}
 }
 ```


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->
修复 `README.md` 中的 `unsupport_args` 示例错误的问题：应为列表类型 `[]`，参考为 `{}`

### PR APIs
<!-- APIs what you've done -->
```bash
# Empty Line But For PR Template
```
