### PR TITLE
转换规则 No.198 torch.distribution.kl.register_kl

### DIFF
--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -3592,6 +3592,18 @@
       "q"
     ]
   },
+  "torch.distributions.kl.register_kl": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.distribution.kl.register_kl",
+    "args_list": [
+      "type_p",
+      "type_q"
+    ],
+    "kwargs_change": {
+      "type_p": "cls_p",
+      "type_q": "cls_q"
+    }
+  },
   "torch.div": {
     "Matcher": "DivMatcher",
     "args_list": [

--- a/tests/test_distributions_kl_register_kl.py
+++ b/tests/test_distributions_kl_register_kl.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.distribution.kl.register_kl")
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+
+        @torch.distributions.kl.register_kl(torch.distributions.beta.Beta, torch.distributions.beta.Beta)
+        def kl(p,q):
+            return p, q
+
+        result = kl(torch.tensor([0.3, 0.3, 0.3]), torch.tensor([0.4, 0.4, 0.2]))
+        """
+    )
+    obj.run(pytorch_code, ["result"])


### PR DESCRIPTION
已经有api文档https://github.com/PaddlePaddle/docs/blob/develop/docs/guides/model_convert/convert_from_pytorch/api_difference/distributions/torch.distributions.kl.register_kl.md

<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->

### PR APIs
<!-- APIs what you've done -->
```bash

```
