### PR TITLE
转换规则 No. 391-395/397/401

### DIFF
--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -6673,7 +6673,10 @@
   "torch.nn.Module.apply": {
     "Matcher": "TensorUnchangeMatcher"
   },
-  "torch.nn.Module.bfloat16": {},
+  "torch.nn.Module.bfloat16": {
+    "Matcher": "NnModuleTypeMatcher",
+    "paddle_api": "paddle.nn.Layer.to"
+  },
   "torch.nn.Module.buffers": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.nn.Layer.buffers",
@@ -6690,16 +6693,25 @@
   },
   "torch.nn.Module.cpu": {},
   "torch.nn.Module.cuda": {},
-  "torch.nn.Module.double": {},
+  "torch.nn.Module.double": {
+    "Matcher": "NnModuleTypeMatcher",
+    "paddle_api": "paddle.nn.Layer.to"
+  },
   "torch.nn.Module.eval": {
     "Matcher": "TensorUnchangeMatcher"
   },
-  "torch.nn.Module.float": {},
+  "torch.nn.Module.float": {
+    "Matcher": "NnModuleTypeMatcher",
+    "paddle_api": "paddle.nn.Layer.to"
+  },
   "torch.nn.Module.get_buffer": {},
   "torch.nn.Module.get_extra_state": {},
   "torch.nn.Module.get_parameter": {},
   "torch.nn.Module.get_submodule": {},
-  "torch.nn.Module.half": {},
+  "torch.nn.Module.half": {
+    "Matcher": "NnModuleTypeMatcher",
+    "paddle_api": "paddle.nn.Layer.to"
+  },
   "torch.nn.Module.ipu": {},
   "torch.nn.Module.load_state_dict": {
     "Matcher": "GenericMatcher",
@@ -6840,13 +6852,24 @@
       "keep_vars"
     ]
   },
-  "torch.nn.Module.to": {},
+  "torch.nn.Module.to": {
+    "Matcher": "NnModuleToMatcher",
+    "paddle_api": "paddle.nn.Layer.to",
+    "args_list": [
+      "device",
+      "dtype",
+      "non_blocking"
+    ]
+  },
   "torch.nn.Module.to_empty": {},
   "torch.nn.Module.train": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.nn.Layer.train"
   },
-  "torch.nn.Module.type": {},
+  "torch.nn.Module.type": {
+    "Matcher": "NnModuleTypeMatcher",
+    "paddle_api": "paddle.nn.Layer.to"
+  },
   "torch.nn.Module.xpu": {},
   "torch.nn.Module.zero_grad": {},
   "torch.nn.ModuleDict": {

--- a/tests/test_nn_Module_bfloat16.py
+++ b/tests/test_nn_Module_bfloat16.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.Module.bfloat16")
+
+
+def _test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([1., 2., 3.])
+        module1 = torch.nn.Module()
+        module1.register_buffer('buffer', x)
+        module1.bfloat16()
+        result = module1.buffer
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_nn_Module_double.py
+++ b/tests/test_nn_Module_double.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.Module.double")
+
+
+def _test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([1., 2., 3.])
+        module1 = torch.nn.Module()
+        module1.register_buffer('buffer', x)
+        module1.double()
+        result = module1.buffer
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_nn_Module_float.py
+++ b/tests/test_nn_Module_float.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.Module.float")
+
+
+def _test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([1., 2., 3.])
+        module1 = torch.nn.Module()
+        module1.register_buffer('buffer', x)
+        module1.float()
+        result = module1.buffer
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_nn_Module_half.py
+++ b/tests/test_nn_Module_half.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.Module.half")
+
+
+def _test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([1., 2., 3.])
+        module1 = torch.nn.Module()
+        module1.register_buffer('buffer', x)
+        module1.half()
+        result = module1.buffer
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_nn_Module_to.py
+++ b/tests/test_nn_Module_to.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.Module.to")
+
+
+def _test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([1., 2., 3.])
+        module1 = torch.nn.Module()
+        module1.register_buffer('buffer', x)
+        module1.to(dtype=torch.float32)
+        result = module1.buffer
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def _test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([1., 2., 3.])
+        module1 = torch.nn.Module()
+        module1.register_buffer('buffer', x)
+        module1.to(device="cpu")
+        result = module1.buffer
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def _test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([1., 2., 3.])
+        module1 = torch.nn.Module()
+        module1.register_buffer('buffer', x)
+        module1.to(device="cpu", non_blocking=False)
+        result = module1.buffer
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_nn_Module_type.py
+++ b/tests/test_nn_Module_type.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.Module.type")
+
+
+def _test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([1., 2., 3.])
+        module1 = torch.nn.Module()
+        module1.register_buffer('buffer', x)
+        module1.type(torch.float32)
+        result = module1.buffer
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def _test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([1., 2., 3.])
+        module1 = torch.nn.Module()
+        module1.register_buffer('buffer', x)
+        module1.type(dst_type=torch.float32)
+        result = module1.buffer
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_nn_Module_zero_grad.py
+++ b/tests/test_nn_Module_zero_grad.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.Module.zero_grad")
+
+
+def _test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([1., 2., 3.])
+        module1 = torch.nn.Module()
+        module1.register_buffer('buffer', x)
+        module1.zero_grad()
+        result = module1.buffer
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def _test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([1., 2., 3.])
+        module1 = torch.nn.Module()
+        module1.register_buffer('buffer', x)
+        module1.zero_grad(set_to_none=True)
+        result = module1.buffer
+        """
+    )
+    obj.run(pytorch_code, ["result"])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->
https://github.com/PaddlePaddle/PaConvert/issues/112

因为torch.nn.Module 在转换框架中识别为torch.Tensor类型，测试用例使用def _test定义没有启用

合并到 https://github.com/PaddlePaddle/PaConvert/pull/186
### PR APIs
<!-- APIs what you've done -->
```bash
391 torch.nn.Module.type
392 torch.nn.Module.float
393 torch.nn.Module.double
394 torch.nn.Module.half
395 torch.nn.Module.bfloat16

397 torch.nn.Module.to

401 torch.nn.Module.zero_grad
```
