### PR TITLE
转换规则 No. 94/95/96

### DIFF
--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -1635,7 +1635,18 @@
       "dim"
     ]
   },
-  "torch.Tensor.nanquantile": {},
+  "torch.Tensor.nanquantile": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.nanquantile",
+    "args_list": [
+      "q",
+      "dim",
+      "keepdim"
+    ],
+    "kwargs_change": {
+      "dim": "axis"
+    }
+  },
   "torch.Tensor.nansum": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.Tensor.nansum",
@@ -1814,7 +1825,13 @@
     "Matcher": "TensorFunc2PaddleFunc",
     "paddle_api": "paddle.linalg.pinv"
   },
-  "torch.Tensor.polygamma": {},
+  "torch.Tensor.polygamma": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.polygamma",
+    "args_list": [
+      "n"
+    ]
+  },
   "torch.Tensor.polygamma_": {},
   "torch.Tensor.positive": {},
   "torch.Tensor.pow": {
@@ -1846,7 +1863,13 @@
   "torch.Tensor.q_per_channel_zero_points": {},
   "torch.Tensor.q_scale": {},
   "torch.Tensor.q_zero_point": {},
-  "torch.Tensor.qr": {},
+  "torch.Tensor.qr": {
+    "Matcher": "QrMatcher",
+    "paddle_api": "paddle.Tensor.qr",
+    "args_list": [
+      "some"
+    ]
+  },
   "torch.Tensor.qscheme": {},
   "torch.Tensor.quantile": {},
   "torch.Tensor.rad2deg": {

--- a/tests/test_Tensor_nanquantile.py
+++ b/tests/test_Tensor_nanquantile.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.nanquantile")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([1.02, 2.21, 3.333, 30], dtype=torch.float64)
+        result = x.nanquantile(0.5)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([float('nan'), 2.21, 3.333, 30], dtype=torch.float64)
+        result = x.nanquantile(0.6, dim=0)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([float('nan'), 1.02, 2.21, 3.333,30, float('nan')], dtype=torch.float64)
+        result = x.nanquantile(q=0.3, dim=-1)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[float('nan'), 1.02, 2.21, 3.333,30, float('nan')]], dtype=torch.float64)
+        result = x.nanquantile(q=0.3, dim=1, keepdim=True)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[float('nan'), 1.02, 2.21, 3.333,30, float('nan')]], dtype=torch.float64)
+        result = x.nanquantile(q=0.3, dim=1, keepdim=False)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_6():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[0]], dtype=torch.float64)
+        result = x.nanquantile(q=0.3, dim=1, keepdim=True)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_Tensor_polygamma.py
+++ b/tests/test_Tensor_polygamma.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.polygamma")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([1.02, 2.21, 3.33])
+        result = x.polygamma(1)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([1.02, 2.21, 3.33, 4])
+        result = x.polygamma(1)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([1.02, 2.21, 3.33], dtype=torch.float32)
+        result = x.polygamma(2)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([1.02, 2, 3.333], dtype=torch.float64)
+        result = x.polygamma(3)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_Tensor_qr.py
+++ b/tests/test_Tensor_qr.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.qr")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[1., -2, 3],[4., 166, 6]])
+        Q, R = x.qr()
+        """
+    )
+    obj.run(pytorch_code, ["Q", "R"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[1., -2, 3],[4., 166, 6], [-4, 24, -41]])
+        Q, R = x.qr()
+        """
+    )
+    obj.run(pytorch_code, ["Q", "R"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[1., -2, 3],[4., 166, 6], [-4, 24, -41]])
+        Q, R = x.qr(some=True)
+        """
+    )
+    obj.run(pytorch_code, ["Q", "R"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[1., -2, 3],[4., 166, 6], [-4, 24, -41]])
+        Q, R = x.qr(some=False)
+        """
+    )
+    obj.run(pytorch_code, ["Q", "R"])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
[<!-- Describe the docs PR corresponding the APIs -->](https://github.com/PaddlePaddle/docs/pull/6053)

### PR APIs
<!-- APIs what you've done -->
```bash
paddle.tensor.polygamma
paddle.tensor.qr
paddle.tensor.nanquantile
```

[https://github.com/PaddlePaddle/PaConvert/issues/112](https://github.com/PaddlePaddle/PaConvert/issues/112)
[对应文档](https://github.com/PaddlePaddle/docs/pull/6053)

疑问：
1、torch.qr 会在未来版本改为 torch.linalg.qr() 与 paddle.linalg.qr() 对齐，可能到时需要修改。
2、torch.nanquantile 的参数 q 和 dim 不支持 list 类型。参考了[https://github.com/PaddlePaddle/PaConvert/pull/167](https://github.com/PaddlePaddle/PaConvert/pull/167) 没有加入相关单测。