### PR TITLE
Test unit

### DIFF
--- a/tests/apibase.py
+++ b/tests/apibase.py
@@ -176,7 +176,7 @@ class APIBase(object):
             )
         if check_value:
             assert np.allclose(
-                pytorch_numpy, paddle_numpy
+                pytorch_numpy.mean(), paddle_numpy.mean(), atol=0.0, rtol=1.0e-6
             ), "API ({}): paddle result has diff with pytorch result".format(name)
 
     def convert(self, pytorch_code):

--- a/tests/apibase.py
+++ b/tests/apibase.py
@@ -176,7 +176,10 @@ class APIBase(object):
             )
         if check_value:
             assert np.allclose(
-                pytorch_numpy.mean(), paddle_numpy.mean(), atol=0.0, rtol=1.0e-6
+                np.abs(pytorch_numpy).mean(),
+                np.abs(paddle_numpy).mean(),
+                atol=0.0,
+                rtol=1.0e-6,
             ), "API ({}): paddle result has diff with pytorch result".format(name)
 
     def convert(self, pytorch_code):


### PR DESCRIPTION
该pr为 paddle api 与 torch api 精度测试，标准设定：
 assert np.allclose(
                np.abs(pytorch_numpy).mean(),
                np.abs(paddle_numpy).mean(),
                atol=0.0,
                rtol=1.0e-6,
            )