### PR TITLE
转换规则 No.334

### DIFF
--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -9766,6 +9766,14 @@
       "input": "x"
     }
   },
+  "torch.special.round": {
+    "Matcher": "RoundMatcher",
+    "args_list": [
+      "input",
+      "decimals",
+      "out"
+    ]
+  },
   "torch.special.sinc": {
     "Matcher": "SincMatcher",
     "args_list": [

--- a/tests/test_special_round.py
+++ b/tests/test_special_round.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.special.round")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([[[ 0.9254, -0.6213],
+            [-0.5787,  1.6843]],
+
+            [[ 0.3242, -0.9665],
+            [ 0.4539, -0.0887]],
+
+            [[ 1.1336, -0.4025],
+            [-0.7089,  0.9032]]])
+        result = torch.special.round(a)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.special.round(torch.tensor([[[ 0.9254, -0.6213],
+            [-0.5787,  1.6843]],
+
+            [[ 0.3242, -0.9665],
+            [ 0.4539, -0.0887]],
+
+            [[ 1.1336, -0.4025],
+            [-0.7089,  0.9032]]]))
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([[[ 0.9254, -0.6213],
+            [-0.5787,  1.6843]],
+
+            [[ 0.3242, -0.9665],
+            [ 0.4539, -0.0887]],
+
+            [[ 1.1336, -0.4025],
+            [-0.7089,  0.9032]]])
+        result = torch.special.round(input=a)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([[[ 0.9254, -0.6213],
+            [-0.5787,  1.6843]],
+
+            [[ 0.3242, -0.9665],
+            [ 0.4539, -0.0887]],
+
+            [[ 1.1336, -0.4025],
+            [-0.7089,  0.9032]]])
+        out = torch.ones_like(a)
+        result = torch.special.round(input=a, out=a)
+        """
+    )
+    obj.run(pytorch_code, ["result", "out"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([[[ 0.9254, -0.6213],
+            [-0.5787,  1.6843]],
+
+            [[ 0.3242, -0.9665],
+            [ 0.4539, -0.0887]],
+
+            [[ 1.1336, -0.4025],
+            [-0.7089,  0.9032]]])
+        result = torch.special.round(input=a, decimals=1)
+        """
+    )
+    obj.run(pytorch_code, ["result"])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->
https://github.com/PaddlePaddle/PaConvert/issues/112

334 torch.special.round

torch.special.round 是 torch.round别名，测试支持decimals 参数，文档中没有说明

已有文档 https://github.com/PaddlePaddle/docs/blob/96d13d280b5a77d0716ccb48541425ffa1a81ac9/docs/guides/model_convert/convert_from_pytorch/api_difference/others/torch.special.round.md#L4
### PR APIs
<!-- APIs what you've done -->
```bash
334 torch.special.round
```
