### PR TITLE
转换规则 No.339-342/345-348

### DIFF
--- a/tests/test_Tensor_diagonal_scatter.py
+++ b/tests/test_Tensor_diagonal_scatter.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.diagonal_scatter")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.zeros(3, 3)
+        src = torch.ones(3)
+        result = input.diagonal_scatter(src)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.zeros(3, 3)
+        src = torch.ones(3)
+        result = input.diagonal_scatter(src=src)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.zeros(3, 3)
+        src = torch.ones(3)
+        result = input.diagonal_scatter(src=src, offset=0, dim1=-2)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_Tensor_scatter_reduce.py
+++ b/tests/test_Tensor_scatter_reduce.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.scatter_reduce")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        src = torch.tensor([1., 2., 3., 4., 5., 6.])
+        index = torch.tensor([0, 1, 0, 1, 2, 1])
+        input = torch.tensor([1., 2., 3., 4.])
+        result = input.scatter_reduce(0, index, src, reduce="sum")
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        src = torch.tensor([1., 2., 3., 4., 5., 6.])
+        index = torch.tensor([0, 1, 0, 1, 2, 1])
+        input = torch.tensor([1., 2., 3., 4.])
+        result = input.scatter_reduce(0, index, src, reduce="sum", include_self=False)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        src = torch.tensor([1., 2., 3., 4., 5., 6.])
+        index = torch.tensor([0, 1, 0, 1, 2, 1])
+        input = torch.tensor([1., 2., 3., 4.])
+        result = input.scatter_reduce(0, index, src, reduce="amax")
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_Tensor_select_scatter.py
+++ b/tests/test_Tensor_select_scatter.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.select_scatter")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.zeros(2, 2)
+        src = torch.ones(2)
+        result = input.select_scatter(src, 0, 0)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.zeros(2, 2)
+        src = torch.ones(2)
+        result = input.select_scatter(src, dim=0, index=0)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.zeros(2, 2)
+        src = torch.ones(2)
+        result = input.select_scatter(src, dim=1, index=1)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_Tensor_slice_scatter.py
+++ b/tests/test_Tensor_slice_scatter.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.slice_scatter")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.zeros(8, 8)
+        b = torch.ones(8)
+        result = a.slice_scatter(b, start=6)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.zeros(8, 8)
+        b = torch.ones(2)
+        result = a.slice_scatter(b, dim=1, start=2, end=6, step=2)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_diagonal_scatter.py
+++ b/tests/test_diagonal_scatter.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.diagonal_scatter")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.zeros(3, 3)
+        src = torch.ones(3)
+        result = torch.diagonal_scatter(input, src)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.zeros(3, 3)
+        src = torch.ones(3)
+        result = torch.diagonal_scatter(input=input, src=src)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.zeros(3, 3)
+        src = torch.ones(3)
+        result = torch.diagonal_scatter(input=input, src=src, offset=0, dim1=-2)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_scatter_reduce.py
+++ b/tests/test_scatter_reduce.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.scatter_reduce")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        src = torch.tensor([1., 2., 3., 4., 5., 6.])
+        index = torch.tensor([0, 1, 0, 1, 2, 1])
+        input = torch.tensor([1., 2., 3., 4.])
+        result = torch.scatter_reduce(input, 0, index, src, reduce="sum")
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        src = torch.tensor([1., 2., 3., 4., 5., 6.])
+        index = torch.tensor([0, 1, 0, 1, 2, 1])
+        input = torch.tensor([1., 2., 3., 4.])
+        result = torch.scatter_reduce(input, 0, index, src, reduce="sum", include_self=False)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        src = torch.tensor([1., 2., 3., 4., 5., 6.])
+        index = torch.tensor([0, 1, 0, 1, 2, 1])
+        input = torch.tensor([1., 2., 3., 4.])
+        result = torch.scatter_reduce(input, 0, index, src, reduce="amax")
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_select_scatter.py
+++ b/tests/test_select_scatter.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.select_scatter")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.zeros(2, 2)
+        src = torch.ones(2)
+        result = torch.select_scatter(input, src, 0, 0)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.zeros(2, 2)
+        src = torch.ones(2)
+        result = torch.select_scatter(input, src, dim=0, index=0)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.zeros(2, 2)
+        src = torch.ones(2)
+        result = torch.select_scatter(input, src, dim=1, index=1)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_slice_scatter.py
+++ b/tests/test_slice_scatter.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.slice_scatter")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.zeros(8, 8)
+        b = torch.ones(8)
+        result = torch.slice_scatter(a, b, start=6)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.zeros(8, 8)
+        b = torch.ones(2)
+        result = torch.slice_scatter(a, b, dim=1, start=2, end=6, step=2)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->
https://github.com/PaddlePaddle/PaConvert/issues/112

文档 https://github.com/PaddlePaddle/docs/pull/6020

测试 paddle.diagonal 返回为元素，不是元素索引，paddle.diagonal 和 paddle.scatter 没有组合实现 torch.diagonal_scatter
select_scatter，slice_scatter，scatter_reduce 使用dim参数设置维度，paddle.scatter没有维度参数，没有组合实现
![图片](https://github.com/PaddlePaddle/PaConvert/assets/4617245/0e688776-847d-4c96-b3ee-b70fe212fdf5)
![图片](https://github.com/PaddlePaddle/PaConvert/assets/4617245/9d90fcc5-9425-4f2e-9df3-99b6545dbecd)
![图片](https://github.com/PaddlePaddle/PaConvert/assets/4617245/c12aecde-6df2-457a-b3c6-a5555233c96f)

![图片](https://github.com/PaddlePaddle/PaConvert/assets/4617245/a705d691-0473-4ef3-bd17-c3117383690a)

不支持API
339 torch.diagonal_scatter
340 torch.select_scatter
341 torch.slice_scatter
342 torch.scatter_reduce
345 torch.Tensor.diagonal_scatter
346 torch.Tensor.scatter_reduce
347 torch.Tensor.select_scatter
348 torch.Tensor.slice_scatter

### PR APIs
<!-- APIs what you've done -->
```bash
339 torch.diagonal_scatter
340 torch.select_scatter
341 torch.slice_scatter
342 torch.scatter_reduce
345 torch.Tensor.diagonal_scatter
346 torch.Tensor.scatter_reduce
347 torch.Tensor.select_scatter
348 torch.Tensor.slice_scatter
```
