### PR TITLE
转换规则 No.243-300 其他未领取项

### DIFF
--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -7084,6 +7084,13 @@
       "padding"
     ]
   },
+  "torch.nn.Mish": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Mish",
+    "args_list": [
+      "inplace"
+    ]
+  },
   "torch.nn.Module": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.nn.Layer"

--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -2966,6 +2966,10 @@
       "input": "x"
     }
   },
+  "torch.autograd.Function": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.autograd.PyLayer"
+  },
   "torch.autograd.backward": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.autograd.backward",
@@ -3085,6 +3089,14 @@
     },
     "unsupport_args": [
       "only_inputs"
+    ]
+  },
+  "torch.autograd.graph.saved_tensors_hooks": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.autograd.saved_tensors_hooks",
+    "args_list": [
+      "pack_hook",
+      "unpack_hook"
     ]
   },
   "torch.backends.cuda.is_built": {
@@ -3744,6 +3756,13 @@
     "kwargs_change": {
       "new_states": "state_list"
     }
+  },
+  "torch.cuda.set_stream": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.device.set_stream",
+    "args_list": [
+      "stream"
+    ]
   },
   "torch.cuda.synchronize": {
     "Matcher": "GenericMatcher",
@@ -5567,6 +5586,19 @@
     "args_list": [
       "A"
     ]
+  },
+  "torch.linalg.svdvals": {
+    "Matcher": "LinalgSvdvalsMatcher",
+    "paddle_api": "paddle.linalg.svd",
+    "args_list": [
+      "A",
+      "driver",
+      "out"
+    ],
+    "kwargs_change": {
+      "A": "x",
+      "driver": ""
+    }
   },
   "torch.linalg.vander": {
     "Matcher": "GenericMatcher",
@@ -8966,6 +8998,20 @@
       "parameters"
     ]
   },
+  "torch.nn.utils.parametrizations.spectral_norm": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.utils.spectral_norm",
+    "args_list": [
+      "module",
+      "name",
+      "n_power_iterations",
+      "eps",
+      "dim"
+    ],
+    "kwargs_change": {
+      "module": "layer"
+    }
+  },
   "torch.nn.utils.remove_weight_norm": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.nn.utils.remove_weight_norm",
@@ -9785,6 +9831,16 @@
       "input": "x"
     }
   },
+  "torch.special.erfc": {
+    "Matcher": "ErfCMatcher",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
   "torch.special.erfinv": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.erfinv",
@@ -9796,9 +9852,34 @@
       "input": "x"
     }
   },
+  "torch.special.exp2": {
+    "Matcher": "Exp2Matcher",
+    "args_list": [
+      "input",
+      "out"
+    ]
+  },
+  "torch.special.expit": {
+    "Matcher": "ExpitMatcher",
+    "args_list": [
+      "input",
+      "out"
+    ]
+  },
   "torch.special.expm1": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.expm1",
+    "args_list": [
+      "input",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.special.gammaln": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.lgamma",
     "args_list": [
       "input",
       "out"

--- a/paconvert/api_matcher.py
+++ b/paconvert/api_matcher.py
@@ -1927,6 +1927,31 @@ class Exp2Matcher(BaseMatcher):
         return code
 
 
+class ExpitMatcher(BaseMatcher):
+    def generate_code(self, kwargs):
+        exp_v = get_unique_name("exp_v")
+        if "out" in kwargs and kwargs["out"] is not None:
+            API_TEMPLATE = textwrap.dedent(
+                """
+                {} = paddle.exp({})
+                paddle.assign({} / (1 + {}), output={})
+                """
+            )
+            code = API_TEMPLATE.format(
+                exp_v, kwargs["input"], exp_v, exp_v, kwargs["out"]
+            )
+        else:
+            API_TEMPLATE = textwrap.dedent(
+                """
+                {} = paddle.exp({})
+                {} / (1 + {})
+                """
+            )
+            code = API_TEMPLATE.format(exp_v, kwargs["input"], exp_v, exp_v)
+
+        return code
+
+
 class FModMatcher(BaseMatcher):
     def generate_code(self, kwargs):
         if "out" in kwargs and kwargs["out"] is not None:
@@ -3265,6 +3290,30 @@ class RNNBaseMatcher(BaseMatcher):
         kwargs["direction"] = direction
 
         return GenericMatcher.generate_code(self, kwargs)
+
+
+class LinalgSvdvalsMatcher(BaseMatcher):
+    def generate_code(self, kwargs):
+        if "out" in kwargs:
+            out_v = kwargs.pop("out")
+            API_TEMPLATE = textwrap.dedent(
+                """
+                paddle.assign({}[1], output={})
+                """
+            )
+            code = API_TEMPLATE.format(
+                GenericMatcher.generate_code(self, kwargs), out_v
+            )
+        else:
+            API_TEMPLATE = textwrap.dedent(
+                """
+                _, {}, _ = {}
+                {}
+                """
+            )
+            s = get_unique_name("s")
+            code = API_TEMPLATE.format(s, GenericMatcher.generate_code(self, kwargs), s)
+        return code
 
 
 class DiffMatcher(BaseMatcher):

--- a/tests/test_Tensor_sparse_resize_.py
+++ b/tests/test_Tensor_sparse_resize_.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.sparse_resize_")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.arange(4.)
+        result = a.sparse_resize_((1, 1), 1, 1)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_Tensor_sparse_resize_and_clear_.py
+++ b/tests/test_Tensor_sparse_resize_and_clear_.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.sparse_resize_and_clear_")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.arange(4.)
+        result = a.sparse_resize_and_clear_((1, 1), 1, 1)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_autograd_Function.py
+++ b/tests/test_autograd_Function.py
@@ -28,6 +28,8 @@ class FunctionAPIBase(APIBase):
         check_value=True,
         check_dtype=True,
         check_stop_gradient=True,
+        atol=0.0,
+        rtol=1.0e-6,
     ):
         assert isinstance(paddle_result, paddle.autograd.PyLayer)
 

--- a/tests/test_autograd_Function.py
+++ b/tests/test_autograd_Function.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+import paddle
+from apibase import APIBase
+
+
+class FunctionAPIBase(APIBase):
+    def compare(
+        self,
+        name,
+        pytorch_result,
+        paddle_result,
+        check_value=True,
+        check_dtype=True,
+        check_stop_gradient=True,
+    ):
+        assert isinstance(paddle_result, paddle.autograd.PyLayer)
+
+
+obj = FunctionAPIBase("torch.autograd.Function")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        from torch.autograd import Function
+
+        # Inherit from Function
+        class cus_tanh(Function):
+            @staticmethod
+            def forward(ctx, x, func=torch.square):
+                ctx.func = func
+                y = func(x)
+                return y
+
+            @staticmethod
+            def backward(ctx, dy):
+                grad = dy + 1
+                return grad
+
+        result = cus_tanh()
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_autograd_Function_backward.py
+++ b/tests/test_autograd_Function_backward.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.autograd.Function.backward")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        from torch.autograd import Function
+
+        # Inherit from Function
+        class cus_tanh(Function):
+            @staticmethod
+            def forward(ctx, x, func=torch.square):
+                ctx.func = func
+                y = func(x)
+                return y
+
+            @staticmethod
+            def backward(ctx, dy):
+                grad = dy + 1
+                return grad
+
+        data = torch.ones([2, 3], dtype=torch.float64)
+        data.requires_grad = True
+        z = cus_tanh.apply(data)
+        z.mean().backward()
+
+        result = data.grad
+        """
+    )
+    obj.run(pytorch_code, ["result"], check_stop_gradient=False)

--- a/tests/test_autograd_Function_forward.py
+++ b/tests/test_autograd_Function_forward.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.autograd.Function.forward")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        from torch.autograd import Function
+
+        # Inherit from Function
+        class cus_tanh(Function):
+            @staticmethod
+            def forward(ctx, x, func=torch.square):
+                ctx.func = func
+                y = func(x)
+                return y
+
+            @staticmethod
+            def backward(ctx, dy):
+                grad = dy + 1
+                return grad
+
+        data = torch.ones([2, 3], dtype=torch.float64)
+        data.requires_grad = True
+        result = cus_tanh.apply(data)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_autograd_function_FunctionCtx_mark_dirty.py
+++ b/tests/test_autograd_function_FunctionCtx_mark_dirty.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.autograd.function.FunctionCtx.mark_dirty")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        from torch.autograd import Function
+
+        # Inherit from Function
+        class cus_tanh(Function):
+            @staticmethod
+            def forward(ctx, x):
+                a = x + x
+                b = x + x + x
+                ctx.mark_dirty(a)
+                return a, b
+
+            @staticmethod
+            def backward(ctx, grad_a, grad_b):
+                return grad_b
+
+        mark_dirty = torch.autograd.function.FunctionCtx.mark_dirty
+        data = torch.ones([2, 3], dtype=torch.float64)
+        data.requires_grad = True
+        a, b = cus_tanh.apply(data)
+        b.sum().backward()
+
+        result = data.grad
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        check_stop_gradient=False,
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_autograd_function_FunctionCtx_mark_non_differentiable.py
+++ b/tests/test_autograd_function_FunctionCtx_mark_non_differentiable.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.autograd.function.FunctionCtx.mark_non_differentiable")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        from torch.autograd import Function
+
+        # Inherit from Function
+        class cus_tanh(Function):
+            @staticmethod
+            def forward(ctx, x):
+                a = x + x
+                b = x + x + x
+                ctx.mark_non_differentiable(a)
+                return a, b
+
+            @staticmethod
+            def backward(ctx, grad_a, grad_b):
+                return 3 * grad_b
+
+        data = torch.ones([2, 3], dtype=torch.float64)
+        data.requires_grad = True
+        a, b = cus_tanh.apply(data)
+        b.sum().backward()
+
+        result = data.grad
+        """
+    )
+    obj.run(pytorch_code, ["result"], check_stop_gradient=False)

--- a/tests/test_autograd_function_FunctionCtx_save_for_backward.py
+++ b/tests/test_autograd_function_FunctionCtx_save_for_backward.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.autograd.function.FunctionCtx.save_for_backward")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        from torch.autograd import Function
+
+        # Inherit from Function
+        class cus_tanh(Function):
+            @staticmethod
+            def forward(ctx, x):
+                # ctx is a context object that store some objects for backward.
+                y = torch.tanh(x)
+                # Pass tensors to backward.
+                ctx.save_for_backward(y)
+                return y
+
+            @staticmethod
+            def backward(ctx, dy):
+                grad = dy + 1
+                return grad
+
+        data = torch.ones([2, 3], dtype=torch.float64)
+        data.requires_grad = True
+        z = cus_tanh.apply(data)
+        z.sum().backward()
+
+        result = data.grad
+        result.requires_grad = False
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_autograd_function_FunctionCtx_set_materialize_grads.py
+++ b/tests/test_autograd_function_FunctionCtx_set_materialize_grads.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.autograd.function.FunctionCtx.set_materialize_grads")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        from torch.autograd import Function
+
+        # Inherit from Function
+        class cus_tanh(Function):
+            @staticmethod
+            def forward(ctx, x):
+                ctx.set_materialize_grads(False)
+                return x+x+x, x+x
+
+            @staticmethod
+            def backward(ctx, grad, grad2):
+                assert grad2==None
+                return grad
+
+        x = torch.ones([1], dtype=torch.float64)
+        x.requires_grad = True
+        cus_tanh.apply(x)[0].backward()
+
+        result = x.grad
+        result.requires_grad = False
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_autograd_graph_saved_tensors_hooks.py
+++ b/tests/test_autograd_graph_saved_tensors_hooks.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.autograd.graph.saved_tensors_hooks")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        def pack_hook(x):
+            # print("Packing", x)
+            return x.numpy()
+
+        def unpack_hook(x):
+            # print("UnPacking", x)
+            return torch.tensor(x)
+
+        a = torch.ones([3,3])
+        b = torch.ones([3,3]) * 2
+        a.requires_grad = True
+        b.requires_grad = True
+        with torch.autograd.graph.saved_tensors_hooks(pack_hook, unpack_hook):
+            y = torch.multiply(a, b)
+        y.sum().backward()
+        result = y
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        from torch.autograd import Function
+
+        class cus_tanh(Function):
+            @staticmethod
+            def forward(ctx, a, b):
+                y = torch.multiply(a, b)
+                ctx.save_for_backward(a, b)
+                return y
+
+            @staticmethod
+            def backward(ctx, dy):
+                grad_a = dy * 2
+                grad_b = dy * 3
+                return grad_a, grad_b
+
+        def pack_hook(x):
+            # print("Packing", x)
+            return x.numpy()
+
+        def unpack_hook(x):
+            # print("UnPacking", x)
+            return torch.tensor(x)
+
+        a = torch.ones([3,3])
+        b = torch.ones([3,3]) * 2
+        a.requires_grad = True
+        b.requires_grad = True
+        with torch.autograd.graph.saved_tensors_hooks(pack_hook, unpack_hook):
+            y = cus_tanh.apply(a, b)
+        y.sum().backward()
+        result = y
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_autograd_profiler_profile_self_cpu_time_total.py
+++ b/tests/test_autograd_profiler_profile_self_cpu_time_total.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.autograd.profiler.profile.self_cpu_time_total")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.autograd.profiler.profile.self_cpu_time_total
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_cuda_StreamContext.py
+++ b/tests/test_cuda_StreamContext.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.cuda.StreamContext")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = None
+        if torch.cuda.is_available():
+            stream = torch.cuda.Stream(0)
+            result = torch.cuda.StreamContext(stream)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = None
+        if torch.cuda.is_available():
+            stream = torch.cuda.Stream(0)
+            result = torch.cuda.StreamContext(stream=stream)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = None
+        if torch.cuda.is_available():
+            stream = torch.cuda.Stream(torch.device("cuda:0"))
+            result = torch.cuda.StreamContext(stream)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_cuda_set_stream.py
+++ b/tests/test_cuda_set_stream.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.cuda.set_stream")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = None
+        if torch.cuda.is_available():
+            result = torch.cuda.set_stream()
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = None
+        if torch.cuda.is_available():
+            stream = torch.cuda.Stream(0)
+            result = torch.cuda.set_stream(stream=stream)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = None
+        if torch.cuda.is_available():
+            stream = torch.cuda.Stream(torch.device("cuda:0"))
+            result = torch.cuda.set_stream(stream)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_gradient.py
+++ b/tests/test_gradient.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.gradient")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        values = torch.tensor([4., 1., 1., 16.], )
+        coordinates = (torch.tensor([-2., -1., 1., 4.]),)
+        result = torch.gradient(values, spacing = coordinates)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        t = torch.tensor([[1, 2, 4, 8], [10, 20, 40, 80]])
+        result = torch.gradient(t)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        t = torch.tensor([[1, 2, 4, 8], [10, 20, 40, 80]])
+        result = torch.gradient(t, spacing = 2.0)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_linalg_cholesky_ex.py
+++ b/tests/test_linalg_cholesky_ex.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.linalg.cholesky_ex")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([[1.1481, 0.9974, 0.9413],
+                [0.9974, 1.3924, 0.6773],
+                [0.9413, 0.6773, 1.1315]])
+        result = torch.linalg.cholesky_ex(a)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([[1.1481, 0.9974, 0.9413],
+                [0.9974, 1.3924, 0.6773],
+                [0.9413, 0.6773, 1.1315]])
+        result = torch.linalg.cholesky_ex(a, upper=False)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([[1.1481, 0.9974, 0.9413],
+                [0.9974, 1.3924, 0.6773],
+                [0.9413, 0.6773, 1.1315]])
+        out = torch.randn(3, 3)
+        result = torch.linalg.cholesky_ex(a, upper=True, out=out)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result", "out"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_linalg_inv_ex.py
+++ b/tests/test_linalg_inv_ex.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.linalg.inv_ex")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[0.02773777, 0.93004224, 0.06911496],
+                [0.24831591, 0.45733623, 0.07717843],
+                [0.48016702, 0.14235102, 0.42620817]])
+        result = torch.linalg.inv_ex(x)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[0.02773777, 0.93004224, 0.06911496],
+                [0.24831591, 0.45733623, 0.07717843],
+                [0.48016702, 0.14235102, 0.42620817]])
+        result = torch.linalg.inv_ex(A=x)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[0.02773777, 0.93004224, 0.06911496],
+                [0.24831591, 0.45733623, 0.07717843],
+                [0.48016702, 0.14235102, 0.42620817]])
+        out = torch.tensor([])
+        result = torch.linalg.inv_ex(x, out=out)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result", "out"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_linalg_matrix_norm.py
+++ b/tests/test_linalg_matrix_norm.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.linalg.matrix_norm")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[0.02773777, 0.93004224, 0.06911496],
+                [0.24831591, 0.45733623, 0.07717843],
+                [0.48016702, 0.14235102, 0.42620817]])
+        result = torch.linalg.matrix_norm(x)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[0.02773777, 0.93004224, 0.06911496],
+                [0.24831591, 0.45733623, 0.07717843],
+                [0.48016702, 0.14235102, 0.42620817]])
+        result = torch.linalg.matrix_norm(A=x, ord='fro')
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[0.02773777, 0.93004224, 0.06911496],
+                [0.24831591, 0.45733623, 0.07717843],
+                [0.48016702, 0.14235102, 0.42620817]])
+        out = torch.tensor([])
+        result = torch.linalg.matrix_norm(A=x, ord='fro', dtype=torch.float32, out=out)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result", "out"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_linalg_svdvals.py
+++ b/tests/test_linalg_svdvals.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.linalg.svdvals")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[12., -51, 4], [6, 167, -68], [-4, 24, -41]])
+        result = torch.linalg.svdvals(x)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[12., -51, 4], [6, 167, -68], [-4, 24, -41]])
+        result = torch.linalg.svdvals(A=x)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[12., -51, 4], [6, 167, -68], [-4, 24, -41]])
+        result = torch.linalg.svdvals(driver=None, A=x)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[12., -51, 4], [6, 167, -68], [-4, 24, -41]])
+        out = torch.tensor([])
+        result = torch.linalg.svdvals(x, out=out)
+        """
+    )
+    obj.run(pytorch_code, ["result", "out"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[12., -51, 4], [6, 167, -68], [-4, 24, -41]])
+        out = torch.tensor([])
+        result = torch.linalg.svdvals(A=x, driver=None, out=out)
+        """
+    )
+    obj.run(pytorch_code, ["result", "out"])

--- a/tests/test_linalg_vector_norm.py
+++ b/tests/test_linalg_vector_norm.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.linalg.vector_norm")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[0.02773777, 0.93004224, 0.06911496],
+                [0.24831591, 0.45733623, 0.07717843],
+                [0.48016702, 0.14235102, 0.42620817]])
+        result = torch.linalg.vector_norm(x)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[0.02773777, 0.93004224, 0.06911496],
+                [0.24831591, 0.45733623, 0.07717843],
+                [0.48016702, 0.14235102, 0.42620817]])
+        result = torch.linalg.vector_norm(A=x, ord=2)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[0.02773777, 0.93004224, 0.06911496],
+                [0.24831591, 0.45733623, 0.07717843],
+                [0.48016702, 0.14235102, 0.42620817]])
+        out = torch.tensor([])
+        result = torch.linalg.vector_norm(A=x, ord=2, dtype=torch.float32, out=out)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result", "out"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_nn_LazyBatchNorm1d.py
+++ b/tests/test_nn_LazyBatchNorm1d.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.LazyBatchNorm1d")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch.nn as nn
+        import torch
+        m = nn.LazyBatchNorm1d()
+        input = torch.tensor([[[ 1.1524,  0.4714,  0.2857],
+         [-1.2533, -0.9829, -1.0981],
+         [ 0.1507, -1.1431, -2.0361]],
+
+        [[ 0.1024, -0.4482,  0.4137],
+         [ 0.9385,  0.4565,  0.7702],
+         [ 0.4135, -0.2587,  0.0482]]])
+        result = m(input)
+        result.requires_grad = False
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch.nn as nn
+        import torch
+        m = nn.LazyBatchNorm1d(affine=True)
+        input = torch.tensor([[[ 1.1524,  0.4714,  0.2857],
+         [-1.2533, -0.9829, -1.0981],
+         [ 0.1507, -1.1431, -2.0361]],
+
+        [[ 0.1024, -0.4482,  0.4137],
+         [ 0.9385,  0.4565,  0.7702],
+         [ 0.4135, -0.2587,  0.0482]]])
+        result = m(input)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch.nn as nn
+        import torch
+        m = nn.LazyBatchNorm1d(affine=False)
+        input = torch.tensor([[[ 1.1524,  0.4714,  0.2857],
+         [-1.2533, -0.9829, -1.0981],
+         [ 0.1507, -1.1431, -2.0361]],
+
+        [[ 0.1024, -0.4482,  0.4137],
+         [ 0.9385,  0.4565,  0.7702],
+         [ 0.4135, -0.2587,  0.0482]]])
+        result = m(input)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch.nn as nn
+        import torch
+        m = nn.LazyBatchNorm1d(affine=True, momentum=0.1)
+        input = torch.tensor([[[ 1.1524,  0.4714,  0.2857],
+         [-1.2533, -0.9829, -1.0981],
+         [ 0.1507, -1.1431, -2.0361]],
+
+        [[ 0.1024, -0.4482,  0.4137],
+         [ 0.9385,  0.4565,  0.7702],
+         [ 0.4135, -0.2587,  0.0482]]])
+        result = m(input)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch.nn as nn
+        import torch
+        m = nn.LazyBatchNorm1d(affine=False, momentum=0.1)
+        input = torch.tensor([[[ 1.1524,  0.4714,  0.2857],
+         [-1.2533, -0.9829, -1.0981],
+         [ 0.1507, -1.1431, -2.0361]],
+
+        [[ 0.1024, -0.4482,  0.4137],
+         [ 0.9385,  0.4565,  0.7702],
+         [ 0.4135, -0.2587,  0.0482]]])
+        result = m(input)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_6():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch.nn as nn
+        import torch
+        m = nn.LazyBatchNorm1d(affine=False, momentum=0.1, dtype=torch.float32)
+        input = torch.tensor([[[ 1.1524,  0.4714,  0.2857],
+         [-1.2533, -0.9829, -1.0981],
+         [ 0.1507, -1.1431, -2.0361]],
+
+        [[ 0.1024, -0.4482,  0.4137],
+         [ 0.9385,  0.4565,  0.7702],
+         [ 0.4135, -0.2587,  0.0482]]])
+        result = m(input)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_nn_LazyBatchNorm2d.py
+++ b/tests/test_nn_LazyBatchNorm2d.py
@@ -1,0 +1,266 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.LazyBatchNorm2d")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch.nn as nn
+        import torch
+        m = nn.LazyBatchNorm2d()
+        input = torch.tensor([[[[0.9436, 0.7335, 0.9228],
+          [0.5443, 0.3380, 0.0676],
+          [0.2152, 0.2725, 0.2988]],
+
+         [[0.3839, 0.7517, 0.8147],
+          [0.7681, 0.0924, 0.3781],
+          [0.6991, 0.2401, 0.4732]],
+
+         [[0.3631, 0.5113, 0.4535],
+          [0.9779, 0.4084, 0.5979],
+          [0.6865, 0.5924, 0.9122]]],
+
+
+        [[[0.1519, 0.2828, 0.0797],
+          [0.5871, 0.1052, 0.2343],
+          [0.0323, 0.0754, 0.6707]],
+
+         [[0.6969, 0.4170, 0.0762],
+          [0.2514, 0.5124, 0.3972],
+          [0.1007, 0.7754, 0.4779]],
+
+         [[0.1753, 0.2245, 0.0369],
+          [0.5224, 0.9840, 0.0497],
+          [0.8938, 0.5135, 0.5939]]]])
+        result = m(input)
+        result.requires_grad = False
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch.nn as nn
+        import torch
+        m = nn.LazyBatchNorm2d(affine=True)
+        input = torch.tensor([[[[0.9436, 0.7335, 0.9228],
+          [0.5443, 0.3380, 0.0676],
+          [0.2152, 0.2725, 0.2988]],
+
+         [[0.3839, 0.7517, 0.8147],
+          [0.7681, 0.0924, 0.3781],
+          [0.6991, 0.2401, 0.4732]],
+
+         [[0.3631, 0.5113, 0.4535],
+          [0.9779, 0.4084, 0.5979],
+          [0.6865, 0.5924, 0.9122]]],
+
+
+        [[[0.1519, 0.2828, 0.0797],
+          [0.5871, 0.1052, 0.2343],
+          [0.0323, 0.0754, 0.6707]],
+
+         [[0.6969, 0.4170, 0.0762],
+          [0.2514, 0.5124, 0.3972],
+          [0.1007, 0.7754, 0.4779]],
+
+         [[0.1753, 0.2245, 0.0369],
+          [0.5224, 0.9840, 0.0497],
+          [0.8938, 0.5135, 0.5939]]]])
+        result = m(input)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch.nn as nn
+        import torch
+        m = nn.LazyBatchNorm2d(affine=False)
+        input = torch.tensor([[[[0.9436, 0.7335, 0.9228],
+          [0.5443, 0.3380, 0.0676],
+          [0.2152, 0.2725, 0.2988]],
+
+         [[0.3839, 0.7517, 0.8147],
+          [0.7681, 0.0924, 0.3781],
+          [0.6991, 0.2401, 0.4732]],
+
+         [[0.3631, 0.5113, 0.4535],
+          [0.9779, 0.4084, 0.5979],
+          [0.6865, 0.5924, 0.9122]]],
+
+
+        [[[0.1519, 0.2828, 0.0797],
+          [0.5871, 0.1052, 0.2343],
+          [0.0323, 0.0754, 0.6707]],
+
+         [[0.6969, 0.4170, 0.0762],
+          [0.2514, 0.5124, 0.3972],
+          [0.1007, 0.7754, 0.4779]],
+
+         [[0.1753, 0.2245, 0.0369],
+          [0.5224, 0.9840, 0.0497],
+          [0.8938, 0.5135, 0.5939]]]])
+        result = m(input)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch.nn as nn
+        import torch
+        m = nn.LazyBatchNorm2d(affine=True, momentum=0.1)
+        input = torch.tensor([[[[0.9436, 0.7335, 0.9228],
+          [0.5443, 0.3380, 0.0676],
+          [0.2152, 0.2725, 0.2988]],
+
+         [[0.3839, 0.7517, 0.8147],
+          [0.7681, 0.0924, 0.3781],
+          [0.6991, 0.2401, 0.4732]],
+
+         [[0.3631, 0.5113, 0.4535],
+          [0.9779, 0.4084, 0.5979],
+          [0.6865, 0.5924, 0.9122]]],
+
+
+        [[[0.1519, 0.2828, 0.0797],
+          [0.5871, 0.1052, 0.2343],
+          [0.0323, 0.0754, 0.6707]],
+
+         [[0.6969, 0.4170, 0.0762],
+          [0.2514, 0.5124, 0.3972],
+          [0.1007, 0.7754, 0.4779]],
+
+         [[0.1753, 0.2245, 0.0369],
+          [0.5224, 0.9840, 0.0497],
+          [0.8938, 0.5135, 0.5939]]]])
+        result = m(input)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch.nn as nn
+        import torch
+        m = nn.LazyBatchNorm2d(affine=False, momentum=0.1)
+        input = torch.tensor([[[[0.9436, 0.7335, 0.9228],
+          [0.5443, 0.3380, 0.0676],
+          [0.2152, 0.2725, 0.2988]],
+
+         [[0.3839, 0.7517, 0.8147],
+          [0.7681, 0.0924, 0.3781],
+          [0.6991, 0.2401, 0.4732]],
+
+         [[0.3631, 0.5113, 0.4535],
+          [0.9779, 0.4084, 0.5979],
+          [0.6865, 0.5924, 0.9122]]],
+
+
+        [[[0.1519, 0.2828, 0.0797],
+          [0.5871, 0.1052, 0.2343],
+          [0.0323, 0.0754, 0.6707]],
+
+         [[0.6969, 0.4170, 0.0762],
+          [0.2514, 0.5124, 0.3972],
+          [0.1007, 0.7754, 0.4779]],
+
+         [[0.1753, 0.2245, 0.0369],
+          [0.5224, 0.9840, 0.0497],
+          [0.8938, 0.5135, 0.5939]]]])
+        result = m(input)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_6():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch.nn as nn
+        import torch
+        m = nn.LazyBatchNorm2d(affine=False, momentum=0.1, dtype=torch.float32)
+        input = torch.tensor([[[[0.9436, 0.7335, 0.9228],
+          [0.5443, 0.3380, 0.0676],
+          [0.2152, 0.2725, 0.2988]],
+
+         [[0.3839, 0.7517, 0.8147],
+          [0.7681, 0.0924, 0.3781],
+          [0.6991, 0.2401, 0.4732]],
+
+         [[0.3631, 0.5113, 0.4535],
+          [0.9779, 0.4084, 0.5979],
+          [0.6865, 0.5924, 0.9122]]],
+
+
+        [[[0.1519, 0.2828, 0.0797],
+          [0.5871, 0.1052, 0.2343],
+          [0.0323, 0.0754, 0.6707]],
+
+         [[0.6969, 0.4170, 0.0762],
+          [0.2514, 0.5124, 0.3972],
+          [0.1007, 0.7754, 0.4779]],
+
+         [[0.1753, 0.2245, 0.0369],
+          [0.5224, 0.9840, 0.0497],
+          [0.8938, 0.5135, 0.5939]]]])
+        result = m(input)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_nn_LazyBatchNorm3d.py
+++ b/tests/test_nn_LazyBatchNorm3d.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.LazyBatchNorm3d")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch.nn as nn
+        import torch
+        m = nn.LazyBatchNorm3d()
+        input = torch.ones(20, 100, 35, 45, 10)
+        result = m(input)
+        result.requires_grad = False
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch.nn as nn
+        import torch
+        m = nn.LazyBatchNorm3d(affine=True)
+        input = torch.ones(20, 100, 35, 45, 10)
+        result = m(input)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch.nn as nn
+        import torch
+        m = nn.LazyBatchNorm3d(affine=False)
+        input = torch.ones(20, 100, 35, 45, 10)
+        result = m(input)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch.nn as nn
+        import torch
+        m = nn.LazyBatchNorm3d(affine=True, momentum=0.1)
+        input = torch.ones(20, 100, 35, 45, 10)
+        result = m(input)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch.nn as nn
+        import torch
+        m = nn.LazyBatchNorm3d(affine=False, momentum=0.1)
+        input = torch.ones(20, 100, 35, 45, 10)
+        result = m(input)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_6():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch.nn as nn
+        import torch
+        m = nn.LazyBatchNorm3d(affine=False, momentum=0.1, dtype=torch.float32)
+        input = torch.ones(20, 100, 35, 45, 10)
+        result = m(input)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_nn_Mish.py
+++ b/tests/test_nn_Mish.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.Mish")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        x = torch.tensor([[[-1.3020, -0.1005,  0.5766,  0.6351, -0.8893,  0.0253, -0.1756, 1.2913],
+                            [-0.8833, -0.1369, -0.0168, -0.5409, -0.1511, -0.1240, -1.1870, -1.8816]]])
+        model = nn.Mish()
+        result = model(x)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        x = torch.tensor([[[-1.3020, -0.1005,  0.5766,  0.6351, -0.8893,  0.0253, -0.1756, 1.2913],
+                            [-0.8833, -0.1369, -0.0168, -0.5409, -0.1511, -0.1240, -1.1870, -1.8816]]])
+        model = nn.Mish(False)
+        result = model(x)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        x = torch.tensor([[[-1.3020, -0.1005,  0.5766,  0.6351, -0.8893,  0.0253, -0.1756, 1.2913],
+                            [-0.8833, -0.1369, -0.0168, -0.5409, -0.1511, -0.1240, -1.1870, -1.8816]]])
+        model = nn.Mish(inplace=False)
+        result = model(x)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_nn_functional_group_norm.py
+++ b/tests/test_nn_functional_group_norm.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.functional.group_norm")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn.functional as F
+        x = torch.tensor([[[[-1.2392, -0.1310, -0.6679,  0.5476],
+                            [ 1.1738, -1.7384, -0.7733,  0.3261],
+                            [-0.0926, -1.0448, -1.2557, -1.5503],
+                            [ 0.6402,  0.9072,  0.6780, -1.9885]],
+
+                            [[ 0.0639, -1.1592,  1.4242, -0.4641],
+                            [-0.1920,  0.1826,  1.9217, -0.4359],
+                            [ 1.1926, -0.0247,  0.4744, -1.0216],
+                            [-0.0360, -1.1656,  0.3661, -1.8147]]]])
+        result = F.group_norm(x, 3)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn.functional as F
+        x = torch.tensor([[[[-1.2392, -0.1310, -0.6679,  0.5476],
+                            [ 1.1738, -1.7384, -0.7733,  0.3261],
+                            [-0.0926, -1.0448, -1.2557, -1.5503],
+                            [ 0.6402,  0.9072,  0.6780, -1.9885]],
+
+                            [[ 0.0639, -1.1592,  1.4242, -0.4641],
+                            [-0.1920,  0.1826,  1.9217, -0.4359],
+                            [ 1.1926, -0.0247,  0.4744, -1.0216],
+                            [-0.0360, -1.1656,  0.3661, -1.8147]]]])
+        result = F.group_norm(x, 3)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn.functional as F
+        x = torch.tensor([[[[-1.2392, -0.1310, -0.6679,  0.5476],
+                            [ 1.1738, -1.7384, -0.7733,  0.3261],
+                            [-0.0926, -1.0448, -1.2557, -1.5503],
+                            [ 0.6402,  0.9072,  0.6780, -1.9885]],
+
+                            [[ 0.0639, -1.1592,  1.4242, -0.4641],
+                            [-0.1920,  0.1826,  1.9217, -0.4359],
+                            [ 1.1926, -0.0247,  0.4744, -1.0216],
+                            [-0.0360, -1.1656,  0.3661, -1.8147]]]])
+        result = F.group_norm(x, 3, eps=1e-5)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_nn_utils_parametrizations_spectral_norm.py
+++ b/tests/test_nn_utils_parametrizations_spectral_norm.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+import paddle
+from apibase import APIBase
+
+
+class SpectralNormAPIBase(APIBase):
+    def compare(
+        self,
+        name,
+        pytorch_result,
+        paddle_result,
+        check_value=True,
+        check_dtype=True,
+        check_stop_gradient=True,
+    ):
+        assert isinstance(paddle_result, paddle.nn.Linear)
+
+
+obj = SpectralNormAPIBase("torch.nn.utils.parametrizations.spectral_norm")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        model = nn.Linear(10, 20)
+        result = torch.nn.utils.parametrizations.spectral_norm(model)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        model = nn.Linear(10, 20)
+        result = torch.nn.utils.parametrizations.spectral_norm(model, name="weight")
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        model = nn.Linear(10, 20)
+        result = torch.nn.utils.parametrizations.spectral_norm(model, name="weight", n_power_iterations=1)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_nn_utils_parametrizations_spectral_norm.py
+++ b/tests/test_nn_utils_parametrizations_spectral_norm.py
@@ -27,6 +27,8 @@ class SpectralNormAPIBase(APIBase):
         check_value=True,
         check_dtype=True,
         check_stop_gradient=True,
+        atol=0.0,
+        rtol=1.0e-6,
     ):
         assert isinstance(paddle_result, paddle.nn.Linear)
 

--- a/tests/test_nn_utils_parametrize_is_parametrized.py
+++ b/tests/test_nn_utils_parametrize_is_parametrized.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.utils.parametrize.is_parametrized")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        model = nn.Linear(10, 20)
+        result = torch.nn.utils.parametrize.is_parametrized(model)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_positive.py
+++ b/tests/test_positive.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.positive")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([4., 1., 1., 16.], )
+        result = torch.positive(x)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        t = torch.tensor([[1, 2, 4, 8], [10, 20, 40, 80]])
+        result = torch.positive(t)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_profiler_ProfilerAction.py
+++ b/tests/test_profiler_ProfilerAction.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.profiler.ProfilerAction")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.profiler.ProfilerAction.WARMUP
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_profiler_ProfilerActivity.py
+++ b/tests/test_profiler_ProfilerActivity.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.profiler.ProfilerActivity")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.profiler.ProfilerActivity.CUDA
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_special_entr.py
+++ b/tests/test_special_entr.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.special.entr")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.special.entr(torch.tensor([0., -2., 3.]))
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([-1., -2., 3.])
+        result = torch.special.entr(a)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = [-1, -2, 3]
+        out = torch.tensor(a, dtype=torch.float32)
+        result = torch.special.entr(torch.tensor(a), out=out)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["out"],
+        unsupport=True,
+        reason="paddle does not support this function temporarily",
+    )

--- a/tests/test_special_erfc.py
+++ b/tests/test_special_erfc.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.special.erfc")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.special.erfc(torch.tensor([0, -1., 10.]))
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([0, -1., 10.])
+        result = torch.special.erfc(a)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([0, -1., 10.])
+        out = torch.tensor([0, -1., 10.])
+        result = torch.special.erfc(a, out=out)
+        """
+    )
+    obj.run(pytorch_code, ["result", "out"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([0, -1., 10.])
+        result = torch.special.erfc(input=a)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_special_erfc.py
+++ b/tests/test_special_erfc.py
@@ -27,7 +27,7 @@ def test_case_1():
         result = torch.special.erfc(torch.tensor([0, -1., 10.]))
         """
     )
-    obj.run(pytorch_code, ["result"])
+    obj.run(pytorch_code, ["result"], atol=1.0e-6)
 
 
 def test_case_2():
@@ -38,7 +38,7 @@ def test_case_2():
         result = torch.special.erfc(a)
         """
     )
-    obj.run(pytorch_code, ["result"])
+    obj.run(pytorch_code, ["result"], atol=1.0e-6)
 
 
 def test_case_3():
@@ -50,7 +50,7 @@ def test_case_3():
         result = torch.special.erfc(a, out=out)
         """
     )
-    obj.run(pytorch_code, ["result", "out"])
+    obj.run(pytorch_code, ["result", "out"], atol=1.0e-6)
 
 
 def test_case_4():
@@ -61,4 +61,4 @@ def test_case_4():
         result = torch.special.erfc(input=a)
         """
     )
-    obj.run(pytorch_code, ["result"])
+    obj.run(pytorch_code, ["result"], atol=1.0e-6)

--- a/tests/test_special_exp2.py
+++ b/tests/test_special_exp2.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.special.exp2")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.special.exp2(torch.tensor([0., -2., 3.]))
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([-1., -2., 3.])
+        result = torch.special.exp2(a)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = [-1, -2, 3]
+        out = torch.tensor(a, dtype=torch.float32)
+        result = torch.special.exp2(torch.tensor(a), out=out)
+        """
+    )
+    obj.run(pytorch_code, ["out"])

--- a/tests/test_special_expit.py
+++ b/tests/test_special_expit.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.special.expit")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.special.expit(torch.tensor([0., -2., 3.]))
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([-1., -2., 3.])
+        result = torch.special.expit(a)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = [-1, -2, 3]
+        out = torch.tensor(a, dtype=torch.float32)
+        result = torch.special.expit(torch.tensor(a), out=out)
+        """
+    )
+    obj.run(pytorch_code, ["out"])

--- a/tests/test_special_gammaln.py
+++ b/tests/test_special_gammaln.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.special.gammaln")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.special.gammaln(torch.tensor([0.34, 1.5, 0.73]))
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.tensor([0.34, 1.5, 0.73])
+        result = torch.special.gammaln(input=input)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.tensor([0.34, 1.5, 0.73])
+        out = torch.tensor([0.34, 1.5, 0.73])
+        result = torch.special.gammaln(input, out=out)
+        """
+    )
+    obj.run(pytorch_code, ["result", "out"])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->
https://github.com/PaddlePaddle/PaConvert/issues/112

映射文档 https://github.com/PaddlePaddle/docs/pull/6075

### PR APIs
<!-- APIs what you've done -->
```bash
243 torch.linalg.inv_ex 功能缺失
246 torch.nn.LazyBatchNorm1d 功能缺失
247 torch.Tensor.sparse_resize_and_clear_ 功能缺失
248 torch.linalg.svdvals
251 torch.linalg.matrix_norm 功能缺失
254 torch.gradient 功能缺失
255 torch.special.gammaln
257 torch.nn.utils.parametrize.is_parametrized 功能缺失
259 torch.special.erfc 组合替代实现
260 torch.linalg.vector_norm 功能缺失
262 torch.nn.functional.group_norm 功能缺失
265 torch.special.expit 组合替代实现
266 torch.nn.Mish 已有文档验证无误
268 torch.linalg.cholesky_ex 功能缺失
269 torch.Tensor.sparse_resize_ 功能缺失
270 torch.positive 功能缺失
275 torch.special.exp2 组合替代实现
276 torch.nn.utils.parametrizations.spectral_norm
277 torch.cuda.StreamContext 功能缺失
278 torch.nn.LazyBatchNorm2d 功能缺失
281 torch.autograd.profiler.profile.self_cpu_time_total 功能缺失
284 torch.profiler.ProfilerActivity 功能缺失
286 torch.special.entr 功能缺失
287 torch.nn.LazyBatchNorm3d 功能缺失
288 torch.autograd.function.FunctionCtx.mark_dirty 功能缺失
289 torch.autograd.function.FunctionCtx.mark_non_differentiable
290 torch.autograd.Function.forward
291 torch.autograd.function.Function
292 torch.autograd.function.FunctionCtx.set_materialize_grads
293 torch.autograd.function.FunctionCtx.save_for_backward
294 torch.autograd.Function.backward
295 torch.profiler.ProfilerAction 功能缺失
296 torch.cuda.set_stream
300 torch.autograd.graph.saved_tensors_hooks
```
