### PR TITLE
转换规则 添加 inplace `divide_` api 的映射 PART.divide

### DIFF
--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -760,10 +760,8 @@
       "other": "y"
     }
   },
-  "torch.Tensor.div": {
-  },
-  "torch.Tensor.div_": {
-  },
+  "torch.Tensor.div": {},
+  "torch.Tensor.div_": {},
   "torch.Tensor.divide": {
     "Matcher": "TensorDivideMatcher",
     "paddle_api": "paddle.Tensor.divide",
@@ -780,6 +778,7 @@
     "min_input_args": 1,
     "args_list": [
       "other",
+      "*",
       "rounding_mode"
     ]
   },

--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -760,8 +760,6 @@
       "other": "y"
     }
   },
-  "torch.Tensor.div": {},
-  "torch.Tensor.div_": {},
   "torch.Tensor.divide": {
     "Matcher": "TensorDivideMatcher",
     "paddle_api": "paddle.Tensor.divide",

--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -760,6 +760,22 @@
       "other": "y"
     }
   },
+  "torch.Tensor.div": {
+    "Matcher": "TensorDivideMatcher",
+    "paddle_api": "paddle.Tensor.divide",
+    "args_list": [
+      "other",
+      "rounding_mode"
+    ]
+  },
+  "torch.Tensor.div_": {
+    "Matcher": "TensorDivideWithRoundingModeMatcher",
+    "paddle_api": "paddle.Tensor.divide_",
+    "args_list": [
+      "other",
+      "rounding_mode"
+    ]
+  },
   "torch.Tensor.divide": {
     "Matcher": "TensorDivideMatcher",
     "paddle_api": "paddle.Tensor.divide",
@@ -770,7 +786,14 @@
       "rounding_mode"
     ]
   },
-  "torch.Tensor.divide_": {},
+  "torch.Tensor.divide_": {
+    "Matcher": "TensorDivideWithRoundingModeMatcher",
+    "paddle_api": "paddle.Tensor.divide_",
+    "args_list": [
+      "other",
+      "rounding_mode"
+    ]
+  },
   "torch.Tensor.dot": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.Tensor.dot",
@@ -2612,7 +2635,16 @@
       "other": "y"
     }
   },
-  "torch.Tensor.true_divide_": {},
+  "torch.Tensor.true_divide_": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.divide_",
+    "args_list": [
+      "other"
+    ],
+    "kwargs_change": {
+      "other": "y"
+    }
+  },
   "torch.Tensor.trunc": {
     "Matcher": "UnchangeMatcher"
   },

--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -761,20 +761,8 @@
     }
   },
   "torch.Tensor.div": {
-    "Matcher": "TensorDivideMatcher",
-    "paddle_api": "paddle.Tensor.divide",
-    "args_list": [
-      "other",
-      "rounding_mode"
-    ]
   },
   "torch.Tensor.div_": {
-    "Matcher": "TensorDivideWithRoundingModeMatcher",
-    "paddle_api": "paddle.Tensor.divide_",
-    "args_list": [
-      "other",
-      "rounding_mode"
-    ]
   },
   "torch.Tensor.divide": {
     "Matcher": "TensorDivideMatcher",
@@ -789,6 +777,7 @@
   "torch.Tensor.divide_": {
     "Matcher": "TensorDivideWithRoundingModeMatcher",
     "paddle_api": "paddle.Tensor.divide_",
+    "min_input_args": 1,
     "args_list": [
       "other",
       "rounding_mode"
@@ -2636,7 +2625,7 @@
     }
   },
   "torch.Tensor.true_divide_": {
-    "Matcher": "GenericMatcher",
+    "Matcher": "Num2TensorBinaryMatcher",
     "paddle_api": "paddle.Tensor.divide_",
     "args_list": [
       "other"

--- a/paconvert/api_matcher.py
+++ b/paconvert/api_matcher.py
@@ -2724,6 +2724,37 @@ class DivideMatcher(BaseMatcher):
         return code
 
 
+class TensorDivideWithRoundingModeMatcher(BaseMatcher):
+    def get_rounding_method(self, mode):
+        if "trunc" in mode:
+            return ".trunc_()"
+        elif "floor" in mode:
+            return ".floor_()"
+        else:
+            return ""
+
+    def generate_code(self, kwargs):
+        API_TEMPLATE = textwrap.dedent(
+            """
+            {}({}){}
+            """
+        )
+
+        if "other" in kwargs:
+            kwargs["y"] = "paddle.to_tensor({})".format(kwargs.pop("other").strip("\n"))
+
+        rounding_mode_v = "None"
+        if "rounding_mode" in kwargs:
+            rounding_mode_v = kwargs.pop("rounding_mode")
+        rounding_method = self.get_rounding_method(rounding_mode_v)
+
+        code = API_TEMPLATE.format(
+            self.get_paddle_api(), self.kwargs_to_str(kwargs), rounding_method
+        )
+
+        return code
+
+
 class AllcloseMatcher(BaseMatcher):
     def generate_code(self, kwargs):
         code = GenericMatcher.generate_code(self, kwargs)

--- a/paconvert/api_matcher.py
+++ b/paconvert/api_matcher.py
@@ -2741,7 +2741,7 @@ class TensorDivideWithRoundingModeMatcher(BaseMatcher):
         )
 
         if "other" in kwargs:
-            kwargs["y"] = "paddle.to_tensor({})".format(kwargs.pop("other").strip("\n"))
+            kwargs["y"] = "paddle.to_tensor({})".format(kwargs.pop("other"))
 
         rounding_mode_v = "None"
         if "rounding_mode" in kwargs:

--- a/tests/test_Tensor_div_.py
+++ b/tests/test_Tensor_div_.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.div_")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([ 0.5950,-0.0872, 2.3298, -0.2972])
+        a.div_(torch.tensor([0.5]))
+        """
+    )
+    obj.run(pytorch_code, ["a"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([[ 0.5950,-0.0872], [2.3298, -0.2972]])
+        b = torch.tensor([0.1815, -1.0111])
+        a.div_(other=b)
+        """
+    )
+    obj.run(pytorch_code, ["a"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([[ 0.5950,-0.0872], [2.3298, -0.2972]])
+        b = torch.tensor([0.1815, -1.0111])
+        a.div_(other=b, rounding_mode=None)
+        """
+    )
+    obj.run(pytorch_code, ["a"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([[ 0.5950,-0.0872], [2.3298, -0.2972]])
+        b = torch.tensor([0.1815, -1.0111])
+        a.div_(other=b, rounding_mode="trunc")
+        """
+    )
+    obj.run(pytorch_code, ["a"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([[ 0.5950,-0.0872], [2.3298, -0.2972]])
+        b = torch.tensor([0.1815, -1.0111])
+        a.div_(other=b, rounding_mode="floor")
+        """
+    )
+    obj.run(pytorch_code, ["a"])

--- a/tests/test_Tensor_div_.py
+++ b/tests/test_Tensor_div_.py
@@ -76,3 +76,14 @@ def test_case_5():
         """
     )
     obj.run(pytorch_code, ["a"])
+
+
+def test_case_6():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([ 0.5950,-0.0872, 2.3298, -0.2972])
+        a.div_(rounding_mode="trunc", other=torch.tensor([0.5]))
+        """
+    )
+    obj.run(pytorch_code, ["a"])

--- a/tests/test_Tensor_divide_.py
+++ b/tests/test_Tensor_divide_.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.divide_")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([ 0.5950,-0.0872, 2.3298, -0.2972])
+        a.divide_(torch.tensor([0.5]))
+        """
+    )
+    obj.run(pytorch_code, ["a"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([[ 0.5950,-0.0872], [2.3298, -0.2972]])
+        b = torch.tensor([0.1815, -1.0111])
+        a.divide_(other=b)
+        """
+    )
+    obj.run(pytorch_code, ["a"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([[ 0.5950,-0.0872], [2.3298, -0.2972]])
+        b = torch.tensor([0.1815, -1.0111])
+        a.divide_(other=b, rounding_mode=None)
+        """
+    )
+    obj.run(pytorch_code, ["a"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([[ 0.5950,-0.0872], [2.3298, -0.2972]])
+        b = torch.tensor([0.1815, -1.0111])
+        a.divide_(other=b, rounding_mode="trunc")
+        """
+    )
+    obj.run(pytorch_code, ["a"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([[ 0.5950,-0.0872], [2.3298, -0.2972]])
+        b = torch.tensor([0.1815, -1.0111])
+        a.divide_(other=b, rounding_mode="floor")
+        """
+    )
+    obj.run(pytorch_code, ["a"])

--- a/tests/test_Tensor_divide_.py
+++ b/tests/test_Tensor_divide_.py
@@ -76,3 +76,14 @@ def test_case_5():
         """
     )
     obj.run(pytorch_code, ["a"])
+
+
+def test_case_6():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([ 0.5950,-0.0872, 2.3298, -0.2972])
+        a.divide_(rounding_mode="trunc", other=torch.tensor([0.5]))
+        """
+    )
+    obj.run(pytorch_code, ["a"])

--- a/tests/test_Tensor_true_divide_.py
+++ b/tests/test_Tensor_true_divide_.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.true_divide_")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.Tensor([[1., 2.], [3., 4.]])
+        b = torch.Tensor([[5., 6.], [7., 8.]])
+        a.true_divide_(b)
+        """
+    )
+    obj.run(pytorch_code, ["a"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.Tensor([[1., 2.], [3., 4.]])
+        b = torch.Tensor([[5., 6.], [7., 8.]])
+        a.true_divide_(other=b)
+        """
+    )
+    obj.run(pytorch_code, ["a"])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->
- `divide_` https://github.com/PaddlePaddle/docs/pull/6169
- `div_`, `true_divide_` https://github.com/PaddlePaddle/docs/pull/6190
- 转换规则修正 https://github.com/PaddlePaddle/docs/pull/6189
### PR APIs
<!-- APIs what you've done -->
```bash
torch.Tensor.divide_
torch.Tensor.div_
torch.Tensor.true_divide_
```