### PR TITLE
转换规则 添加 inplace detach_ api 的映射 PART.detach

### DIFF
--- a/tests/test_Tensor_detach_.py
+++ b/tests/test_Tensor_detach_.py
@@ -31,7 +31,12 @@ def test_case_1():
         y.detach_()
         """
     )
-    obj.run(pytorch_code, ["y"])
+    obj.run(
+        pytorch_code,
+        ["y"],
+        unsupport=True,
+        reason="Tensor.detach_ throws unexpected exception, refer to: https://github.com/PaddlePaddle/Paddle/issues/57303",
+    )
 
 
 def test_case_2():
@@ -42,4 +47,9 @@ def test_case_2():
         x.detach_()
         """
     )
-    obj.run(pytorch_code, ["x"])
+    obj.run(
+        pytorch_code,
+        ["x"],
+        unsupport=True,
+        reason="Tensor.detach_ throws unexpected exception, refer to: https://github.com/PaddlePaddle/Paddle/issues/57303",
+    )

--- a/tests/test_Tensor_detach_.py
+++ b/tests/test_Tensor_detach_.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.detach_")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[1.0, 1.0, 1.0],
+                        [2.0, 2.0, 2.0],
+                        [3.0, 3.0, 3.0]], requires_grad=True)
+        linear = torch.nn.Linear(3, 4)
+        y = linear(x)
+        y.detach_()
+        """
+    )
+    obj.run(pytorch_code, ["y"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[1.0, 1.0, 1.0]], requires_grad=True)
+        x.detach_()
+        """
+    )
+    obj.run(pytorch_code, ["x"])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->
- https://github.com/PaddlePaddle/docs/pull/6169
- 转换规则已添加 #282

由于 `detach_` method 当前实现存在问题，因此该 PR 采用 unsupport 方式绕开单测。
- https://github.com/PaddlePaddle/Paddle/issues/57303

### PR APIs
<!-- APIs what you've done -->
```bash
torch.Tensor.detach_
```
