### PR TITLE
fix `Tensor.detach_` unittests error

### DIFF
--- a/tests/test_Tensor_detach_.py
+++ b/tests/test_Tensor_detach_.py
@@ -19,7 +19,8 @@ from apibase import APIBase
 obj = APIBase("torch.Tensor.detach_")
 
 
-def test_case_1():
+# Tensor.detach_ throws unexpected exception, refer to: https://github.com/PaddlePaddle/Paddle/issues/57303
+def _test_case_1():
     pytorch_code = textwrap.dedent(
         """
         import torch
@@ -31,15 +32,10 @@ def test_case_1():
         y.detach_()
         """
     )
-    obj.run(
-        pytorch_code,
-        ["y"],
-        unsupport=True,
-        reason="Tensor.detach_ throws unexpected exception, refer to: https://github.com/PaddlePaddle/Paddle/issues/57303",
-    )
+    obj.run(pytorch_code, ["y"])
 
 
-def test_case_2():
+def _test_case_2():
     pytorch_code = textwrap.dedent(
         """
         import torch
@@ -47,9 +43,4 @@ def test_case_2():
         x.detach_()
         """
     )
-    obj.run(
-        pytorch_code,
-        ["x"],
-        unsupport=True,
-        reason="Tensor.detach_ throws unexpected exception, refer to: https://github.com/PaddlePaddle/Paddle/issues/57303",
-    )
+    obj.run(pytorch_code, ["x"])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->
---
由于 `unsupport` 必须要求出现转换失败的 ">>>"，因此该单测使用 `unsupport` 为非预期用法，采用对单测方法名加前置下划线的方式先屏蔽单测

### PR APIs
<!-- APIs what you've done -->
```bash
torch.Tensor.detach_
```
