### PR TITLE
转换规则 添加部分 inplace api 的映射 PART.04

### DIFF
--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -2422,7 +2422,7 @@
   },
   "torch.Tensor.renorm_": {
     "Matcher": "TensorFunc2PaddleFunc",
-    "min_input_args": 0,
+    "min_input_args": 3,
     "paddle_api": "paddle.renorm_",
     "args_list": [
       "p",

--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -665,12 +665,20 @@
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.Tensor.cos"
   },
-  "torch.Tensor.cos_": {},
+  "torch.Tensor.cos_": {
+    "Matcher": "TensorFunc2PaddleFunc",
+    "min_input_args": 0,
+    "paddle_api": "paddle.cos_"
+  },
   "torch.Tensor.cosh": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.Tensor.cosh"
   },
-  "torch.Tensor.cosh_": {},
+  "torch.Tensor.cosh_": {
+    "Matcher": "TensorFunc2PaddleFunc",
+    "min_input_args": 0,
+    "paddle_api": "paddle.cosh_"
+  },
   "torch.Tensor.count_nonzero": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.Tensor.count_nonzero",
@@ -955,7 +963,11 @@
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.Tensor.erf"
   },
-  "torch.Tensor.erf_": {},
+  "torch.Tensor.erf_": {
+    "Matcher": "TensorFunc2PaddleFunc",
+    "min_input_args": 0,
+    "paddle_api": "paddle.erf_"
+  },
   "torch.Tensor.erfc": {
     "Matcher": "ErfCMatcher"
   },
@@ -994,7 +1006,11 @@
   "torch.Tensor.expm1": {
     "Matcher": "UnchangeMatcher"
   },
-  "torch.Tensor.expm1_": {},
+  "torch.Tensor.expm1_": {
+    "Matcher": "TensorFunc2PaddleFunc",
+    "min_input_args": 0,
+    "paddle_api": "paddle.expm1_"
+  },
   "torch.Tensor.exponential_": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.Tensor.exponential_",
@@ -2404,7 +2420,20 @@
       "maxnorm": "max_norm"
     }
   },
-  "torch.Tensor.renorm_": {},
+  "torch.Tensor.renorm_": {
+    "Matcher": "TensorFunc2PaddleFunc",
+    "min_input_args": 0,
+    "paddle_api": "paddle.renorm_",
+    "args_list": [
+      "p",
+      "dim",
+      "maxnorm"
+    ],
+    "kwargs_change": {
+      "dim": "axis",
+      "maxnorm": "max_norm"
+    }
+  },
   "torch.Tensor.repeat": {
     "Matcher": "TensorRepeatMatcher"
   },
@@ -2697,9 +2726,14 @@
   },
   "torch.Tensor.square": {
     "Matcher": "GenericMatcher",
+    "min_input_args": 0,
     "paddle_api": "paddle.Tensor.square"
   },
-  "torch.Tensor.square_": {},
+  "torch.Tensor.square_": {
+    "Matcher": "TensorFunc2PaddleFunc",
+    "min_input_args": 0,
+    "paddle_api": "paddle.square_"
+  },
   "torch.Tensor.squeeze": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.Tensor.squeeze",
@@ -2897,7 +2931,14 @@
       "diagonal"
     ]
   },
-  "torch.Tensor.tril_": {},
+  "torch.Tensor.tril_": {
+    "Matcher": "TensorFunc2PaddleFunc",
+    "min_input_args": 0,
+    "paddle_api": "paddle.tril_",
+    "args_list": [
+      "diagonal"
+    ]
+  },
   "torch.Tensor.triu": {
     "Matcher": "TensorFunc2PaddleFunc",
     "paddle_api": "paddle.triu",
@@ -2906,7 +2947,14 @@
       "diagonal"
     ]
   },
-  "torch.Tensor.triu_": {},
+  "torch.Tensor.triu_": {
+    "Matcher": "TensorFunc2PaddleFunc",
+    "min_input_args": 0,
+    "paddle_api": "paddle.triu_",
+    "args_list": [
+      "diagonal"
+    ]
+  },
   "torch.Tensor.true_divide": {
     "Matcher": "Num2TensorBinaryMatcher",
     "paddle_api": "paddle.Tensor.divide",

--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -2652,7 +2652,11 @@
   "torch.Tensor.sin": {
     "Matcher": "UnchangeMatcher"
   },
-  "torch.Tensor.sin_": {},
+  "torch.Tensor.sin_": {
+    "Matcher": "TensorFunc2PaddleFunc",
+    "min_input_args": 0,
+    "paddle_api": "paddle.sin_"
+  },
   "torch.Tensor.sinc": {
     "Matcher": "SincMatcher"
   },
@@ -2660,7 +2664,11 @@
   "torch.Tensor.sinh": {
     "Matcher": "UnchangeMatcher"
   },
-  "torch.Tensor.sinh_": {},
+  "torch.Tensor.sinh_": {
+    "Matcher": "TensorFunc2PaddleFunc",
+    "min_input_args": 0,
+    "paddle_api": "paddle.sinh_"
+  },
   "torch.Tensor.size": {
     "Matcher": "TensorSizeMatcher",
     "min_input_args": 0,
@@ -2873,13 +2881,18 @@
     "Matcher": "TensorFunc2PaddleFunc",
     "paddle_api": "paddle.tan"
   },
-  "torch.Tensor.tan_": {},
+  "torch.Tensor.tan_": {
+    "Matcher": "TensorFunc2PaddleFunc",
+    "min_input_args": 0,
+    "paddle_api": "paddle.tan_"
+  },
   "torch.Tensor.tanh": {
     "Matcher": "UnchangeMatcher"
   },
   "torch.Tensor.tanh_": {
-    "Matcher": "GenericMatcher",
-    "paddle_api": "paddle.Tensor.tanh_"
+    "Matcher": "TensorFunc2PaddleFunc",
+    "min_input_args": 0,
+    "paddle_api": "paddle.tanh_"
   },
   "torch.Tensor.tensor_split": {},
   "torch.Tensor.tile": {},

--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -256,21 +256,37 @@
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.Tensor.acos"
   },
-  "torch.Tensor.arccos_": {},
+  "torch.Tensor.arccos_": {
+    "Matcher": "TensorFunc2PaddleFunc",
+    "min_input_args": 0,
+    "paddle_api": "paddle.acos_"
+  },
   "torch.Tensor.arccosh": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.Tensor.acosh"
   },
-  "torch.Tensor.arccosh_": {},
+  "torch.Tensor.arccosh_": {
+    "Matcher": "TensorFunc2PaddleFunc",
+    "min_input_args": 0,
+    "paddle_api": "paddle.acosh_"
+  },
   "torch.Tensor.arcsin": {
     "Matcher": "UnchangeMatcher"
   },
-  "torch.Tensor.arcsin_": {},
+  "torch.Tensor.arcsin_": {
+    "Matcher": "TensorFunc2PaddleFunc",
+    "min_input_args": 0,
+    "paddle_api": "paddle.asin_"
+  },
   "torch.Tensor.arcsinh": {
     "Matcher": "TensorFunc2PaddleFunc",
     "paddle_api": "paddle.asinh"
   },
-  "torch.Tensor.arcsinh_": {},
+  "torch.Tensor.arcsinh_": {
+    "Matcher": "TensorFunc2PaddleFunc",
+    "min_input_args": 0,
+    "paddle_api": "paddle.asinh_"
+  },
   "torch.Tensor.arctan": {
     "Matcher": "UnchangeMatcher"
   },
@@ -286,12 +302,20 @@
     }
   },
   "torch.Tensor.arctan2_": {},
-  "torch.Tensor.arctan_": {},
+  "torch.Tensor.arctan_": {
+    "Matcher": "TensorFunc2PaddleFunc",
+    "min_input_args": 0,
+    "paddle_api": "paddle.atan_"
+  },
   "torch.Tensor.arctanh": {
     "Matcher": "TensorFunc2PaddleFunc",
     "paddle_api": "paddle.atanh"
   },
-  "torch.Tensor.arctanh_": {},
+  "torch.Tensor.arctanh_": {
+    "Matcher": "TensorFunc2PaddleFunc",
+    "min_input_args": 0,
+    "paddle_api": "paddle.atanh_"
+  },
   "torch.Tensor.argmax": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.Tensor.argmax",

--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -54,7 +54,11 @@
     "min_input_args": 0,
     "paddle_api": "paddle.Tensor.abs"
   },
-  "torch.Tensor.abs_": {},
+  "torch.Tensor.abs_": {
+    "Matcher": "TensorFunc2PaddleFunc",
+    "min_input_args": 0,
+    "paddle_api": "paddle.abs_"
+  },
   "torch.Tensor.add": {
     "Matcher": "TensorAddMatcher",
     "paddle_api": "paddle.Tensor.add",

--- a/tests/test_Tensor_abs_.py
+++ b/tests/test_Tensor_abs_.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.abs_")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([-1])
+        a.abs_()
+        """
+    )
+    obj.run(pytorch_code, ["a"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([-1, -2, 3])
+        a.abs_()
+        """
+    )
+    obj.run(pytorch_code, ["a"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = [-1, -2, 3]
+        out = torch.tensor(a)
+        out.abs_()
+        """
+    )
+    obj.run(pytorch_code, ["out"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([-1., 2., -3.4, -4.1, 0, -0.])
+        a.abs_()
+        """
+    )
+    obj.run(pytorch_code, ["a"])

--- a/tests/test_Tensor_acos_.py
+++ b/tests/test_Tensor_acos_.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.acos_")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([0.34, -0.56, 0.73])
+        a.acos_()
+        """
+    )
+    obj.run(pytorch_code, ["a"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([1., -1., 0.])
+        a.acos_()
+        """
+    )
+    obj.run(pytorch_code, ["a"])

--- a/tests/test_Tensor_arccos_.py
+++ b/tests/test_Tensor_arccos_.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.arccos_")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([0.34, -0.56, 0.73])
+        a.arccos_()
+        """
+    )
+    obj.run(pytorch_code, ["a"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([1., -1., 0.])
+        a.arccos_()
+        """
+    )
+    obj.run(pytorch_code, ["a"])

--- a/tests/test_Tensor_arccosh_.py
+++ b/tests/test_Tensor_arccosh_.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.arccosh_")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([1.3192, 1.9915, 1.9674, 1.7151])
+        a.arccosh_()
+        """
+    )
+    obj.run(pytorch_code, ["a"])

--- a/tests/test_Tensor_arcsin_.py
+++ b/tests/test_Tensor_arcsin_.py
@@ -28,4 +28,4 @@ def test_case_1():
         a.arcsin_()
         """
     )
-    obj.run(pytorch_code, ["result"])
+    obj.run(pytorch_code, ["a"])

--- a/tests/test_Tensor_arcsin_.py
+++ b/tests/test_Tensor_arcsin_.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.arcsin_")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([0.34, -0.56, 0.73])
+        a.arcsin_()
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_Tensor_arcsinh_.py
+++ b/tests/test_Tensor_arcsinh_.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.arcsinh_")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([1.3192, 1.9915, 1.9674, 1.7151])
+        a.arcsinh_()
+        """
+    )
+    obj.run(pytorch_code, ["a"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([ 0.1606, -1.4267, -1.0899, -1.0250 ])
+        a.arcsinh_()
+        """
+    )
+    obj.run(pytorch_code, ["a"])

--- a/tests/test_Tensor_arctan_.py
+++ b/tests/test_Tensor_arctan_.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.arctan_")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([ 0.2341,  0.2539, -0.6256, -0.6448])
+        a.arctan_()
+        """
+    )
+    obj.run(pytorch_code, ["a"])

--- a/tests/test_Tensor_arctanh_.py
+++ b/tests/test_Tensor_arctanh_.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.arctanh_")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([-0.9385, 0.2968, -0.8591, -0.1871])
+        a.arctanh_()
+        """
+    )
+    obj.run(pytorch_code, ["a"])

--- a/tests/test_Tensor_cos_.py
+++ b/tests/test_Tensor_cos_.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.cos_")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([ 1.4309,  1.2706, -0.8562,  0.9796])
+        a.cos_()
+        """
+    )
+    obj.run(pytorch_code, ["a"])

--- a/tests/test_Tensor_cosh_.py
+++ b/tests/test_Tensor_cosh_.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.cosh_")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([1.4309,  1.2706, -0.8562,  0.9796])
+        a.cosh_()
+        """
+    )
+    obj.run(pytorch_code, ["a"])

--- a/tests/test_Tensor_erf_.py
+++ b/tests/test_Tensor_erf_.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.erf_")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([0, -1., 10.])
+        a.erf_()
+        """
+    )
+    obj.run(pytorch_code, ["a"])

--- a/tests/test_Tensor_expm1_.py
+++ b/tests/test_Tensor_expm1_.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.expm1_")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([0., -2., 3.])
+        a.expm1_()
+        """
+    )
+    obj.run(pytorch_code, ["a"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([1., -2., 3.])
+        a.expm1_()
+        """
+    )
+    obj.run(pytorch_code, ["a"])

--- a/tests/test_Tensor_renorm_.py
+++ b/tests/test_Tensor_renorm_.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.renorm_")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[ 1.,  1.,  1.],
+                            [ 2.,  2.,  2.],
+                            [ 3.,  3.,  3.]])
+        x.renorm_(1, 0, 5)
+        """
+    )
+    obj.run(pytorch_code, ["x"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[ 1.,  1.,  1.],
+                            [ 2.,  2.,  2.],
+                            [ 3.,  3.,  3.]])
+        x.renorm_(p=1, dim=0, maxnorm=5)
+        """
+    )
+    obj.run(pytorch_code, ["x"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[ 1.,  1.,  1.],
+                            [ 2.,  2.,  2.],
+                            [ 3.,  3.,  3.]])
+        x.renorm_(maxnorm=5, dim=0, p=1)
+        """
+    )
+    obj.run(pytorch_code, ["x"])

--- a/tests/test_Tensor_sin_.py
+++ b/tests/test_Tensor_sin_.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.sin_")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([1.4309,  1.2706, -0.8562,  0.9796])
+        a.sin_()
+        """
+    )
+    obj.run(pytorch_code, ["a"])

--- a/tests/test_Tensor_sinh_.py
+++ b/tests/test_Tensor_sinh_.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.sinh_")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([1.4309,  1.2706, -0.8562,  0.9796])
+        a.sinh_()
+        """
+    )
+    obj.run(pytorch_code, ["a"])

--- a/tests/test_Tensor_square_.py
+++ b/tests/test_Tensor_square_.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.square_")
+
+
+# AttributeError: module 'paddle.base.libpaddle.eager.ops.legacy' has no attribute 'square_'
+def _test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([0.2970,  1.5420, 4])
+        x.square_()
+        """
+    )
+    obj.run(pytorch_code, ["x"])

--- a/tests/test_Tensor_tan_.py
+++ b/tests/test_Tensor_tan_.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.tan_")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.Tensor([[1.,2.], [3.,4.]])
+        a.tan_()
+        """
+    )
+    obj.run(pytorch_code, ["a"])

--- a/tests/test_Tensor_tril_.py
+++ b/tests/test_Tensor_tril_.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.tril_")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[-1.0813, -0.8619,  0.7105],
+                        [ 0.0935,  0.1380,  2.2112],
+                        [-0.3409, -0.9828,  0.0289]])
+        x.tril_()
+        """
+    )
+    obj.run(pytorch_code, ["x"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[-1.0813, -0.8619,  0.7105],
+                        [ 0.0935,  0.1380,  2.2112],
+                        [-0.3409, -0.9828,  0.0289]])
+        x.tril_(1)
+        """
+    )
+    obj.run(pytorch_code, ["x"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[-1.0813, -0.8619,  0.7105],
+                        [ 0.0935,  0.1380,  2.2112],
+                        [-0.3409, -0.9828,  0.0289]])
+        x.tril_(diagonal=-1)
+        """
+    )
+    obj.run(pytorch_code, ["x"])

--- a/tests/test_Tensor_triu_.py
+++ b/tests/test_Tensor_triu_.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.triu_")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[-1.0813, -0.8619,  0.7105],
+                        [ 0.0935,  0.1380,  2.2112],
+                        [-0.3409, -0.9828,  0.0289]])
+        x.triu_()
+        """
+    )
+    obj.run(pytorch_code, ["x"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[-1.0813, -0.8619,  0.7105],
+                        [ 0.0935,  0.1380,  2.2112],
+                        [-0.3409, -0.9828,  0.0289]])
+        x.triu_(1)
+        """
+    )
+    obj.run(pytorch_code, ["x"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[-1.0813, -0.8619,  0.7105],
+                        [ 0.0935,  0.1380,  2.2112],
+                        [-0.3409, -0.9828,  0.0289]])
+        x.triu_(diagonal=-1)
+        """
+    )
+    obj.run(pytorch_code, ["x"])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->
- 添加了 19 个 inplace API，之后补充
- 对于 `arcXXX` 的单测，应当添加 `aXXX` 和 `arcXXX` 两组，本 PR 仅添加了 `arcXXX` 一组，后续 PR 补充。

### PR APIs
<!-- APIs what you've done -->
```bash
torch.Tensor.abs_

torch.Tensor.acos_
torch.Tensor.acosh_
torch.Tensor.asin_
torch.Tensor.asinh_
torch.Tensor.atan_
torch.Tensor.atanh_

torch.Tensor.erf_
torch.Tensor.expm1_
torch.Tensor.renorm_
torch.Tensor.square_
torch.Tensor.tril_
torch.Tensor.triu_

torch.Tensor.cos_
torch.Tensor.cosh_
torch.Tensor.sin_
torch.Tensor.sinh_
torch.Tensor.tan_
torch.Tensor.tanh_
```
