### PR TITLE
【Hackathon 5th No.43】API转换21-41

### DIFF
--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -9203,10 +9203,10 @@
       "enable_nested_tensor",
       "mask_check"
     ],
-    "unsupport_args": [
-      "enable_nested_tensor",
-      "mask_check"
-    ]
+    "kwargs_change": {
+      "enable_nested_tensor": "",
+      "mask_check": ""
+    }
   },
   "torch.nn.TransformerEncoderLayer": {
     "Matcher": "GenericMatcher",
@@ -13225,15 +13225,15 @@
       "pin_memory_device"
     ],
     "kwargs_change": {
-      "generator": ""
+      "pin_memory": "",
+      "multiprocessing_context": "",
+      "generator": "",
+      "persistent_workers": "",
+      "pin_memory_device": ""
     },
     "unsupport_args": [
-      "pin_memory",
-      "multiprocessing_context",
       "sampler",
-      "prefetch_factor",
-      "persistent_workers",
-      "pin_memory_device"
+      "prefetch_factor"
     ]
   },
   "torch.utils.data.Dataset": {

--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -13225,14 +13225,16 @@
       "pin_memory_device"
     ],
     "kwargs_change": {
-      "sampler": "",
-      "pin_memory": "",
-      "multiprocessing_context": "",
-      "generator": "",
-      "prefetch_factor": "",
-      "persistent_workers": "",
-      "pin_memory_device": ""
-    }
+      "generator": ""
+    },
+    "unsupport_args": [
+      "pin_memory",
+      "multiprocessing_context",
+      "sampler",
+      "prefetch_factor",
+      "persistent_workers",
+      "pin_memory_device"
+    ]
   },
   "torch.utils.data.Dataset": {
     "Matcher": "GenericMatcher",

--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -4029,6 +4029,14 @@
     "Matcher": "GenericMatcher",
     "paddle_api": "'bool'"
   },
+  "torch.broadcast_shapes": {
+    "Matcher": "BroadcastShapesMatcher",
+    "paddle_api": "paddle.broadcast_shape"
+  },
+  "torch.broadcast_tensors": {
+    "Matcher": "BroadcastTensorsMatcher",
+    "paddle_api": "paddle.broadcast_tensors"
+  },
   "torch.broadcast_to": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.broadcast_to",
@@ -5784,6 +5792,13 @@
       "dim": "axes"
     }
   },
+  "torch.finfo": {
+    "Matcher": "IInfoMatcher",
+    "paddle_api": "paddle.finfo",
+    "args_list": [
+      "type"
+    ]
+  },
   "torch.fix": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.trunc",
@@ -6204,6 +6219,13 @@
       "other",
       "*",
       "out"
+    ]
+  },
+  "torch.iinfo": {
+    "Matcher": "IInfoMatcher",
+    "paddle_api": "paddle.iinfo",
+    "args_list": [
+      "type"
     ]
   },
   "torch.imag": {
@@ -8055,6 +8077,18 @@
       "dtype": ""
     }
   },
+  "torch.nn.GaussianNLLLoss": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.GaussianNLLLoss",
+    "args_list": [
+      "full",
+      "eps",
+      "reduction"
+    ],
+    "kwargs_change": {
+      "eps": "epsilon"
+    }
+  },
   "torch.nn.GroupNorm": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.nn.GroupNorm",
@@ -8680,6 +8714,28 @@
       "modules": "sublayers"
     }
   },
+  "torch.nn.MultiLabelSoftMarginLoss": {
+    "Matcher": "SizeAverageMatcher",
+    "paddle_api": "paddle.nn.MultiLabelSoftMarginLoss",
+    "args_list": [
+      "weight",
+      "size_average",
+      "reduce",
+      "reduction"
+    ]
+  },
+  "torch.nn.MultiMarginLoss": {
+    "Matcher": "SizeAverageMatcher",
+    "paddle_api": "paddle.nn.MultiMarginLoss",
+    "args_list": [
+      "p",
+      "margin",
+      "weight",
+      "size_average",
+      "reduce",
+      "reduction"
+    ]
+  },
   "torch.nn.MultiheadAttention": {
     "paddle_api": "paddle.nn.MultiHeadAttention",
     "args_list": [
@@ -8776,6 +8832,21 @@
     "args_list": [
       "downscale_factor"
     ]
+  },
+  "torch.nn.PoissonNLLLoss": {
+    "Matcher": "SizeAverageMatcher",
+    "paddle_api": "paddle.nn.PoissonNLLLoss",
+    "args_list": [
+      "log_input",
+      "full",
+      "size_average",
+      "eps",
+      "reduce",
+      "reduction"
+    ],
+    "kwargs_change": {
+      "eps": "epsilon"
+    }
   },
   "torch.nn.RNN": {
     "Matcher": "RNNMatcher",
@@ -8953,6 +9024,19 @@
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.nn.Sigmoid"
   },
+  "torch.nn.SmoothL1Loss": {
+    "Matcher": "SmoothL1LossMatcher",
+    "paddle_api": "paddle.nn.SmoothL1Loss",
+    "args_list": [
+      "size_average",
+      "reduce",
+      "reduction",
+      "beta"
+    ],
+    "kwargs_change": {
+      "beta": "delta"
+    }
+  },
   "torch.nn.SoftMarginLoss": {
     "Matcher": "SizeAverageMatcher",
     "paddle_api": "paddle.nn.SoftMarginLoss",
@@ -9043,6 +9127,35 @@
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.nn.Tanhshrink"
   },
+  "torch.nn.Transformer": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.Transformer",
+    "args_list": [
+      "d_model",
+      "nhead",
+      "num_encoder_layers",
+      "num_decoder_layers",
+      "dim_feedforward",
+      "dropout",
+      "activation",
+      "custom_encoder",
+      "custom_decoder",
+      "layer_norm_eps",
+      "batch_first",
+      "norm_first",
+      "device",
+      "dtype"
+    ],
+    "kwargs_change": {
+      "norm_first": "normalize_before",
+      "device": "",
+      "dtype": ""
+    },
+    "unsupport_args": [
+      "layer_norm_eps",
+      "batch_first"
+    ]
+  },
   "torch.nn.TransformerDecoder": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.nn.TransformerDecoder",
@@ -9055,6 +9168,49 @@
   "torch.nn.TransformerDecoderLayer": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.nn.TransformerDecoderLayer",
+    "args_list": [
+      "d_model",
+      "nhead",
+      "dim_feedforward",
+      "dropout",
+      "activation",
+      "layer_norm_eps",
+      "batch_first",
+      "norm_first",
+      "device",
+      "dtype"
+    ],
+    "kwargs_change": {
+      "norm_first": "normalize_before",
+      "device": "",
+      "dtype": ""
+    },
+    "unsupport_args": [
+      "layer_norm_eps",
+      "batch_first"
+    ],
+    "paddle_default_kwargs": {
+      "dim_feedforward": 2048
+    }
+  },
+  "torch.nn.TransformerEncoder": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.TransformerEncoder",
+    "args_list": [
+      "encoder_layer",
+      "num_layers",
+      "norm",
+      "enable_nested_tensor",
+      "mask_check"
+    ],
+    "unsupport_args": [
+      "enable_nested_tensor",
+      "mask_check"
+    ]
+  },
+  "torch.nn.TransformerEncoderLayer": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.nn.TransformerEncoderLayer",
     "args_list": [
       "d_model",
       "nhead",
@@ -10446,6 +10602,26 @@
     ],
     "kwargs_change": {
       "input": "x"
+    }
+  },
+  "torch.nn.functional.triplet_margin_loss": {
+    "Matcher": "SizeAverageMatcher",
+    "paddle_api": "paddle.nn.functional.triplet_margin_loss",
+    "args_list": [
+      "anchor",
+      "positive",
+      "negative",
+      "margin",
+      "p",
+      "eps",
+      "swap",
+      "size_average",
+      "reduce",
+      "reduction"
+    ],
+    "kwargs_change": {
+      "anchor": "input",
+      "eps": "epsilon"
     }
   },
   "torch.nn.functional.triplet_margin_with_distance_loss": {
@@ -13026,6 +13202,37 @@
     "args_list": [
       "datasets"
     ]
+  },
+  "torch.utils.data.DataLoader": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.io.DataLoader",
+    "args_list": [
+      "dataset",
+      "batch_size",
+      "shuffle",
+      "sampler",
+      "batch_sampler",
+      "num_workers",
+      "collate_fn",
+      "pin_memory",
+      "drop_last",
+      "timeout",
+      "worker_init_fn",
+      "multiprocessing_context",
+      "generator",
+      "prefetch_factor",
+      "persistent_workers",
+      "pin_memory_device"
+    ],
+    "kwargs_change": {
+      "sampler": "",
+      "pin_memory": "",
+      "multiprocessing_context": "",
+      "generator": "",
+      "prefetch_factor": "",
+      "persistent_workers": "",
+      "pin_memory_device": ""
+    }
   },
   "torch.utils.data.Dataset": {
     "Matcher": "GenericMatcher",

--- a/paconvert/api_matcher.py
+++ b/paconvert/api_matcher.py
@@ -445,6 +445,8 @@ class TransposeMatcher(BaseMatcher):
 
 class BroadcastTensorsMatcher(BaseMatcher):
     def get_paddle_nodes(self, args, kwargs):
+        if len(args) == 1 and isinstance(args[0], ast.Starred):
+            return None
         new_args = self.parse_args(args)
         code = "{}([{}])".format(self.get_paddle_api(), ",".join(new_args))
         return ast.parse(code).body
@@ -452,6 +454,8 @@ class BroadcastTensorsMatcher(BaseMatcher):
 
 class BroadcastShapesMatcher(BaseMatcher):
     def get_paddle_nodes(self, args, kwargs):
+        if len(args) == 1 and isinstance(args[0], ast.Starred):
+            return None
         new_args = self.parse_args(args)
         code = new_args[0]
         # Call the paddle.broadcast_shape multiple times
@@ -496,7 +500,7 @@ class SmoothL1LossMatcher(BaseMatcher):
         beta = kwargs.get("beta", None)
         if beta is not None:
             beta = beta.replace("(", "").replace(")", "")
-            if float(beta) != 1.0:
+            if not beta.isnumeric() or float(beta) != 1.0:
                 return None
         code = SizeAverageMatcher.generate_code(self, kwargs)
         return ast.parse(code).body

--- a/paconvert/api_matcher.py
+++ b/paconvert/api_matcher.py
@@ -500,7 +500,11 @@ class SmoothL1LossMatcher(BaseMatcher):
         beta = kwargs.get("beta", None)
         if beta is not None:
             beta = beta.replace("(", "").replace(")", "")
-            if not beta.isnumeric() or float(beta) != 1.0:
+            try:
+                beta = float(beta)
+                if float(beta) != 1.0:
+                    return None
+            except:
                 return None
         code = SizeAverageMatcher.generate_code(self, kwargs)
         return ast.parse(code).body

--- a/tests/apibase.py
+++ b/tests/apibase.py
@@ -174,7 +174,7 @@ class APIBase(object):
                 )
             return
 
-        if isinstance(pytorch_result, (bool, np.number, int, str, type(None))):
+        if isinstance(pytorch_result, (bool, np.number, int, float, str, type(None))):
             assert type(paddle_result) == type(
                 pytorch_result
             ), "paddle result's type [{}] should be the same with pytorch's type [{}]".format(

--- a/tests/test_broadcast_shapes.py
+++ b/tests/test_broadcast_shapes.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.broadcast_shapes")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = (2,)
+        y = (3, 1)
+        result = torch.broadcast_shapes(x, y)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.broadcast_shapes((2,), (3, 1))
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = (2,)
+        y = (3, 1)
+        z = (1, 1, 1)
+        result = torch.broadcast_shapes(x, y, z)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.broadcast_shapes((2,), (3, 1), (1, 1, 1))
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = (2,)
+        y = (3, 1)
+        result = torch.broadcast_shapes(x, y, (1, 1, 2))
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_broadcast_tensors.py
+++ b/tests/test_broadcast_tensors.py
@@ -71,8 +71,8 @@ def test_case_5():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        result = torch.broadcast_tensors(torch.tensor([[0,1,2]]),
-                torch.tensor([[0],[1]]), torch.tensor([[20]]))
+        tensors = torch.tensor([[0,1,2]]), torch.tensor([[0],[1]]), torch.tensor([[20]])
+        result = torch.broadcast_tensors(*tensors)
         """
     )
     obj.run(pytorch_code, ["result"])

--- a/tests/test_broadcast_tensors.py
+++ b/tests/test_broadcast_tensors.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.broadcast_tensors")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[0,1,2]])
+        y = torch.tensor([[0],[1]])
+        result = torch.broadcast_tensors(x, y)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        y = torch.tensor([[0],[1]])
+        result = torch.broadcast_tensors(torch.tensor([[0,1,2]]), y)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[0,1,2]])
+        y = torch.tensor([[0],[1],[2]])
+        z = torch.tensor([[20]])
+        result = torch.broadcast_tensors(x, y, z)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[0,1,2]])
+        y = torch.tensor([[0],[1]])
+        result = torch.broadcast_tensors(x, y, torch.tensor([[20]]))
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.broadcast_tensors(torch.tensor([[0,1,2]]),
+                torch.tensor([[0],[1]]), torch.tensor([[20]]))
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_can_cast.py
+++ b/tests/test_can_cast.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.can_cast")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[0,1,2]])
+        y = torch.tensor([[0],[1]])
+        result = torch.can_cast(x, y)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle not support this API now",
+    )

--- a/tests/test_finfo.py
+++ b/tests/test_finfo.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.finfo")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        bits = torch.finfo(torch.float16).bits
+        min = torch.finfo(torch.float16).min
+        max = torch.finfo(torch.float16).max
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["bits", "min", "max"],
+        check_value=False,
+        check_stop_gradient=False,
+    )
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.float32
+        bits = torch.finfo(x).bits
+        min = torch.finfo(x).min
+        max = torch.finfo(x).max
+        """
+    )
+    obj.run(pytorch_code, ["bits", "min", "max"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.bfloat16
+        bits = torch.finfo(type=x).bits
+        min = torch.finfo(type=x).min
+        max = torch.finfo(type=x).max
+        """
+    )
+    obj.run(pytorch_code, ["bits", "min", "max"])

--- a/tests/test_finfo.py
+++ b/tests/test_finfo.py
@@ -17,7 +17,7 @@ import textwrap
 
 from apibase import APIBase
 
-obj = APIBase("torch.finfo")
+obj = APIBase("torch.finfo", is_aux_api=True)
 
 
 def test_case_1():

--- a/tests/test_iinfo.py
+++ b/tests/test_iinfo.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.iinfo")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        bits = torch.iinfo(torch.int32).bits
+        min = torch.iinfo(torch.int32).min
+        max = torch.iinfo(torch.int32).max
+        """
+    )
+    obj.run(pytorch_code, ["bits", "min", "max"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.int16
+        bits = torch.iinfo(x).bits
+        min = torch.iinfo(x).min
+        max = torch.iinfo(x).max
+        """
+    )
+    obj.run(pytorch_code, ["bits", "min", "max"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.uint8
+        bits = torch.iinfo(type=x).bits
+        min = torch.iinfo(type=x).min
+        max = torch.iinfo(type=x).max
+        """
+    )
+    obj.run(pytorch_code, ["bits", "min", "max"])

--- a/tests/test_iinfo.py
+++ b/tests/test_iinfo.py
@@ -17,7 +17,7 @@ import textwrap
 
 from apibase import APIBase
 
-obj = APIBase("torch.iinfo")
+obj = APIBase("torch.iinfo", is_aux_api=True)
 
 
 def test_case_1():

--- a/tests/test_nn_CTCLoss.py
+++ b/tests/test_nn_CTCLoss.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.CTCLoss")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        log_probs = torch.tensor([[[4.17021990e-01, 7.20324516e-01, 1.14374816e-04],
+                                   [3.02332580e-01, 1.46755889e-01, 9.23385918e-02]],
+                                  [[1.86260208e-01, 3.45560730e-01, 3.96767467e-01],
+                                   [5.38816750e-01, 4.19194520e-01, 6.85219526e-01]],
+                                  [[2.04452246e-01, 8.78117442e-01, 2.73875929e-02],
+                                   [6.70467496e-01, 4.17304814e-01, 5.58689833e-01]],
+                                  [[1.40386939e-01, 1.98101491e-01, 8.00744593e-01],
+                                   [9.68261600e-01, 3.13424170e-01, 6.92322612e-01]],
+                                  [[8.76389146e-01, 8.94606650e-01, 8.50442126e-02],
+                                   [3.90547849e-02, 1.69830427e-01, 8.78142476e-01]]], dtype=torch.float32)
+        labels = torch.tensor([[1, 2, 2], [1, 2, 2]], dtype=torch.int32)
+        input_lengths = torch.tensor([5, 5], dtype=torch.int64)
+        label_lengths = torch.tensor([3, 3], dtype=torch.int64)
+        result = torch.nn.CTCLoss(blank=0, reduction='mean')(log_probs, labels, input_lengths, label_lengths)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="pytorch and paddle return different results",
+    )
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        T = 50
+        C = 20
+        N = 16
+        S = 30
+        S_min = 10
+        input = torch.arange(T * N * C).to(dtype=torch.float32).reshape((T, N, C)).log_softmax(0).detach().requires_grad_()
+        target = torch.randint(low=1, high=C, size=(N, S), dtype=torch.int32)
+        input_lengths = torch.full(size=(N,), fill_value=T, dtype=torch.int64)
+        target_lengths = torch.randint(low=S_min, high=S, size=(N,), dtype=torch.int64)
+        ctc_loss = torch.nn.CTCLoss()
+        result = ctc_loss(input, target, input_lengths, target_lengths)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="pytorch and paddle return different results",
+    )

--- a/tests/test_nn_CTCLoss.py
+++ b/tests/test_nn_CTCLoss.py
@@ -43,7 +43,7 @@ def test_case_1():
         pytorch_code,
         ["result"],
         unsupport=True,
-        reason="pytorch and paddle return different results",
+        reason="torch log_softmax + ctc_loss is equivalent to paddle ctc_loss",
     )
 
 
@@ -68,5 +68,5 @@ def test_case_2():
         pytorch_code,
         ["result"],
         unsupport=True,
-        reason="pytorch and paddle return different results",
+        reason="torch log_softmax + ctc_loss is equivalent to paddle ctc_loss",
     )

--- a/tests/test_nn_GaussianNLLLoss.py
+++ b/tests/test_nn_GaussianNLLLoss.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.GaussianNLLLoss")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.GaussianNLLLoss()
+        input = torch.ones([5, 2]).to(dtype=torch.float32)
+        label = torch.ones([5, 2]).to(dtype=torch.float32)
+        variance = torch.ones([5, 2]).to(dtype=torch.float32)
+        result = loss(input, label, variance)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.GaussianNLLLoss(full=False)
+        input = torch.ones([5, 2]).to(dtype=torch.float32)
+        label = torch.ones([5, 2]).to(dtype=torch.float32)
+        variance = torch.ones([5, 2]).to(dtype=torch.float32)
+        result = loss(input, label, variance)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.GaussianNLLLoss(eps=1e-08,
+                full=False)
+        input = torch.full([5, 2], 1).to(dtype=torch.float32)
+        label = torch.full([5, 2], 2).to(dtype=torch.float32)
+        variance = torch.ones([5, 2]).to(dtype=torch.float32)
+        result = loss(input, label, variance)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.GaussianNLLLoss(full=False,
+                eps=1e-08,
+                reduction='mean')
+        input = torch.full([5, 2], 1).to(dtype=torch.float32)
+        label = torch.full([5, 2], 2).to(dtype=torch.float32)
+        variance = torch.ones([5, 2]).to(dtype=torch.float32)
+        result = loss(input, label, variance)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.GaussianNLLLoss(full=False,
+                eps=1e-08,
+                reduction='sum')
+        input = torch.full([5, 2], 1).to(dtype=torch.float32)
+        label = torch.full([5, 2], 2).to(dtype=torch.float32)
+        variance = torch.ones([5, 2]).to(dtype=torch.float32)
+        result = loss(input, label, variance)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_nn_MultiLabelMarginLoss.py
+++ b/tests/test_nn_MultiLabelMarginLoss.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.MultiLabelMarginLoss")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.MultiLabelMarginLoss()
+        input = torch.tensor([[0.1, 0.2, 0.4, 0.8]]).to(dtype=torch.float32)
+        label = torch.LongTensor([[3, 0, -1, 1]])
+        result = loss(input, label)
+        """
+    )
+    obj.run(
+        pytorch_code, ["result"], unsupport=True, reason="The API is not supported."
+    )

--- a/tests/test_nn_MultiLabelSoftMarginLoss.py
+++ b/tests/test_nn_MultiLabelSoftMarginLoss.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.MultiLabelSoftMarginLoss")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.MultiLabelSoftMarginLoss()
+        input = torch.tensor([[1, -2, 3], [0, -1, 2], [1, 0, 1]]).to(dtype=torch.float32)
+        label = torch.tensor([[-1, 1, -1], [1, 1, 1], [1, -1, 1]]).to(dtype=torch.float32)
+        result = loss(input, label)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.MultiLabelSoftMarginLoss(reduction='sum')
+        input = torch.tensor([[1, -2, 3], [0, -1, 2], [1, 0, 1]]).to(dtype=torch.float32)
+        label = torch.tensor([[-1, 1, -1], [1, 1, 1], [1, -1, 1]]).to(dtype=torch.float32)
+        result = loss(input, label)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.MultiLabelSoftMarginLoss(reduction='sum',
+                size_average=None)
+        input = torch.tensor([[1, -2, 3], [0, -1, 2], [1, 0, 1]]).to(dtype=torch.float32)
+        label = torch.tensor([[-1, 1, -1], [1, 1, 1], [1, -1, 1]]).to(dtype=torch.float32)
+        result = loss(input, label)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.MultiLabelSoftMarginLoss(weight=None,
+                size_average=None,
+                reduce=None, reduction='mean')
+        input = torch.tensor([[1, -2, 3], [0, -1, 2], [1, 0, 1]]).to(dtype=torch.float32)
+        label = torch.tensor([[-1, 1, -1], [1, 1, 1], [1, -1, 1]]).to(dtype=torch.float32)
+        result = loss(input, label)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.MultiLabelSoftMarginLoss(None, None, None, 'mean')
+        input = torch.tensor([[1, -2, 3], [0, -1, 2], [1, 0, 1]]).to(dtype=torch.float32)
+        label = torch.tensor([[-1, 1, -1], [1, 1, 1], [1, -1, 1]]).to(dtype=torch.float32)
+        result = loss(input, label)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_nn_MultiMarginLoss.py
+++ b/tests/test_nn_MultiMarginLoss.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.MultiMarginLoss")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.MultiMarginLoss()
+        input = torch.tensor([[1, -2, 3], [0, -1, 2], [1, 0, 1]]).to(dtype=torch.float32)
+        label = torch.tensor([0, 1, 2])
+        result = loss(input, label)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.MultiMarginLoss(reduction='sum')
+        input = torch.tensor([[1, -2, 3], [0, -1, 2], [1, 0, 1]]).to(dtype=torch.float32)
+        label = torch.tensor([0, 1, 2])
+        result = loss(input, label)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.MultiMarginLoss(reduction='sum',
+                p=1)
+        input = torch.tensor([[1, -2, 3], [0, -1, 2], [1, 0, 1]]).to(dtype=torch.float32)
+        label = torch.tensor([0, 1, 2])
+        result = loss(input, label)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.MultiMarginLoss(p=1, margin=1.0,
+                weight=None, size_average=None,
+                reduce=None, reduction='mean')
+        input = torch.tensor([[1, -2, 3], [0, -1, 2], [1, 0, 1]]).to(dtype=torch.float32)
+        label = torch.tensor([0, 1, 2])
+        result = loss(input, label)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.MultiMarginLoss(1, 1.0,
+                None, None,
+                None, 'mean')
+        input = torch.tensor([[1, -2, 3], [0, -1, 2], [1, 0, 1]]).to(dtype=torch.float32)
+        label = torch.tensor([0, 1, 2])
+        result = loss(input, label)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_nn_PoissonNLLLoss.py
+++ b/tests/test_nn_PoissonNLLLoss.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.PoissonNLLLoss")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.PoissonNLLLoss()
+        input = torch.ones([5, 2]).to(dtype=torch.float32)
+        label = torch.ones([5, 2]).to(dtype=torch.float32)
+        result = loss(input, label)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.PoissonNLLLoss(log_input=True, full=False)
+        input = torch.ones([5, 2]).to(dtype=torch.float32)
+        label = torch.ones([5, 2]).to(dtype=torch.float32)
+        result = loss(input, label)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.PoissonNLLLoss(log_input=True, eps=1e-08,
+                size_average=None, full=False)
+        input = torch.full([5, 2], 1).to(dtype=torch.float32)
+        label = torch.full([5, 2], 2).to(dtype=torch.float32)
+        result = loss(input, label)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.PoissonNLLLoss(log_input=True, full=False,
+                size_average=None, eps=1e-08,
+                reduce=None, reduction='mean')
+        input = torch.full([5, 2], 1).to(dtype=torch.float32)
+        label = torch.full([5, 2], 2).to(dtype=torch.float32)
+        result = loss(input, label)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.PoissonNLLLoss(True, False,
+                None, 1e-08,
+                None, 'sum')
+        input = torch.full([5, 2], 1).to(dtype=torch.float32)
+        label = torch.full([5, 2], 2).to(dtype=torch.float32)
+        result = loss(input, label)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_nn_SmoothL1Loss.py
+++ b/tests/test_nn_SmoothL1Loss.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.SmoothL1Loss")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.SmoothL1Loss()
+        input = torch.ones([3, 3]).to(dtype=torch.float32)
+        label = torch.full([3, 3], 2).to(dtype=torch.float32)
+        result = loss(input, label)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.SmoothL1Loss(reduction='sum')
+        input = torch.ones([3, 3]).to(dtype=torch.float32)
+        label = torch.full([3, 3], 2).to(dtype=torch.float32)
+        result = loss(input, label)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.SmoothL1Loss(beta=1.0, reduction='none')
+        input = torch.ones([3, 3]).to(dtype=torch.float32)
+        label = torch.full([3, 3], 2).to(dtype=torch.float32)
+        result = loss(input, label)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.SmoothL1Loss(size_average=None,
+                reduce=None, reduction='mean', beta=1.0)
+        input = torch.ones([3, 3]).to(dtype=torch.float32)
+        label = torch.full([3, 3], 2).to(dtype=torch.float32)
+        result = loss(input, label)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.SmoothL1Loss(None,
+                None, 'mean', 1.0)
+        input = torch.ones([3, 3]).to(dtype=torch.float32)
+        label = torch.full([3, 3], 2).to(dtype=torch.float32)
+        result = loss(input, label)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_6():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.SmoothL1Loss(beta=1.5, reduction='none')
+        input = torch.ones([3, 3]).to(dtype=torch.float32)
+        label = torch.full([3, 3], 2).to(dtype=torch.float32)
+        result = loss(input, label)
+        """
+    )
+    obj.run(
+        pytorch_code, ["result"], unsupport=True, reason="beta !=1.0 is not supported."
+    )

--- a/tests/test_nn_Transformer.py
+++ b/tests/test_nn_Transformer.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.Transformer")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        transformer_model = torch.nn.Transformer()
+        src = torch.rand((10, 32, 512))
+        tgt = torch.rand((10, 32, 512))
+        result = transformer_model(src, tgt)
+        """
+    )
+    obj.run(pytorch_code, ["result"], check_value=False)
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        transformer_model = torch.nn.Transformer(d_model=512,
+                nhead=8, num_encoder_layers=6,
+                num_decoder_layers=6, dim_feedforward=2048,
+                dropout=0.1, activation='relu'
+                )
+        src = torch.rand((10, 32, 512))
+        tgt = torch.rand((10, 32, 512))
+        result = transformer_model(src, tgt)
+        """
+    )
+    obj.run(pytorch_code, ["result"], check_value=False)
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        transformer_model = torch.nn.Transformer(d_model=512,
+                num_decoder_layers=6, dim_feedforward=2048,
+                dropout=0.1, activation='relu',
+                custom_encoder=None, custom_decoder=None,
+                nhead=8, num_encoder_layers=6)
+        src = torch.rand((10, 32, 512))
+        tgt = torch.rand((10, 32, 512))
+        result = transformer_model(src, tgt)
+        """
+    )
+    obj.run(pytorch_code, ["result"], check_value=False)
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        transformer_model = torch.nn.Transformer(d_model=512,
+                nhead=8, num_encoder_layers=6,
+                num_decoder_layers=6, dim_feedforward=2048,
+                dropout=0.1, activation='relu',
+                custom_encoder=None, custom_decoder=None,
+                norm_first=False, device=None, dtype=None)
+        src = torch.rand((10, 32, 512))
+        tgt = torch.rand((10, 32, 512))
+        result = transformer_model(src, tgt)
+        """
+    )
+    obj.run(pytorch_code, ["result"], check_value=False)
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        transformer_model = torch.nn.Transformer(512,
+                8, 6,
+                6, 2048,
+                0.1, 'relu',
+                None, None)
+        src = torch.rand((10, 32, 512))
+        tgt = torch.rand((10, 32, 512))
+        result = transformer_model(src, tgt)
+        """
+    )
+    obj.run(pytorch_code, ["result"], check_value=False)
+
+
+def test_case_6():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        transformer_model = torch.nn.Transformer(512,
+                8, 6,
+                6, 2048,
+                0.1, 'relu',
+                None, None,
+                layer_norm_eps=1e-05)
+        src = torch.rand((10, 32, 512))
+        tgt = torch.rand((10, 32, 512))
+        result = transformer_model(src, tgt)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        check_value=False,
+        unsupport=True,
+        reason="paddle unsupport layer_norm_eps args",
+    )
+
+
+def test_case_7():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        transformer_model = torch.nn.Transformer(512,
+                8, 6,
+                6, 2048,
+                0.1, 'relu',
+                None, None,
+                batch_first=False
+                )
+        src = torch.rand((10, 32, 512))
+        tgt = torch.rand((10, 32, 512))
+        result = transformer_model(src, tgt)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        check_value=False,
+        unsupport=True,
+        reason="paddle unsupport batch_first args",
+    )

--- a/tests/test_nn_TransformerEncoder.py
+++ b/tests/test_nn_TransformerEncoder.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.TransformerEncoder")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        layer = nn.TransformerEncoderLayer(d_model=512, nhead=8)
+        transformer = nn.TransformerEncoder(layer, num_layers=6)
+        tgt = torch.rand(20, 32, 512)
+        result = transformer(tgt)
+        """
+    )
+    obj.run(pytorch_code, ["result"], check_value=False)
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        layer = nn.TransformerEncoderLayer(d_model=512, nhead=8)
+        transformer = nn.TransformerEncoder(layer, 6)
+        tgt = torch.rand(20, 32, 512)
+        result = transformer(tgt)
+        """
+    )
+    obj.run(pytorch_code, ["result"], check_value=False)
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        layer = nn.TransformerEncoderLayer(d_model=512, nhead=8)
+        transformer = nn.TransformerEncoder(encoder_layer=layer, num_layers=6)
+        tgt = torch.rand(20, 32, 512)
+        result = transformer(tgt)
+        """
+    )
+    obj.run(pytorch_code, ["result"], check_value=False)
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        layer = nn.TransformerEncoderLayer(d_model=512, nhead=8)
+        transformer = nn.TransformerEncoder(encoder_layer=layer, num_layers=6, norm=None)
+        tgt = torch.rand(20, 32, 512)
+        result = transformer(tgt)
+        """
+    )
+    obj.run(pytorch_code, ["result"], check_value=False)
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        layer = nn.TransformerEncoderLayer(d_model=512, nhead=8)
+        transformer = nn.TransformerEncoder(layer, 6, None)
+        tgt = torch.rand(20, 32, 512)
+        result = transformer(tgt)
+        """
+    )
+    obj.run(pytorch_code, ["result"], check_value=False)
+
+
+def test_case_6():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        layer = nn.TransformerEncoderLayer(d_model=512, nhead=8)
+        transformer = nn.TransformerEncoder(layer, 6, None, enable_nested_tensor=True)
+        tgt = torch.rand(20, 32, 512)
+        result = transformer(tgt)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        check_value=False,
+        unsupport=True,
+        reason="paddle unsupport enable_nested_tensor args",
+    )
+
+
+def test_case_7():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        layer = nn.TransformerEncoderLayer(d_model=512, nhead=8)
+        transformer = nn.TransformerEncoder(layer, 6, None, mask_check=True)
+        tgt = torch.rand(20, 32, 512)
+        result = transformer(tgt)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        check_value=False,
+        unsupport=True,
+        reason="paddle unsupport mask_check args",
+    )

--- a/tests/test_nn_TransformerEncoder.py
+++ b/tests/test_nn_TransformerEncoder.py
@@ -100,13 +100,7 @@ def test_case_6():
         result = transformer(tgt)
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        check_value=False,
-        unsupport=True,
-        reason="paddle unsupport enable_nested_tensor args",
-    )
+    obj.run(pytorch_code, ["result"], check_value=False)
 
 
 def test_case_7():
@@ -120,10 +114,4 @@ def test_case_7():
         result = transformer(tgt)
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        check_value=False,
-        unsupport=True,
-        reason="paddle unsupport mask_check args",
-    )
+    obj.run(pytorch_code, ["result"], check_value=False)

--- a/tests/test_nn_TransformerEncoderLayer.py
+++ b/tests/test_nn_TransformerEncoderLayer.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.TransformerEncoderLayer")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        tgt = torch.ones(10, 32, 512)
+        model = nn.TransformerEncoderLayer(d_model=512, nhead=8)
+        result = model(tgt)
+        """
+    )
+    obj.run(pytorch_code, ["result"], check_value=False)
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        tgt = torch.ones(10, 32, 512)
+        model = nn.TransformerEncoderLayer(d_model=512, nhead=8,norm_first=True)
+        result = model(tgt)
+        """
+    )
+    obj.run(pytorch_code, ["result"], check_value=False)
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        tgt = torch.ones(10, 32, 512)
+        model = nn.TransformerEncoderLayer(d_model=512, nhead=8,dtype=torch.float32)
+        result = model(tgt)
+        """
+    )
+    obj.run(pytorch_code, ["result"], check_value=False)
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        tgt = torch.ones(10, 32, 512)
+        model = nn.TransformerEncoderLayer(d_model=512, nhead=8,batch_first=True)
+        result = model(tgt)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle unsupport batch_first args",
+    )
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        tgt = torch.ones(10, 32, 512)
+        model = nn.TransformerEncoderLayer(d_model=512, nhead=8,layer_norm_eps=1e-05)
+        result = model(tgt)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle unsupport layer_norm_eps args",
+    )
+
+
+def test_case_6():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        tgt = torch.ones(10, 32, 512)
+        model = nn.TransformerEncoderLayer(d_model=512, nhead=8,
+                dim_feedforward=2048,
+                dropout=0.1, activation='relu',
+                norm_first=False,
+                device=None,
+                dtype=torch.float32)
+        result = model(tgt)
+        """
+    )
+    obj.run(pytorch_code, ["result"], check_value=False)
+
+
+def test_case_7():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        tgt = torch.ones(10, 32, 512)
+        model = nn.TransformerEncoderLayer(512, 8,
+                2048,
+                0.1, 'relu',
+                norm_first=False,
+                device=None,
+                dtype=torch.float32)
+        result = model(tgt)
+        """
+    )
+    obj.run(pytorch_code, ["result"], check_value=False)

--- a/tests/test_nn_functional_ctc_loss.py
+++ b/tests/test_nn_functional_ctc_loss.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.functional.ctc_loss")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        log_probs = torch.tensor([[[4.17021990e-01, 7.20324516e-01, 1.14374816e-04],
+                                   [3.02332580e-01, 1.46755889e-01, 9.23385918e-02]],
+                                  [[1.86260208e-01, 3.45560730e-01, 3.96767467e-01],
+                                   [5.38816750e-01, 4.19194520e-01, 6.85219526e-01]],
+                                  [[2.04452246e-01, 8.78117442e-01, 2.73875929e-02],
+                                   [6.70467496e-01, 4.17304814e-01, 5.58689833e-01]],
+                                  [[1.40386939e-01, 1.98101491e-01, 8.00744593e-01],
+                                   [9.68261600e-01, 3.13424170e-01, 6.92322612e-01]],
+                                  [[8.76389146e-01, 8.94606650e-01, 8.50442126e-02],
+                                   [3.90547849e-02, 1.69830427e-01, 8.78142476e-01]]], dtype=torch.float32)
+        labels = torch.tensor([[1, 2, 2], [1, 2, 2]], dtype=torch.int32)
+        input_lengths = torch.tensor([5, 5], dtype=torch.int64)
+        label_lengths = torch.tensor([3, 3], dtype=torch.int64)
+        result = torch.nn.functional.ctc_loss(log_probs, labels,
+                input_lengths,
+                label_lengths,
+                blank=0,
+                reduction='mean')
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="pytorch and paddle return different results",
+    )

--- a/tests/test_nn_functional_multilabel_margin_loss.py
+++ b/tests/test_nn_functional_multilabel_margin_loss.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.functional.multilabel_margin_loss")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        loss = torch.nn.functional.multilabel_margin_loss
+        input = torch.tensor([[0.1, 0.2, 0.4, 0.8]]).to(dtype=torch.float32)
+        label = torch.LongTensor([[3, 0, -1, 1]])
+        result = loss(input, label)
+        """
+    )
+    obj.run(
+        pytorch_code, ["result"], unsupport=True, reason="The API is not supported."
+    )

--- a/tests/test_nn_functional_threshold.py
+++ b/tests/test_nn_functional_threshold.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.functional.threshold")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        x = torch.tensor([[[-1.3020, -0.1005,  0.5766,  0.6351, -0.8893,  0.0253, -0.1756, 1.2913],
+                            [-0.8833, -0.1369, -0.0168, -0.5409, -0.1511, -0.1240, -1.1870, -1.8816]]])
+        result = nn.functional.threshold(x, 0.5, 0.0)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support value != 0.0 and value is mandatory in torch",
+    )
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        x = torch.tensor([[[-1.3020, -0.1005,  0.5766,  0.6351, -0.8893,  0.0253, -0.1756, 1.2913],
+                            [-0.8833, -0.1369, -0.0168, -0.5409, -0.1511, -0.1240, -1.1870, -1.8816]]])
+        result = nn.functional.threshold(x, threshold=0.5, value=0.0)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support value != 0.0 and value is mandatory in torch",
+    )
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        x = torch.tensor([[[-1.3020, -0.1005,  0.5766,  0.6351, -0.8893,  0.0253, -0.1756, 1.2913],
+                            [-0.8833, -0.1369, -0.0168, -0.5409, -0.1511, -0.1240, -1.1870, -1.8816]]])
+        result = nn.functional.threshold(x, value=0.0, threshold=0.5)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support value != 0.0 and value is mandatory in torch",
+    )
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        x = torch.tensor([[[-1.3020, -0.1005,  0.5766,  0.6351, -0.8893,  0.0253, -0.1756, 1.2913],
+                            [-0.8833, -0.1369, -0.0168, -0.5409, -0.1511, -0.1240, -1.1870, -1.8816]]])
+        result = nn.functional.threshold(x, 0.5, 0.0, False)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support value != 0.0 and value is mandatory in torch",
+    )
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn as nn
+        x = torch.tensor([[[-1.3020, -0.1005,  0.5766,  0.6351, -0.8893,  0.0253, -0.1756, 1.2913],
+                            [-0.8833, -0.1369, -0.0168, -0.5409, -0.1511, -0.1240, -1.1870, -1.8816]]])
+        result = nn.functional.threshold(x, threshold=0.5, value=0.1, inplace=False)
+        """
+    )
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="paddle does not support value != 0.0 and value is mandatory in torch",
+    )

--- a/tests/test_nn_functional_triplet_margin_loss.py
+++ b/tests/test_nn_functional_triplet_margin_loss.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.nn.functional.triplet_margin_loss")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn.functional as F
+        input = torch.tensor([[1, 5, 3], [0, 3, 2], [1, 4, 1]]).to(dtype=torch.float32)
+        positive = torch.tensor([[5, 1, 2], [3, 2, 1], [3, -1, 1]]).to(dtype=torch.float32)
+        negative = torch.tensor([[2, 1, -3], [1, 1, -1], [4, -2, 1]]).to(dtype=torch.float32)
+        result = F.triplet_margin_loss(input, positive, negative, margin=1.0, reduction='none')
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn.functional as F
+        input = torch.tensor([[1, 5, 3], [0, 3, 2], [1, 4, 1]]).to(dtype=torch.float32)
+        positive = torch.tensor([[5, 1, 2], [3, 2, 1], [3, -1, 1]]).to(dtype=torch.float32)
+        negative = torch.tensor([[2, 1, -3], [1, 1, -1], [4, -2, 1]]).to(dtype=torch.float32)
+        result = F.triplet_margin_loss(input, positive, negative, 1.0, 2)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn.functional as F
+        input = torch.tensor([[1, 5, 3], [0, 3, 2], [1, 4, 1]]).to(dtype=torch.float32)
+        positive = torch.tensor([[5, 1, 2], [3, 2, 1], [3, -1, 1]]).to(dtype=torch.float32)
+        negative = torch.tensor([[2, 1, -3], [1, 1, -1], [4, -2, 1]]).to(dtype=torch.float32)
+        result = F.triplet_margin_loss(margin=1.0, reduction='none',
+                anchor=input, positive=positive, negative=negative)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn.functional as F
+        input = torch.tensor([[1, 5, 3], [0, 3, 2], [1, 4, 1]]).to(dtype=torch.float32)
+        positive = torch.tensor([[5, 1, 2], [3, 2, 1], [3, -1, 1]]).to(dtype=torch.float32)
+        negative = torch.tensor([[2, 1, -3], [1, 1, -1], [4, -2, 1]]).to(dtype=torch.float32)
+        result = F.triplet_margin_loss(anchor=input,
+                positive = positive,
+                negative = negative,
+                margin=1.0, p=2, eps=1e-06,
+                swap=False, size_average=None,
+                reduce=None, reduction='mean')
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torch.nn.functional as F
+        input = torch.tensor([[1, 5, 3], [0, 3, 2], [1, 4, 1]]).to(dtype=torch.float32)
+        positive = torch.tensor([[5, 1, 2], [3, 2, 1], [3, -1, 1]]).to(dtype=torch.float32)
+        negative = torch.tensor([[2, 1, -3], [1, 1, -1], [4, -2, 1]]).to(dtype=torch.float32)
+        result = F.triplet_margin_loss(input,
+                positive,
+                negative,
+                1.0, 2, 1e-06,
+                False, None,
+                None, 'mean')
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_utils_data_DataLoader.py
+++ b/tests/test_utils_data_DataLoader.py
@@ -54,7 +54,6 @@ def test_case_1():
 
         data = Data()
         result = torch.utils.data.DataLoader(data)
-        print(result)
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -78,7 +77,6 @@ def test_case_2():
 
         data = Data()
         result = torch.utils.data.DataLoader(dataset=data)
-        print(result)
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -104,7 +102,6 @@ def test_case_3():
         result = torch.utils.data.DataLoader(dataset=data,
                 shuffle=False, sampler=None,
                 batch_sampler=None, num_workers=0, batch_size=1)
-        print(result)
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -137,7 +134,6 @@ def test_case_4():
                 prefetch_factor=None,
                 persistent_workers=False,
                 pin_memory_device='')
-        print(result)
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -170,7 +166,6 @@ def test_case_5():
                 prefetch_factor=None,
                 persistent_workers=False,
                 pin_memory_device='')
-        print(result)
         """
     )
     obj.run(pytorch_code, ["result"])

--- a/tests/test_utils_data_DataLoader.py
+++ b/tests/test_utils_data_DataLoader.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+import paddle
+from apibase import APIBase
+
+
+class DataLoaderAPIBase(APIBase):
+    def compare(
+        self,
+        name,
+        pytorch_result,
+        paddle_result,
+        check_value=True,
+        check_dtype=True,
+        check_stop_gradient=True,
+        rtol=1.0e-6,
+        atol=0.0,
+    ):
+        assert isinstance(paddle_result, paddle.io.DataLoader)
+
+
+obj = DataLoaderAPIBase("torch.utils.data.DataLoader")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        from torch.utils.data import Dataset
+        import torch
+        class Data(Dataset):
+            def __init__(self):
+                self.x = [1,2,3,4]
+
+            def __getitem__(self, idx):
+                return self.x[idx]
+
+            def __len__(self):
+                return len(self.x)
+
+
+        data = Data()
+        result = torch.utils.data.DataLoader(data)
+        print(result)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        from torch.utils.data import Dataset
+        import torch
+        class Data(Dataset):
+            def __init__(self):
+                self.x = [1,2,3,4]
+
+            def __getitem__(self, idx):
+                return self.x[idx]
+
+            def __len__(self):
+                return len(self.x)
+
+
+        data = Data()
+        result = torch.utils.data.DataLoader(dataset=data)
+        print(result)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        from torch.utils.data import Dataset
+        import torch
+        class Data(Dataset):
+            def __init__(self):
+                self.x = [1,2,3,4]
+
+            def __getitem__(self, idx):
+                return self.x[idx]
+
+            def __len__(self):
+                return len(self.x)
+
+
+        data = Data()
+        result = torch.utils.data.DataLoader(dataset=data,
+                shuffle=False, sampler=None,
+                batch_sampler=None, num_workers=0, batch_size=1)
+        print(result)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        from torch.utils.data import Dataset
+        import torch
+        class Data(Dataset):
+            def __init__(self):
+                self.x = [1,2,3,4]
+
+            def __getitem__(self, idx):
+                return self.x[idx]
+
+            def __len__(self):
+                return len(self.x)
+
+
+        data = Data()
+        result = torch.utils.data.DataLoader(dataset=data,
+                batch_size=1, shuffle=False, sampler=None,
+                batch_sampler=None, num_workers=0, collate_fn=None,
+                pin_memory=False, drop_last=False, timeout=0,
+                worker_init_fn=None,
+                multiprocessing_context=None,
+                generator=None,
+                prefetch_factor=None,
+                persistent_workers=False,
+                pin_memory_device='')
+        print(result)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        from torch.utils.data import Dataset
+        import torch
+        class Data(Dataset):
+            def __init__(self):
+                self.x = [1,2,3,4]
+
+            def __getitem__(self, idx):
+                return self.x[idx]
+
+            def __len__(self):
+                return len(self.x)
+
+
+        data = Data()
+        result = torch.utils.data.DataLoader(data,
+                1, False, None,
+                None, 0, None,
+                False, False, 0,
+                None,
+                None,
+                None,
+                prefetch_factor=None,
+                persistent_workers=False,
+                pin_memory_device='')
+        print(result)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_utils_data_DataLoader.py
+++ b/tests/test_utils_data_DataLoader.py
@@ -100,7 +100,7 @@ def test_case_3():
 
         data = Data()
         result = torch.utils.data.DataLoader(dataset=data,
-                shuffle=False, sampler=None,
+                shuffle=False,
                 batch_sampler=None, num_workers=0, batch_size=1)
         """
     )
@@ -136,7 +136,12 @@ def test_case_4():
                 pin_memory_device='')
         """
     )
-    obj.run(pytorch_code, ["result"])
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="The parameter sampler not support.",
+    )
 
 
 def test_case_5():
@@ -168,4 +173,9 @@ def test_case_5():
                 pin_memory_device='')
         """
     )
-    obj.run(pytorch_code, ["result"])
+    obj.run(
+        pytorch_code,
+        ["result"],
+        unsupport=True,
+        reason="The parameter sampler not support.",
+    )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->

https://github.com/PaddlePaddle/community/blob/master/hackathon/hackathon_5th/%E3%80%90PaddlePaddle%20Hackathon%205th%E3%80%91%E5%BC%80%E6%BA%90%E8%B4%A1%E7%8C%AE%E4%B8%AA%E4%BA%BA%E6%8C%91%E6%88%98%E8%B5%9B%E6%A1%86%E6%9E%B6%E5%BC%80%E5%8F%91%E4%BB%BB%E5%8A%A1%E5%90%88%E9%9B%86.md#no43%E4%B8%BApaddle%E4%BB%A3%E7%A0%81%E8%BD%AC%E6%8D%A2%E5%B7%A5%E5%85%B7%E6%96%B0%E5%A2%9Eapi%E8%BD%AC%E6%8D%A2%E8%A7%84%E5%88%99
API转换21-41

文档PR https://github.com/PaddlePaddle/docs/pull/6280

paddle.nn.CTCLoss	torch和paddle结果不一致，文档说明对输入有softmax计算
https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/nn/CTCLoss_cn.html#ctcloss
![image](https://github.com/PaddlePaddle/PaConvert/assets/4617245/2143a093-0865-4718-aa13-ea55df157b0b)

### PR APIs
<!-- APIs what you've done -->
```bash
21	torch.broadcast_tensors	paddle.broadcast_tensors	已有文档验证无误
22	torch.broadcast_shapes	paddle.broadcast_shape	已有文档验证无误
23	torch.can_cast		功能缺失
24	torch.utils.data.DataLoader	paddle.io.DataLoader	已有文档验证无误
25	torch.nn.Threshold	paddle.nn.ThresholdedReLU	已有文档和单测，paddle不支持 value 参数，value参数在torch中为必填
26	torch.nn.functional.threshold	paddle.nn.functional.thresholded_relu	已有文档和单测，paddle不支持 value 参数，value参数在torch中为必填
27	torch.nn.Transformer	paddle.nn.Transformer	已有文档验证无误
28	torch.nn.TransformerEncoder	paddle.nn.TransformerEncoder	已有文档验证无误
29	torch.nn.TransformerEncoderLayer	paddle.nn.TransformerEncoderLayer	已有文档验证无误
30	torch.iinfo	paddle.iinfo		增加文档和单测
31	torch.finfo	paddle.finfo	增加文档和单测
32	torch.nn.CTCLoss	paddle.nn.CTCLoss	paddle, torch计算结果不一致，不确定是否设置功能缺失
33	torch.nn.functional.ctc_loss	paddle.nn.functional.ctc_loss	同 torch.nn.CTCLoss
34	torch.nn.PoissonNLLLoss	paddle.nn.PoissonNLLLoss		文档中eps参数名修改epsilon
35	torch.nn.GaussianNLLLoss	paddle.nn.GaussianNLLLoss		已有文档验证无误
36	torch.nn.MultiLabelMarginLoss			功能缺失，文档有误paddle.nn.MultiLabelSoftMarginLoss不能匹配
37	torch.nn.functional.multilabel_margin_loss	paddle.nn.functional.multi_label_soft_margin_loss	同 torch.nn.MultiLabelMarginLoss
38	torch.nn.SmoothL1Loss	paddle.nn.SmoothL1Loss	beta参数不为1.0时不支持，paddle.nn.SmoothL1Loss实际是对应torch.nn.HuberLoss
39	torch.nn.MultiLabelSoftMarginLoss	paddle.nn.MultiLabelSoftMarginLoss	已有文档验证无误
40	torch.nn.MultiMarginLoss	paddle.nn.MultiMarginLoss		已有文档验证无误
41	torch.nn.functional.triplet_margin_loss	paddle.nn.functional.triplet_margin_loss	已有文档验证无误

```
