### PR TITLE
fix_dtype

### DIFF
--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -13823,8 +13823,8 @@
     ]
   },
   "torch.set_default_tensor_type": {
+    "Matcher": "GenericMatcher",
     "paddle_api": "paddle.set_default_dtype",
-    "Matcher": "SetDefaultTensorTypeMatcher",
     "args_list": [
       "d"
     ]

--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -13822,6 +13822,13 @@
       "d"
     ]
   },
+  "torch.set_default_tensor_type": {
+    "paddle_api": "paddle.set_default_dtype",
+    "Matcher": "SetDefaultTensorTypeMatcher",
+    "args_list": [
+      "d"
+    ]
+  },
   "torch.set_grad_enabled": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.set_grad_enabled",

--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -5,19 +5,19 @@
   },
   "torch.BoolTensor": {
     "Matcher": "TensorMatcher",
-    "paddle_api": "paddle.Tensor"
+    "paddle_api": "paddle.bool"
   },
   "torch.ByteTensor": {
     "Matcher": "TensorMatcher",
-    "paddle_api": "paddle.Tensor"
+    "paddle_api": "paddle.uint8"
   },
   "torch.DoubleTensor": {
     "Matcher": "TensorMatcher",
-    "paddle_api": "paddle.Tensor"
+    "paddle_api": "paddle.float64"
   },
   "torch.FloatTensor": {
     "Matcher": "TensorMatcher",
-    "paddle_api": "paddle.Tensor"
+    "paddle_api": "paddle.float32"
   },
   "torch.Generator": {
     "Matcher": "GeneratorMatcher",
@@ -28,19 +28,19 @@
   },
   "torch.HalfTensor": {
     "Matcher": "TensorMatcher",
-    "paddle_api": "paddle.Tensor"
+    "paddle_api": "paddle.float16"
   },
   "torch.IntTensor": {
     "Matcher": "TensorMatcher",
-    "paddle_api": "paddle.Tensor"
+    "paddle_api": "paddle.int32"
   },
   "torch.LongTensor": {
     "Matcher": "TensorMatcher",
-    "paddle_api": "paddle.Tensor"
+    "paddle_api": "paddle.int64"
   },
   "torch.ShortTensor": {
     "Matcher": "TensorMatcher",
-    "paddle_api": "paddle.Tensor"
+    "paddle_api": "paddle.int16"
   },
   "torch.Size": {
     "Matcher": "SizeMatcher",
@@ -4823,15 +4823,15 @@
   "torch.ctc_loss": {},
   "torch.cuda.BoolTensor": {
     "Matcher": "TensorMatcher",
-    "paddle_api": "paddle.Tensor"
+    "paddle_api": "paddle.bool"
   },
   "torch.cuda.ByteTensor": {
     "Matcher": "TensorMatcher",
-    "paddle_api": "paddle.Tensor"
+    "paddle_api": "paddle.uint8"
   },
   "torch.cuda.DoubleTensor": {
     "Matcher": "TensorMatcher",
-    "paddle_api": "paddle.Tensor"
+    "paddle_api": "paddle.float64"
   },
   "torch.cuda.Event": {
     "Matcher": "GenericMatcher",
@@ -4845,23 +4845,23 @@
   },
   "torch.cuda.FloatTensor": {
     "Matcher": "TensorMatcher",
-    "paddle_api": "paddle.Tensor"
+    "paddle_api": "paddle.float32"
   },
   "torch.cuda.HalfTensor": {
     "Matcher": "TensorMatcher",
-    "paddle_api": "paddle.Tensor"
+    "paddle_api": "paddle.float16"
   },
   "torch.cuda.IntTensor": {
     "Matcher": "TensorMatcher",
-    "paddle_api": "paddle.Tensor"
+    "paddle_api": "paddle.int32"
   },
   "torch.cuda.LongTensor": {
     "Matcher": "TensorMatcher",
-    "paddle_api": "paddle.Tensor"
+    "paddle_api": "paddle.int64"
   },
   "torch.cuda.ShortTensor": {
     "Matcher": "TensorMatcher",
-    "paddle_api": "paddle.Tensor"
+    "paddle_api": "paddle.int16"
   },
   "torch.cuda.Stream": {
     "Matcher": "CudaStreamMatcher",

--- a/paconvert/api_matcher.py
+++ b/paconvert/api_matcher.py
@@ -1372,7 +1372,8 @@ class TorchTensorMatcher(BaseMatcher):
 
         if "device" in kwargs:
             kwargs["place"] = kwargs.pop("device")
-
+            if kwargs["place"] == '"""cuda"""':
+                kwargs["place"] = '"""gpu"""'
         if "requires_grad" in kwargs:
             kwargs["stop_gradient"] = "not " + kwargs.pop("requires_grad").strip("()")
 

--- a/paconvert/api_matcher.py
+++ b/paconvert/api_matcher.py
@@ -1649,6 +1649,19 @@ class SetPrintOptionsMatcher(BaseMatcher):
         return GenericMatcher.generate_code(self, kwargs)
 
 
+class SetDefaultTensorTypeMatcher(BaseMatcher):
+    def generate_code(self, kwargs):
+        dtype_dict = {
+            '"""torch.DoubleTensor"""': "paddle.float64",
+            '"""torch.FloatTensor"""': "paddle.float32",
+            '"""torch.HalfTensor"""': "paddle.float16",
+        }
+        if kwargs["d"] in dtype_dict:
+            kwargs["d"] = dtype_dict[kwargs["d"]]
+        code = "{}({})".format(self.get_paddle_api(), kwargs["d"])
+        return code
+
+
 class RandLikeMatcher(BaseMatcher):
     def generate_code(self, kwargs):
         stop_gradient_v = None

--- a/paconvert/api_matcher.py
+++ b/paconvert/api_matcher.py
@@ -1652,13 +1652,6 @@ class SetPrintOptionsMatcher(BaseMatcher):
 
 class SetDefaultTensorTypeMatcher(BaseMatcher):
     def generate_code(self, kwargs):
-        dtype_dict = {
-            '"""torch.DoubleTensor"""': "paddle.float64",
-            '"""torch.FloatTensor"""': "paddle.float32",
-            '"""torch.HalfTensor"""': "paddle.float16",
-        }
-        if kwargs["d"] in dtype_dict:
-            kwargs["d"] = dtype_dict[kwargs["d"]]
         code = "{}({})".format(self.get_paddle_api(), kwargs["d"])
         return code
 

--- a/paconvert/api_matcher.py
+++ b/paconvert/api_matcher.py
@@ -1650,12 +1650,6 @@ class SetPrintOptionsMatcher(BaseMatcher):
         return GenericMatcher.generate_code(self, kwargs)
 
 
-class SetDefaultTensorTypeMatcher(BaseMatcher):
-    def generate_code(self, kwargs):
-        code = "{}({})".format(self.get_paddle_api(), kwargs["d"])
-        return code
-
-
 class RandLikeMatcher(BaseMatcher):
     def generate_code(self, kwargs):
         stop_gradient_v = None

--- a/tests/code_library/code_case/paddle_code/api_paddle_Tensor2Float.py
+++ b/tests/code_library/code_case/paddle_code/api_paddle_Tensor2Float.py
@@ -2,7 +2,7 @@ import paddle
 print('#########################case1#########################')
 
 
-def a(x: paddle.Tensor):
+def a(x: paddle.float32):
     pass
 
 

--- a/tests/code_library/code_case/paddle_code/api_paddle_Tensor2Int.py
+++ b/tests/code_library/code_case/paddle_code/api_paddle_Tensor2Int.py
@@ -2,7 +2,7 @@ import paddle
 print('#########################case1#########################')
 
 
-def a(x: paddle.Tensor):
+def a(x: paddle.int32):
     pass
 
 

--- a/tests/code_library/code_case/paddle_code/api_paddle_Tensor2Long.py
+++ b/tests/code_library/code_case/paddle_code/api_paddle_Tensor2Long.py
@@ -2,7 +2,7 @@ import paddle
 print('#########################case1#########################')
 
 
-def a(x: paddle.Tensor):
+def a(x: paddle.int64):
     pass
 
 

--- a/tests/code_library/code_case/paddle_code/api_paddle_to_tensor.py
+++ b/tests/code_library/code_case/paddle_code/api_paddle_to_tensor.py
@@ -6,3 +6,5 @@ print('#########################case2#########################')
 flag = True
 a = paddle.to_tensor(data=paddle.to_tensor(data=[2, 3, 4]), dtype='float32',
     place=paddle.CUDAPinnedPlace(), stop_gradient=not flag)
+print('#########################case2#########################')
+a = paddle.to_tensor(data=[2, 3, 4], place='gpu')

--- a/tests/code_library/code_case/paddle_code/attribute_visit_name.py
+++ b/tests/code_library/code_case/paddle_code/attribute_visit_name.py
@@ -26,5 +26,5 @@ def func3(dtype='float32'):
 
 isinstance(x, paddle.Tensor)
 setattr(paddle.Tensor, 'add', add_func)
->>>>>>Union[transformers.generation.utils.GenerateOutput, paddle.Tensor]
+>>>>>>Union[transformers.generation.utils.GenerateOutput, paddle.int64]
 Optional[paddle.Tensor] = None

--- a/tests/code_library/code_case/torch_code/api_torch_tensor.py
+++ b/tests/code_library/code_case/torch_code/api_torch_tensor.py
@@ -34,3 +34,6 @@ a = torch.tensor(
     requires_grad=flag,
     pin_memory=True,
 )
+print("#########################case2#########################")
+# case 3:
+a = torch.tensor([2, 3, 4],device="cuda")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->
旧有转换策略的修复与完善
### PR APIs
<!-- APIs what you've done -->
类型相关API的转换策略暂时修复。TODO：对于torch.FloatTensor该映射成paddle.float还是映射成paddle.Tensor。如果作为函数参数应该映射成paddle.float更好，如果torch.FloatTensor作为类型注解转换为paddle.Tensor更好。因此后续应该对此类映射做系统修复。


