### PR TITLE
fix codestyle & support paddlenlp

### DIFF
--- a/paconvert/base.py
+++ b/paconvert/base.py
@@ -58,6 +58,7 @@ TORCH_PACKAGE_LIST = [
     "accelerate",
     "diffusers",
     "torch_xla",
+    "flash_attn",
 ]
 MAY_TORCH_PACKAGE_LIST = [
     "setuptools",

--- a/tests/code_library/code_case/paddle_code/attribute_visit_name.py
+++ b/tests/code_library/code_case/paddle_code/attribute_visit_name.py
@@ -1,4 +1,5 @@
 import paddle
+import paddlenlp
 
 
 class A(paddle.nn.Layer):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->
修复codestyle的bug和增加import_paddlenlp。
### PR APIs
<!-- APIs what you've done -->

修复codestyle的bug，经定位hook black和hook isort在头文件矫正上存在相互冲突，black会将 from x import a,b,c,d中的a,b,c,d分为4行，但isort会将a,b作为一行，c，d作为一行。因此将头文件转写为本pr的形式。此外，和import_paddle一样，增加import_paddlenlp。

