### PR TITLE
Expanded scenarios for enhanced tools

### DIFF
--- a/paconvert/converter.py
+++ b/paconvert/converter.py
@@ -249,7 +249,7 @@ class Converter:
         mark_next_line = False
         # torch.* in __doc__
         # torch.* in str
-        in_str = False  # indicate whether the previous line is in a string
+        in_str = False
         prev_include_three_quotations = (
             False  # indicate whether the previous line include three quotations
         )

--- a/paconvert/converter.py
+++ b/paconvert/converter.py
@@ -249,13 +249,17 @@ class Converter:
         mark_next_line = False
         # torch.* in __doc__
         # torch.* in str
-        in_str = False  # indicate whether the previous line is in a string
-        prev_include_three_quotations = (
-            False  # indicate whether the previous line include three quotations
-        )
+        in_str = False  # indicate the line is in a string
 
         for i, line in enumerate(lines):
-            if not in_str and not prev_include_three_quotations and i != 0:
+            if in_str:
+                if line.count('"""') % 2 != 0:
+                    in_str = False
+                continue
+            if line.count('"""') % 2 != 0:
+                in_str = True
+                continue
+            if not in_str and i != 0:
                 pre_line = re.sub(r"[\'\"]{1}[^\'\"]+[\'\"]{1}", "", lines[i - 1])
                 count_bracket += (
                     pre_line.count("(")
@@ -268,16 +272,7 @@ class Converter:
             if count_bracket != 0:
                 continue
 
-            if line.count('"""') % 2 != 0:
-                in_str = not in_str
-            if line.count('"""') > 0:
-                prev_include_three_quotations = True
-            else:
-                prev_include_three_quotations = False
-
             tmp_line = re.sub(r"[\'\"]{1}[^\'\"]+[\'\"]{1}", "", line)
-            if in_str:
-                continue
 
             if (
                 "Class Method:" in line

--- a/paconvert/converter.py
+++ b/paconvert/converter.py
@@ -249,17 +249,13 @@ class Converter:
         mark_next_line = False
         # torch.* in __doc__
         # torch.* in str
-        in_str = False  # indicate the line is in a string
+        in_str = False  # indicate whether the previous line is in a string
+        prev_include_three_quotations = (
+            False  # indicate whether the previous line include three quotations
+        )
 
         for i, line in enumerate(lines):
-            if in_str:
-                if line.count('"""') % 2 != 0:
-                    in_str = False
-                continue
-            if line.count('"""') % 2 != 0:
-                in_str = True
-                continue
-            if not in_str and i != 0:
+            if not in_str and not prev_include_three_quotations and i != 0:
                 pre_line = re.sub(r"[\'\"]{1}[^\'\"]+[\'\"]{1}", "", lines[i - 1])
                 count_bracket += (
                     pre_line.count("(")
@@ -272,7 +268,16 @@ class Converter:
             if count_bracket != 0:
                 continue
 
+            if line.count('"""') % 2 != 0:
+                in_str = not in_str
+            if line.count('"""') > 0:
+                prev_include_three_quotations = True
+            else:
+                prev_include_three_quotations = False
+
             tmp_line = re.sub(r"[\'\"]{1}[^\'\"]+[\'\"]{1}", "", line)
+            if in_str:
+                continue
 
             if (
                 "Class Method:" in line

--- a/paconvert/converter.py
+++ b/paconvert/converter.py
@@ -265,6 +265,9 @@ class Converter:
                     - pre_line.count("]")
                     - pre_line.count("}")
                 )
+            if count_bracket != 0:
+                continue
+
             if line.count('"""') % 2 != 0:
                 in_str = not in_str
             if line.count('"""') > 0:
@@ -292,8 +295,6 @@ class Converter:
 
             # model_torch.npy
             for torch_package in self.imports_map[file]["torch_packages"]:
-                if count_bracket != 0:
-                    break
                 if tmp_line.startswith("%s." % torch_package):
                     lines[i] = ">>>>>>" + line
                     break

--- a/paconvert/transformer/basic_transformer.py
+++ b/paconvert/transformer/basic_transformer.py
@@ -588,6 +588,7 @@ class BasicTransformer(BaseTransformer):
                 )
                 return node
             elif node_list == "misidentify":
+                self.torch_api_count -= 1
                 # This API usage indicate that it is not this class method
                 log_debug(
                     self.logger,

--- a/paconvert/transformer/import_transformer.py
+++ b/paconvert/transformer/import_transformer.py
@@ -243,6 +243,7 @@ class ImportTransformer(BaseTransformer):
             from torch.nn import Module
             from torch import Tensor
             from torch import float32
+            import torch.add as TorchAdd
 
             1. class A(Module):
             2. def func() -> Tensor:
@@ -254,7 +255,7 @@ class ImportTransformer(BaseTransformer):
             8. {'build_ext': BuildExtension}
             9. inputs: Optional[Tensor] = None
             10. Union[GenerateOutput, torch.LongTensor]
-            11. import torch.add as xyz  my_add = xyz（as rvalue）
+            11. my_add = TorchAdd
         """
         is_torch = False
         if isinstance(
@@ -289,9 +290,9 @@ class ImportTransformer(BaseTransformer):
         elif (
             isinstance(self.parent_node, ast.Assign)
             and isinstance(node, ast.Name)
-            and node == self.parent_node.value
+            and node == self.parent_node.value  # as rvalue
         ):
-            is_torch = True  # 11. import torch.add as xyz  my_add = xyz（as rvalue）
+            is_torch = True  # 11. my_add = TorchAdd
 
         if is_torch:
             torch_api = self.get_full_api_from_node(node)

--- a/paconvert/transformer/import_transformer.py
+++ b/paconvert/transformer/import_transformer.py
@@ -289,7 +289,6 @@ class ImportTransformer(BaseTransformer):
             is_torch = True  # 10. Union[GenerateOutput, torch.LongTensor]
         elif (
             isinstance(self.parent_node, ast.Assign)
-            and isinstance(node, ast.Name)
             and node == self.parent_node.value  # as rvalue
         ):
             is_torch = True  # 11. my_add = TorchAdd

--- a/paconvert/transformer/import_transformer.py
+++ b/paconvert/transformer/import_transformer.py
@@ -254,6 +254,7 @@ class ImportTransformer(BaseTransformer):
             8. {'build_ext': BuildExtension}
             9. inputs: Optional[Tensor] = None
             10. Union[GenerateOutput, torch.LongTensor]
+            11. import torch.add as xyz  my_add = xyz（as rvalue）
         """
         is_torch = False
         if isinstance(
@@ -285,6 +286,12 @@ class ImportTransformer(BaseTransformer):
             and isinstance(self.node_stack[-3], ast.Subscript)
         ):
             is_torch = True  # 10. Union[GenerateOutput, torch.LongTensor]
+        elif (
+            isinstance(self.parent_node, ast.Assign)
+            and isinstance(node, ast.Name)
+            and node == self.parent_node.value
+        ):
+            is_torch = True  # 11. import torch.add as xyz  my_add = xyz（as rvalue）
 
         if is_torch:
             torch_api = self.get_full_api_from_node(node)

--- a/tests/code_library/code_case/__init__.py
+++ b/tests/code_library/code_case/__init__.py
@@ -68,6 +68,7 @@ add_to_dict("class_method_static_call.py", "class_method_static_call.py")
 add_to_dict("import_analysis.py", "import_analysis.py")
 add_to_dict("torch_llama.py", "paddle_llama.py")
 add_to_dict("may_torch_package_list.py", "may_paddle_package_list.py")
+add_to_dict("torch_mark_unsupport.py", "paddle_mark_unsupport.py")
 
 # this part is about attribute mapping file
 

--- a/tests/code_library/code_case/paddle_code/attribute_visit_name.py
+++ b/tests/code_library/code_case/paddle_code/attribute_visit_name.py
@@ -29,3 +29,4 @@ isinstance(x, paddle.Tensor)
 setattr(paddle.Tensor, 'add', add_func)
 >>>>>>Union[transformers.generation.utils.GenerateOutput, paddle.int64]
 Optional[paddle.Tensor] = None
+my_add = paddle.add

--- a/tests/code_library/code_case/paddle_code/paddle_mark_unsupport.py
+++ b/tests/code_library/code_case/paddle_code/paddle_mark_unsupport.py
@@ -1,0 +1,32 @@
+import paddle
+print('#########################case1#########################')
+source = """
+at::Tensor sin_add(at::Tensor x, at::Tensor y) {
+    return x.sin() + y.sin();
+}
+"""
+>>>>>>torch.utils.cpp_extension.load_inline(name='inline_extension', cpp_sources=
+    [source], functions=['sin_add'])
+result = True
+print('#########################case2#########################')
+print('(Torch')
+print('#########################case3#########################')
+""" This is an non-standard example
+) """
+""" (
+    This is an non-standard example
+) """
+""" (
+    This is (an non-standard example
+) """
+print('#########################case4#########################')
+print('#########################case5#########################')
+""" This is an non-standard example) """
+source = """
+at::Tensor sin_add(at::Tensor x, at::Tensor y) {
+    return x.sin() + y.sin();
+}
+"""
+>>>>>>torch.utils.cpp_extension.load_inline(name='inline_extension', cpp_sources=
+    [source], functions=['sin_add'])
+result = True

--- a/tests/code_library/code_case/torch_code/attribute_visit_name.py
+++ b/tests/code_library/code_case/torch_code/attribute_visit_name.py
@@ -5,6 +5,7 @@ from torch import float32
 from transformers.generation.utils import GenerateOutput
 
 import torch.utils.data as data # noqa: F401
+import torch.add as TorchAdd # noqa: F401
 
 class A(Module):
     def __init__(self, data: Tensor):
@@ -32,3 +33,5 @@ setattr(Tensor, 'add', add_func)
 
 Union[GenerateOutput, torch.LongTensor]
 Optional[Tensor] = None
+
+my_add = TorchAdd

--- a/tests/code_library/code_case/torch_code/torch_mark_unsupport.py
+++ b/tests/code_library/code_case/torch_code/torch_mark_unsupport.py
@@ -1,0 +1,38 @@
+from torch.utils.cpp_extension import load_inline
+print("#########################case1#########################")
+source = """
+at::Tensor sin_add(at::Tensor x, at::Tensor y) {
+    return x.sin() + y.sin();
+}
+"""
+load_inline(
+        name='inline_extension',
+        cpp_sources=[source],
+        functions=['sin_add'])
+result = True
+print("#########################case2#########################")
+print("(Torch")
+print("#########################case3#########################")
+""" This is an non-standard example
+) """
+""" (
+    This is an non-standard example
+) """
+""" (
+    This is (an non-standard example
+) """
+print("#########################case4#########################")
+# TODO: Uncomment after merging its conversion strategy
+# code_convert_tools_from_torch_to_paddle_logits_processor = LogitsProcessorList([stop_words_logits_processor])
+print("#########################case5#########################")
+""" This is an non-standard example) """
+source = """
+at::Tensor sin_add(at::Tensor x, at::Tensor y) {
+    return x.sin() + y.sin();
+}
+"""
+load_inline(
+        name='inline_extension',
+        cpp_sources=[source],
+        functions=['sin_add'])
+result = True


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->
新增功能：
1.import as机制中对于as的别名，作为右值时，应该对其转换；而visit name函数中没有此项功能。
2.增强未转API的标记功能，对多行显示python语句只标记首行，提升transformers类API的标记准确性。
3.完善torch API总数 计数逻辑，对于误识别的类方法在总数中减1
### PR APIs
<!-- APIs what you've done -->
1.当 from xx import yy as xyz  时，当my_fun=xyz时，应该将xyz转换为xx.yy。此pr用于支持此项功能。
2.增强paddlenlp.transformers的API转换场景，转换为paddlenlp.transformers.xx 时，之前的匹配模式会因为检测到transformers前不以大小写字母和下划线开头，会匹配成功。\w匹配数字、下划线、大小写字母加上\\.匹配“.”，可以使得标记规则更鲁棒。
3.增强paddlenlp.transformers的API转换场景，由于转换代码的格式化，一行代码可能被展示为多行代码，而名字较长的paddlenlp.transformers.xx API可能会在某行开头为transformers.xx，此时如果进行标记则不正确。因此需要计算括号的个数，从而判断本行代码为单独的行，而不是上一行的续写。
4.misidentify后没有将待转换API总数-1，会多报未转换API数目。如line = "abc",x=line.split()，此时误识别，但torch_api_count会被额外加1

Note：判断一行代码是否为一个node的第一行是不好判断的。因此此处不判断是否为node的第一行，而是将全部代码看作一个整体（全部代码中的括号符一定是匹配的）。但考虑到一些不规范的标注情形，或是一些代码行内的字符串常量包含"("、")"、"["、“]”、“{”、“}”时的情形，可能会干扰标注的函数的工作。加强后的PR可以排除上述情形的干扰。




