### PR TITLE
Fix bug that api is in string

### DIFF
--- a/paconvert/converter.py
+++ b/paconvert/converter.py
@@ -248,12 +248,18 @@ class Converter:
         mark_next_line = False
         in_str = False
         for i, line in enumerate(lines):
-            # torch.* in __doc__
-            # torch.* in str
+            # """
+            # 1. torch.*
+            # """
+
             if line.count('"""') % 2 != 0:
                 in_str = not in_str
 
-            tmp_line = re.sub(r"[\'\"]{1}[^\'\"]+[\'\"]{1}", "", line)
+            # 2. "torch.*"
+            # 3. 'torch.*'
+            # just replace the string with ""
+            rm_str_line = re.sub(r"[\"]{1}[^\"]+[\"]{1}", "", line)
+            rm_str_line = re.sub(r"[\']{1}[^\']+[\']{1}", "", rm_str_line)
             if in_str:
                 continue
 
@@ -273,11 +279,11 @@ class Converter:
 
             # model_torch.npy
             for torch_package in self.imports_map[file]["torch_packages"]:
-                if tmp_line.startswith("%s." % torch_package):
+                if rm_str_line.startswith("%s." % torch_package):
                     lines[i] = ">>>>>>" + line
                     break
 
-                if re.match(r".*[^A-Za-z_]{1}%s\." % torch_package, tmp_line):
+                if re.match(r".*[^A-Za-z_]{1}%s\." % torch_package, rm_str_line):
                     lines[i] = ">>>>>>" + line
 
         return "\n".join(lines)

--- a/tests/code_library/code_case/__init__.py
+++ b/tests/code_library/code_case/__init__.py
@@ -68,6 +68,7 @@ add_to_dict("class_method_static_call.py", "class_method_static_call.py")
 add_to_dict("import_analysis.py", "import_analysis.py")
 add_to_dict("torch_llama.py", "paddle_llama.py")
 add_to_dict("may_torch_package_list.py", "may_paddle_package_list.py")
+add_to_dict("api_in_str.py", "api_in_str.py")
 
 # this part is about attribute mapping file
 

--- a/tests/code_library/code_case/paddle_code/api_in_str.py
+++ b/tests/code_library/code_case/paddle_code/api_in_str.py
@@ -1,0 +1,39 @@
+import paddle
+paddle.add
+_LOCAL_PROCESS_GROUP = None
+_MISSING_LOCAL_PG_ERROR = (
+    "Local process group is not yet created! Please use detectron2's `launch()` to start processes and initialize pytorch process group. If you need to start processes in other ways, please call comm.create_local_process_group(num_workers_per_machine) after calling torch.distributed.init_process_group()."
+    )
+_MISSING_LOCAL_PG_ERROR = (
+    'Local process group is not yet created! Please use detectron2 launch() to start processes and initialize pytorch process group. If you need to start processes in other ways, please call comm.create_local_process_group(num_workers_per_machine) after calling torch.distributed.init_process_group().'
+    )
+_MISSING_LOCAL_PG_ERROR = (
+    "Local process group is not yet created! Please use detectron2's `launch()` to start processes and initialize pytorch process group. If you need to start processes in other ways, please call comm.create_local_process_group(num_workers_per_machine) after calling torch.distributed.init_process_group()."
+    )
+_MISSING_LOCAL_PG_ERROR = (
+    'Local process group is not yet created! Please use detectron2 launch() to start processes and initialize pytorch process group. If you need to start processes in other ways, please call comm.create_local_process_group(num_workers_per_machine) after calling torch.distributed.init_process_group().'
+    )
+_MISSING_LOCAL_PG_ERROR = """
+"Local process group is not yet created! Please use detectron2's `launch()` "
+"to start processes and initialize pytorch process group. If you need to start "
+"processes in other ways, please call comm.create_local_process_group("
+"num_workers_per_machine) after calling torch.distributed.init_process_group().\"
+"""
+"""
+"Local process group is not yet created! Please use detectron2's `launch()` "
+"to start processes and initialize pytorch process group. If you need to start "
+"processes in other ways, please call comm.create_local_process_group("
+"num_workers_per_machine) after calling torch.distributed.init_process_group().\"
+"""
+_MISSING_LOCAL_PG_ERROR = """
+Local process group is not yet created! Please use detectron2's `launch()` 
+to start processes and initialize pytorch process group. If you need to start 
+processes in other ways, please call comm.create_local_process_group(
+num_workers_per_machine) after calling torch.distributed.init_process_group().
+"""
+"""
+Local process group is not yet created! Please use detectron2's `launch()` 
+to start processes and initialize pytorch process group. If you need to start 
+processes in other ways, please call comm.create_local_process_group(
+num_workers_per_machine) after calling torch.distributed.init_process_group().
+"""

--- a/tests/code_library/code_case/paddle_code/import_analysis.py
+++ b/tests/code_library/code_case/paddle_code/import_analysis.py
@@ -1,8 +1,6 @@
 import paddle
-import datasets
 from . import datasets
 from .datasets import x
-from datasets import x
 from yolov3.datasets import a
 from . import torchvision
 from .torchvision import x

--- a/tests/code_library/code_case/torch_code/api_in_str.py
+++ b/tests/code_library/code_case/torch_code/api_in_str.py
@@ -1,0 +1,54 @@
+import torch
+
+torch.add
+
+_LOCAL_PROCESS_GROUP = None
+_MISSING_LOCAL_PG_ERROR = (
+    "Local process group is not yet created! Please use detectron2's `launch()` "
+    "to start processes and initialize pytorch process group. If you need to start "
+    "processes in other ways, please call comm.create_local_process_group("
+    "num_workers_per_machine) after calling torch.distributed.init_process_group()."
+)
+
+_MISSING_LOCAL_PG_ERROR = (
+    'Local process group is not yet created! Please use detectron2 launch() '
+    'to start processes and initialize pytorch process group. If you need to start '
+    'processes in other ways, please call comm.create_local_process_group('
+    'num_workers_per_machine) after calling torch.distributed.init_process_group().'
+)
+
+_MISSING_LOCAL_PG_ERROR = (
+    "Local process group is not yet created! Please use detectron2's `launch()` to start processes and initialize pytorch process group. If you need to start processes in other ways, please call comm.create_local_process_group(num_workers_per_machine) after calling torch.distributed.init_process_group()."
+)
+
+_MISSING_LOCAL_PG_ERROR = (
+    'Local process group is not yet created! Please use detectron2 launch() to start processes and initialize pytorch process group. If you need to start processes in other ways, please call comm.create_local_process_group(num_workers_per_machine) after calling torch.distributed.init_process_group().'
+)
+
+_MISSING_LOCAL_PG_ERROR = """
+"Local process group is not yet created! Please use detectron2's `launch()` "
+"to start processes and initialize pytorch process group. If you need to start "
+"processes in other ways, please call comm.create_local_process_group("
+"num_workers_per_machine) after calling torch.distributed.init_process_group()."
+"""
+
+"""
+"Local process group is not yet created! Please use detectron2's `launch()` "
+"to start processes and initialize pytorch process group. If you need to start "
+"processes in other ways, please call comm.create_local_process_group("
+"num_workers_per_machine) after calling torch.distributed.init_process_group()."
+"""
+
+_MISSING_LOCAL_PG_ERROR = """
+Local process group is not yet created! Please use detectron2's `launch()` 
+to start processes and initialize pytorch process group. If you need to start 
+processes in other ways, please call comm.create_local_process_group(
+num_workers_per_machine) after calling torch.distributed.init_process_group().
+"""
+
+"""
+Local process group is not yet created! Please use detectron2's `launch()` 
+to start processes and initialize pytorch process group. If you need to start 
+processes in other ways, please call comm.create_local_process_group(
+num_workers_per_machine) after calling torch.distributed.init_process_group().
+"""


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->
Fix bug that api is in str

### PR APIs
<!-- APIs what you've done -->

修复API在字符串中的Bug，例如
```
"detectron2's calling torch.distributed.init_process_group()."
```
则会判断错误，将字符串中的API进行了为未转换标记
