### PR TITLE
support_distributed

### DIFF
--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -5512,7 +5512,7 @@
     "min_input_args": 2
   },
   "torch.distributed.all_gather_object": {
-    "Matcher": "GenericMatcher",
+    "Matcher": "AllGatherObjectMatcher",
     "paddle_api": "paddle.distributed.all_gather_object",
     "args_list": [
       "object_list",

--- a/paconvert/api_matcher.py
+++ b/paconvert/api_matcher.py
@@ -4236,6 +4236,27 @@ class Func2Attribute(BaseMatcher):
         return code
 
 
+class AllGatherObjectMatcher(BaseMatcher):
+    def generate_code(self, kwargs):
+        if "group" not in kwargs:
+            kwargs["group"] = None
+
+        API_TEMPLATE = textwrap.dedent(
+            """
+                {}=[]
+                {}(object_list={}, obj={}, group={})
+            """
+        )
+        return API_TEMPLATE.format(
+            kwargs["object_list"],
+            self.get_paddle_api(),
+            kwargs["object_list"],
+            kwargs["obj"],
+            kwargs["group"],
+            self.kwargs_to_str(kwargs),
+        )
+
+
 class SetUpMatcher(BaseMatcher):
     def generate_code(self, kwargs):
         is_torch_cpp_extension = False

--- a/tests/distributed/all_gather_object.py
+++ b/tests/distributed/all_gather_object.py
@@ -12,25 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import textwrap
+import common
+import torch.distributed as dist
 
-from apibase import APIBase
+common.init_env()
 
-obj = APIBase("torch.distributed.all_gather_object")
-
-
-def test_case_1():
-    pytorch_code = textwrap.dedent(
-        """
-        import torch
-        import torch.distributed as dist
-        result = None
-        if torch.cuda.is_available():
-            dist.init_process_group("nccl", init_method='tcp://127.0.0.1:23456', rank=0, world_size=3)
-            gather_objects = ["foo", 12, {1: 2}]
-            output = [None for _ in gather_objects]
-            dist.all_gather_object(output, gather_objects[dist.get_rank()])
-            result = True
-        """
-    )
-    obj.run(pytorch_code, ["result"])
+gather_objects = ["foo", 12]
+output = [None for _ in gather_objects]
+dist.all_gather_object(output, gather_objects[dist.get_rank()])
+if dist.get_rank() == 0:
+    common.dump_output(output)

--- a/tests/distributed/nn_DataParallel.py
+++ b/tests/distributed/nn_DataParallel.py
@@ -16,7 +16,7 @@ import torch
 
 common.init_env()
 
-model = torch.nn.Linear(1, 1, bias=False).cuda()
+model = torch.nn.Linear(10, 10, bias=False)
 model = torch.nn.DataParallel(model)
 print(model)
 common.dump_output("finish")

--- a/tests/distributed/run_test.sh
+++ b/tests/distributed/run_test.sh
@@ -13,6 +13,14 @@
 # limitations under the License.
 # 
 
+
+echo "Insalling develop version paddle"
+python -m pip uninstall -y paddlepaddle
+python -m pip uninstall -y paddlepaddle-gpu
+rm -rf /root/anaconda3/lib/python*/site-packages/paddlepaddle-0.0.0.dist-info/
+python -m pip install --no-cache-dir paddlepaddle-gpu==0.0.0.post118 -f https://www.paddlepaddle.org.cn/whl/linux/gpu/develop.html
+python -c "import paddle; print('paddle version information:' , paddle.__version__); commit = paddle.__git_commit__;print('paddle commit information:' , commit)"
+
 python ../../paconvert/main.py --in_dir . --out_dir /tmp/paddle --log_level "DEBUG"
 
 export CUDA_VISIBLE_DEVICES=0,1

--- a/tests/distributed/run_test.sh
+++ b/tests/distributed/run_test.sh
@@ -25,9 +25,24 @@ if [ $# -gt 0 ] ; then
     exit
 fi
 
-test_list=`ls *.py | grep -v common.py | grep -v test_dist.py`
+check_error=0
+
+failed_tests=()
+
+test_list=`ls *.py | grep -v common.py | grep -v t_dist.py`
 for item in $test_list; do
     cmd1="torchrun --nproc_per_node=2 ${item}"
     cmd2="python -m paddle.distributed.launch /tmp/paddle/${item}"
-    python t_dist.py "$cmd1" "$cmd2"
+    python t_dist.py "$cmd1" "$cmd2"; tmp_check_error=$?
+    if [ $tmp_check_error -ne 0 ]; then
+        check_error=1
+        failed_tests+=("$item")
+    fi
 done
+
+echo "Failed tests:"
+for item in $my_list; do
+    echo "$item"
+done
+echo "Exit code:" $check_error
+exit $check_error


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->
支持分布式 ci，和当前分布式单测
### PR APIs
torch中对all_gather_object对于输出的结果是采用类似于索引的方式赋值，如两卡并行环境中outlist=[None,None]，则rank=0的进程会将结果赋值给outlis[0]，但paddle中采用的是append的方式，会先后将rank=0、1的进程会将结果append给outlist。因此转换时需将outlist置空