### PR TITLE
upgrade

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -4,9 +4,9 @@ FROM registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda11.8-cudnn8.6-trt8
 RUN apt-get update && \
     apt-get install -y net-tools
 
-RUN ln -sf `which python3.9` /usr/bin/python
+RUN ln -sf `which python3.10` /usr/bin/python
 
-RUN ln -sf `which pip3.9` /usr/local/bin/pip
+RUN ln -sf `which pip3.10` /usr/local/bin/pip
 
 RUN python -m pip install astor 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->
因为主框架所有ci均使用python3.10，因此对docker环境进行统一
### PR APIs
<!-- APIs what you've done -->
```bash

```
