### PR TITLE
fix torch.load matcher

### DIFF
--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -8309,7 +8309,8 @@
       "f": "path",
       "map_location": "",
       "pickle_module": "",
-      "weights_only": ""
+      "weights_only": "",
+      "pickle_load_args": ""
     },
     "unsupport_args": [
       "mmap"
@@ -16032,7 +16033,10 @@
       "typical_p",
       "torchscript",
       "attn_implementation"
-    ]
+    ],
+    "kwargs_change": {
+      "torch_dtype": "dtype"
+    }
   },
   "transformers.StoppingCriteriaList": {
     "Matcher": "UnchangeMatcher",

--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -8293,7 +8293,7 @@
     }
   },
   "torch.load": {
-    "Matcher": "GenericMatcher",
+    "Matcher": "LoadMatcher",
     "paddle_api": "paddle.load",
     "min_input_args": 1,
     "args_list": [
@@ -8303,7 +8303,7 @@
       "*",
       "weights_only",
       "mmap",
-      "**pickle_load_args"
+      "pickle_load_args"
     ],
     "kwargs_change": {
       "f": "path",

--- a/paconvert/api_matcher.py
+++ b/paconvert/api_matcher.py
@@ -1789,23 +1789,14 @@ class TensorRequiresGrad_Matcher(BaseMatcher):
 
 class LoadMatcher(BaseMatcher):
     def generate_code(self, kwargs):
-        unsupported_params = [
-            "map_location",
-            "pickle_module",
-            "weights_only",
-            "pickle_load_args",
-        ]
-        for param in unsupported_params:
-            if param in kwargs:
-                kwargs.pop(param)
-
+        if "mmap" in kwargs:
+            return None
         API_TEMPLATE = textwrap.dedent(
             """
-            paddle.load(path={})
+            {}(path=str({}))
             """
         )
-        code = API_TEMPLATE.format(kwargs["f"])
-        return code
+        return API_TEMPLATE.format(self.get_paddle_api(), kwargs["f"])
 
 
 class TensorTypeMatcher(BaseMatcher):

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -121,3 +121,18 @@ def test_case_8():
         """
     )
     obj.run(pytorch_code, ["result"])
+
+
+def test_case_9():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        from pathlib import PosixPath
+
+        result = torch.tensor([0., 1., 2., 3., 4.])
+        torch.save(result, 'tensor.pt', pickle_protocol=4)
+        new_path = PosixPath('tensor.pt')
+        result = torch.load(new_path)
+        """
+    )
+    obj.run(pytorch_code, ["result"])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->
torch.load支持大量pathlike对象，但paddle不支持，修复之，后续框架可以增强支持的类型
### PR APIs
<!-- APIs what you've done -->
```bash

```
