### PR TITLE
Fix torch.sparse.FloatTensor

### DIFF
--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -14593,16 +14593,11 @@
       "values",
       "size",
       "*",
-      "dtype",
-      "device",
-      "requires_grad",
-      "check_invariants"
+      "device"
     ],
     "kwargs_change": {
       "size": "shape",
-      "dtype": "dtype",
-      "device": "place",
-      "check_invariants": ""
+      "device": "place"
     }
   },
   "torch.sparse.addmm": {

--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -14587,7 +14587,7 @@
   "torch.sparse.FloatTensor": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.sparse.sparse_coo_tensor",
-    "min_input_args": 2,
+    "min_input_args": 3,
     "args_list": [
       "indices",
       "values",
@@ -14597,7 +14597,7 @@
     ],
     "kwargs_change": {
       "size": "shape",
-      "device": "place"
+      "device": ""
     }
   },
   "torch.sparse.addmm": {

--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -14584,6 +14584,27 @@
       "dim": "axis"
     }
   },
+  "torch.sparse.FloatTensor": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.sparse.sparse_coo_tensor",
+    "min_input_args": 2,
+    "args_list": [
+      "indices",
+      "values",
+      "size",
+      "*",
+      "dtype",
+      "device",
+      "requires_grad",
+      "check_invariants"
+    ],
+    "kwargs_change": {
+      "size": "shape",
+      "dtype": "dtype",
+      "device": "place",
+      "check_invariants": ""
+    }
+  },
   "torch.sparse.addmm": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.sparse.addmm",

--- a/paconvert/base.py
+++ b/paconvert/base.py
@@ -197,6 +197,8 @@ class BaseTransformer(ast.NodeTransformer):
         return True
 
     def get_full_attr(self, node):
+        if "torch" not in self.imports_map[self.file]["torch_packages"]:
+            return "NonTorchClass"
         if isinstance(node, ast.Attribute):
             return self.get_full_attr(node.value) + "." + node.attr
         # x.abs() -> 'x'

--- a/paconvert/base.py
+++ b/paconvert/base.py
@@ -197,7 +197,7 @@ class BaseTransformer(ast.NodeTransformer):
         return True
 
     def get_full_attr(self, node):
-        if "torch" not in self.imports_map[self.file]["torch_packages"]:
+        if len(self.imports_map[self.file]["torch_packages"]) == 0:
             return "NonTorchClass"
         if isinstance(node, ast.Attribute):
             return self.get_full_attr(node.value) + "." + node.attr

--- a/paconvert/transformer/basic_transformer.py
+++ b/paconvert/transformer/basic_transformer.py
@@ -389,8 +389,6 @@ class BasicTransformer(BaseTransformer):
         super(BasicTransformer, self).generic_visit(node)
 
         full_attr = self.get_full_attr(node.func)
-        if full_attr in ALIAS_MAPPING:
-            full_attr = ALIAS_MAPPING[full_attr]
 
         # Torch Package Call, include torch third_party
         #   such as : torch.add(x, y) / torch.add(torch.abs(x), y)
@@ -400,6 +398,8 @@ class BasicTransformer(BaseTransformer):
                 full_attr.startswith("%s." % torch_package)
                 or full_attr in self.MAY_TORCH_METHOD_LIST
             ):
+                if full_attr in ALIAS_MAPPING:
+                    full_attr = ALIAS_MAPPING[full_attr]
                 torch_api = full_attr
                 self.torch_api_count += 1
                 log_debug(
@@ -485,10 +485,7 @@ class BasicTransformer(BaseTransformer):
 
         # Torch Class call
         #   such as : x.add(y) / x.abs().add / sgd.step() / model.to(torch.device('cuda'))
-        if (
-            "NonTorchClass" not in full_attr
-            and "torch" in self.imports_map[self.file]["torch_packages"]
-        ):
+        if "NonTorchClass" not in full_attr:
             is_tensor_api = False
             is_module_api = False
             is_optim_api = False

--- a/paconvert/transformer/basic_transformer.py
+++ b/paconvert/transformer/basic_transformer.py
@@ -389,10 +389,13 @@ class BasicTransformer(BaseTransformer):
         super(BasicTransformer, self).generic_visit(node)
 
         full_attr = self.get_full_attr(node.func)
+        if full_attr in ALIAS_MAPPING:
+            full_attr = ALIAS_MAPPING[full_attr]
 
         # Torch Package Call, include torch third_party
         #   such as : torch.add(x, y) / torch.add(torch.abs(x), y)
         for torch_package in self.imports_map[self.file]["torch_packages"]:
+
             if (
                 full_attr.startswith("%s." % torch_package)
                 or full_attr in self.MAY_TORCH_METHOD_LIST

--- a/paconvert/transformer/basic_transformer.py
+++ b/paconvert/transformer/basic_transformer.py
@@ -485,8 +485,10 @@ class BasicTransformer(BaseTransformer):
 
         # Torch Class call
         #   such as : x.add(y) / x.abs().add / sgd.step() / model.to(torch.device('cuda'))
-        if "NonTorchClass" not in full_attr:
-
+        if (
+            "NonTorchClass" not in full_attr
+            and "torch" in self.imports_map[self.file]["torch_packages"]
+        ):
             is_tensor_api = False
             is_module_api = False
             is_optim_api = False

--- a/tests/test_Tensor_transpose.py
+++ b/tests/test_Tensor_transpose.py
@@ -16,7 +16,7 @@ import textwrap
 
 from apibase import APIBase
 
-obj = APIBase("torch.Tensor.transpose")
+obj = APIBase("torch.Tensor.transpose", is_aux_api=True)
 
 
 def test_case_1():
@@ -47,6 +47,18 @@ def test_case_3():
         import torch
         a = torch.Tensor([[1.,2.], [3.,4.]])
         result = a.transpose(dim1=0, dim0=1)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.Tensor([[1.,2.], [3.,4.]])
+        list_a = [a,a]
+        result = [x.transpose(dim1=0, dim0=1) for x in list_a ]
         """
     )
     obj.run(pytorch_code, ["result"])

--- a/tests/test_sparse_FloatTensor.py
+++ b/tests/test_sparse_FloatTensor.py
@@ -61,6 +61,7 @@ def test_case_3():
     obj.run(pytorch_code, ["result"])
 
 
+# NOTE: 'device' only support "cpu".
 def test_case_4():
     pytorch_code = textwrap.dedent(
         """
@@ -68,7 +69,7 @@ def test_case_4():
         i = torch.tensor([[0, 1, 1],
                           [2, 0, 2]])
         v = torch.tensor([3, 4, 5])
-        result = torch.sparse.FloatTensor(size=[2, 4], values=v, indices=i)
+        result = torch.sparse.FloatTensor(size=[2, 4], values=v, indices=i, device = "cpu")
         result = result.to_dense()
         """
     )

--- a/tests/test_sparse_FloatTensor.py
+++ b/tests/test_sparse_FloatTensor.py
@@ -45,3 +45,31 @@ def test_case_2():
         """
     )
     obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        i = torch.tensor([[0, 1, 1],
+                          [2, 0, 2]])
+        v = torch.tensor([3, 4, 5])
+        result = torch.sparse.FloatTensor(values=v, indices=i, size=[2, 4])
+        result = result.to_dense()
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        i = torch.tensor([[0, 1, 1],
+                          [2, 0, 2]])
+        v = torch.tensor([3, 4, 5])
+        result = torch.sparse.FloatTensor(size=[2, 4], values=v, indices=i)
+        result = result.to_dense()
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_sparse_FloatTensor.py
+++ b/tests/test_sparse_FloatTensor.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.sparse.FloatTensor")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        i = torch.tensor([[0, 1, 1],
+                          [2, 0, 2]])
+        v = torch.tensor([3, 4, 5], dtype=torch.float32)
+        result = torch.sparse.FloatTensor(i, v, [2, 4])
+        result = result.to_dense()
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        i = torch.tensor([[0, 1, 1],
+                          [2, 0, 2]])
+        v = torch.tensor([3, 4, 5])
+        result = torch.sparse.FloatTensor(indices=i, values=v, size=[2, 4])
+        result = result.to_dense()
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_swapdims.py
+++ b/tests/test_swapdims.py
@@ -16,7 +16,7 @@ import textwrap
 
 from apibase import APIBase
 
-obj = APIBase("torch.swapdims")
+obj = APIBase("torch.swapdims", is_aux_api=True)
 
 
 def test_case_1():

--- a/tests/test_transpose.py
+++ b/tests/test_transpose.py
@@ -16,7 +16,7 @@ import textwrap
 
 from apibase import APIBase
 
-obj = APIBase("torch.transpose")
+obj = APIBase("torch.transpose", is_aux_api=True)
 
 
 def test_case_1():
@@ -58,6 +58,18 @@ def test_case_4():
         import torch
         a = torch.Tensor([[1.,2.], [3.,4.]])
         result = torch.transpose(dim1=1, dim0=0, input=a)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.Tensor([[1.,2.], [3.,4.]])
+        list_a = [a,a]
+        result = [torch.transpose(input=x, dim1=0, dim0=1) for x in list_a ]
         """
     )
     obj.run(pytorch_code, ["result"])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->
无

### PR APIs
<!-- APIs what you've done -->
```bash
torch.sparse.FloatTensor 新增matcher
torch.transpose 的matcher升级，支持更多python语法用法
torch.sigomid  的识别问题
*.start  的误匹配

机制修复：
1.更严格的torch 类方法识别，有的文件未导入 torch，此时不应该做类方法识别。

2.强化对别名的转换，在获取正确的full_attr时，再做一次转换

```
