### PR TITLE
【Hackathon 7th No.38】为 Paddle 代码转换工具新增 API 转换规则（第5组）

### DIFF
--- a/paconvert/api_alias_mapping.json
+++ b/paconvert/api_alias_mapping.json
@@ -49,6 +49,7 @@
   "torch.celu_": "torch.nn.functional.celu_",
   "torch.channel_shuffle": "torch.nn.functional.channel_shuffle",
   "torch.clip": "torch.clamp",
+  "torch.concatenate": "torch.cat",
   "torch.conv1d": "torch.nn.functional.conv1d",
   "torch.conv2d": "torch.nn.functional.conv2d",
   "torch.conv3d": "torch.nn.functional.conv3d",

--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -1999,9 +1999,21 @@
     "paddle_api": "paddle.Tensor.isnan",
     "min_input_args": 0
   },
-  "torch.Tensor.isneginf": {},
-  "torch.Tensor.isposinf": {},
-  "torch.Tensor.isreal": {},
+  "torch.Tensor.isneginf": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.isneginf",
+    "min_input_args": 0
+  },
+  "torch.Tensor.isposinf": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.isposinf",
+    "min_input_args": 0
+  },
+  "torch.Tensor.isreal": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.isreal",
+    "min_input_args": 0
+  },
   "torch.Tensor.istft": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.Tensor.istft",
@@ -2923,7 +2935,9 @@
       "n"
     ]
   },
-  "torch.Tensor.positive": {},
+  "torch.Tensor.positive": {
+    "Matcher": "PositiveMatcher"
+  },
   "torch.Tensor.pow": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.Tensor.pow",
@@ -3285,7 +3299,27 @@
       "reduce": "'add'"
     }
   },
-  "torch.Tensor.scatter_reduce": {},
+  "torch.Tensor.scatter_reduce": {
+    "Matcher": "ScatterReduceMatcher",
+    "paddle_api": "paddle.Tensor.put_along_axis",
+    "min_input_args": 3,
+    "args_list": [
+      "dim",
+      "index",
+      "src",
+      "reduce",
+      "*",
+      "include_self"
+    ],
+    "kwargs_change": {
+      "dim": "axis",
+      "index": "indices",
+      "src": "values"
+    },
+    "paddle_default_kwargs": {
+      "broadcast": "False"
+    }
+  },
   "torch.Tensor.scatter_reduce_": {},
   "torch.Tensor.select": {
     "Matcher": "SelectMatcher",
@@ -4869,6 +4903,17 @@
       "other": "y"
     }
   },
+  "torch.block_diag": {
+    "Matcher": "ScalableVarMatcher",
+    "paddle_api": "paddle.block_diag",
+    "min_input_args": 1,
+    "args_list": [
+      "*tensors"
+    ],
+    "kwargs_change": {
+      "tensors": "inputs"
+    }
+  },
   "torch.bmm": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.bmm",
@@ -4931,6 +4976,24 @@
     "kwargs_change": {
       "input": "x",
       "boundaries": "sorted_sequence"
+    }
+  },
+  "torch.can_cast": {
+    "Matcher": "CanCastMatcher",
+    "args_list": [
+      "from_",
+      "to"
+    ]
+  },
+  "torch.cartesian_prod": {
+    "Matcher": "CartesianProdMatcher",
+    "paddle_api": "paddle.cartesian_prod",
+    "min_input_args": 1,
+    "args_list": [
+      "*tensors"
+    ],
+    "kwargs_change": {
+      "tensors": "x"
     }
   },
   "torch.cat": {
@@ -7194,6 +7257,16 @@
       "axis": 0
     }
   },
+  "torch.float_power": {
+    "Matcher": "FloatPowerMatcher",
+    "min_input_args": 2,
+    "args_list": [
+      "input",
+      "exponent",
+      "*",
+      "out"
+    ]
+  },
   "torch.floor": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.floor",
@@ -7839,6 +7912,22 @@
       "input": "x"
     }
   },
+  "torch.isin": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.isin",
+    "min_input_args": 2,
+    "args_list": [
+      "elements",
+      "test_elements",
+      "*",
+      "assume_unique",
+      "invert"
+    ],
+    "kwargs_change": {
+      "elements": "x",
+      "test_elements": "test_x"
+    }
+  },
   "torch.isinf": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.isinf",
@@ -7853,6 +7942,43 @@
   "torch.isnan": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.isnan",
+    "min_input_args": 1,
+    "args_list": [
+      "input"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.isneginf": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.isneginf",
+    "min_input_args": 1,
+    "args_list": [
+      "input",
+      "*",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.isposinf": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.isposinf",
+    "min_input_args": 1,
+    "args_list": [
+      "input",
+      "*",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.isreal": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.isreal",
     "min_input_args": 1,
     "args_list": [
       "input"
@@ -13915,6 +14041,12 @@
       "out"
     ]
   },
+  "torch.positive": {
+    "Matcher": "PositiveMatcher",
+    "args_list": [
+      "input"
+    ]
+  },
   "torch.pow": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.pow",
@@ -14432,6 +14564,29 @@
     },
     "paddle_default_kwargs": {
       "reduce": "'add'"
+    }
+  },
+  "torch.scatter_reduce": {
+    "Matcher": "ScatterReduceMatcher",
+    "paddle_api": "paddle.put_along_axis",
+    "min_input_args": 4,
+    "args_list": [
+      "input",
+      "dim",
+      "index",
+      "src",
+      "reduce",
+      "*",
+      "include_self"
+    ],
+    "kwargs_change": {
+      "input": "arr",
+      "dim": "axis",
+      "index": "indices",
+      "src": "values"
+    },
+    "paddle_default_kwargs": {
+      "broadcast": "False"
     }
   },
   "torch.searchsorted": {

--- a/paconvert/api_matcher.py
+++ b/paconvert/api_matcher.py
@@ -1450,6 +1450,14 @@ class ScatterMatcher(BaseMatcher):
         return GenericMatcher.generate_code(self, kwargs)
 
 
+class ScatterReduceMatcher(BaseMatcher):
+    def generate_code(self, kwargs):
+        reduce_mapping = {'"""sum"""': '"add"', '"""prod"""': '"multiply"'}
+        if "reduce" in kwargs and kwargs["reduce"] in reduce_mapping:
+            kwargs["reduce"] = reduce_mapping[kwargs["reduce"]]
+        return GenericMatcher.generate_code(self, kwargs)
+
+
 class SparseSoftmaxMatcher(BaseMatcher):
     def generate_code(self, kwargs):
         code = ""
@@ -3138,6 +3146,16 @@ class Num2TensorBinaryMatcher(BaseMatcher):
         return code
 
 
+class CartesianProdMatcher(BaseMatcher):
+    def get_paddle_nodes(self, args, kwargs):
+        new_args = self.parse_args(args)
+        code = "paddle.cartesian_prod([ {}".format(new_args[0])
+        for arg in new_args[1:]:
+            code = code + ", {}".format(arg)
+        code = code + "])"
+        return ast.parse(code).body
+
+
 class Chain_MatmulMatcher(BaseMatcher):
     def get_paddle_nodes(self, args, kwargs):
         if len(args) == 1 and isinstance(args[0], ast.Starred):
@@ -4274,11 +4292,246 @@ class SymeigMatcher(BaseMatcher):
         return "paddle_aux._CONVERT_SYMEIG({})".format(self.kwargs_to_str(kwargs))
 
 
+class CanCastMatcher(BaseMatcher):
+    def generate_aux_code(self):
+        CODE_TEMPLATE = textwrap.dedent(
+            """
+            def can_cast(from_, to):
+                can_cast_dict = {
+                    paddle.bfloat16: {
+                        paddle.bfloat16: True,
+                        paddle.float16: True,
+                        paddle.float32: True,
+                        paddle.float64: True,
+                        paddle.complex64: True,
+                        paddle.complex128: True,
+                        paddle.uint8: False,
+                        paddle.int8: False,
+                        paddle.int16: False,
+                        paddle.int32: False,
+                        paddle.int64: False,
+                        paddle.bool: False
+                    },
+                    paddle.float16: {
+                        paddle.bfloat16: True,
+                        paddle.float16: True,
+                        paddle.float32: True,
+                        paddle.float64: True,
+                        paddle.complex64: True,
+                        paddle.complex128: True,
+                        paddle.uint8: False,
+                        paddle.int8: False,
+                        paddle.int16: False,
+                        paddle.int32: False,
+                        paddle.int64: False,
+                        paddle.bool: False,
+                    },
+                    paddle.float32: {
+                        paddle.bfloat16: True,
+                        paddle.float16: True,
+                        paddle.float32: True,
+                        paddle.float64: True,
+                        paddle.complex64: True,
+                        paddle.complex128: True,
+                        paddle.uint8: False,
+                        paddle.int8: False,
+                        paddle.int16: False,
+                        paddle.int32: False,
+                        paddle.int64: False,
+                        paddle.bool: False,
+                    },
+                    paddle.float64: {
+                        paddle.bfloat16: True,
+                        paddle.float16: True,
+                        paddle.float32: True,
+                        paddle.float64: True,
+                        paddle.complex64: True,
+                        paddle.complex128: True,
+                        paddle.uint8: False,
+                        paddle.int8: False,
+                        paddle.int16: False,
+                        paddle.int32: False,
+                        paddle.int64: False,
+                        paddle.bool: False,
+                    },
+                    paddle.complex64: {
+                        paddle.bfloat16: False,
+                        paddle.float16: False,
+                        paddle.float32: False,
+                        paddle.float64: False,
+                        paddle.complex64: True,
+                        paddle.complex128: True,
+                        paddle.uint8: False,
+                        paddle.int8: False,
+                        paddle.int16: False,
+                        paddle.int32: False,
+                        paddle.int64: False,
+                        paddle.bool: False,
+                    },
+                    paddle.complex128: {
+                        paddle.bfloat16: False,
+                        paddle.float16: False,
+                        paddle.float32: False,
+                        paddle.float64: False,
+                        paddle.complex64: True,
+                        paddle.complex128: True,
+                        paddle.uint8: False,
+                        paddle.int8: False,
+                        paddle.int16: False,
+                        paddle.int32: False,
+                        paddle.int64: False,
+                        paddle.bool: False,
+                    },
+                    paddle.uint8: {
+                        paddle.bfloat16: True,
+                        paddle.float16: True,
+                        paddle.float32: True,
+                        paddle.float64: True,
+                        paddle.complex64: True,
+                        paddle.complex128: True,
+                        paddle.uint8: True,
+                        paddle.int8: True,
+                        paddle.int16: True,
+                        paddle.int32: True,
+                        paddle.int64: True,
+                        paddle.bool: False,
+                    },
+                    paddle.int8: {
+                        paddle.bfloat16: True,
+                        paddle.float16: True,
+                        paddle.float32: True,
+                        paddle.float64: True,
+                        paddle.complex64: True,
+                        paddle.complex128: True,
+                        paddle.uint8: True,
+                        paddle.int8: True,
+                        paddle.int16: True,
+                        paddle.int32: True,
+                        paddle.int64: True,
+                        paddle.bool: False,
+                    },
+                    paddle.int16: {
+                        paddle.bfloat16: True,
+                        paddle.float16: True,
+                        paddle.float32: True,
+                        paddle.float64: True,
+                        paddle.complex64: True,
+                        paddle.complex128: True,
+                        paddle.uint8: True,
+                        paddle.int8: True,
+                        paddle.int16: True,
+                        paddle.int32: True,
+                        paddle.int64: True,
+                        paddle.bool: False,
+                    },
+                    paddle.int32: {
+                        paddle.bfloat16: True,
+                        paddle.float16: True,
+                        paddle.float32: True,
+                        paddle.float64: True,
+                        paddle.complex64: True,
+                        paddle.complex128: True,
+                        paddle.uint8: True,
+                        paddle.int8: True,
+                        paddle.int16: True,
+                        paddle.int32: True,
+                        paddle.int64: True,
+                        paddle.bool: False,
+                    },
+                    paddle.int64: {
+                        paddle.bfloat16: True,
+                        paddle.float16: True,
+                        paddle.float32: True,
+                        paddle.float64: True,
+                        paddle.complex64: True,
+                        paddle.complex128: True,
+                        paddle.uint8: True,
+                        paddle.int8: True,
+                        paddle.int16: True,
+                        paddle.int32: True,
+                        paddle.int64: True,
+                        paddle.bool: False,
+                    },
+                    paddle.bool: {
+                        paddle.bfloat16: True,
+                        paddle.float16: True,
+                        paddle.float32: True,
+                        paddle.float64: True,
+                        paddle.complex64: True,
+                        paddle.complex128: True,
+                        paddle.uint8: True,
+                        paddle.int8: True,
+                        paddle.int16: True,
+                        paddle.int32: True,
+                        paddle.int64: True,
+                        paddle.bool: True,
+                    }
+                }
+                return can_cast_dict[from_][to]
+            setattr(paddle, 'can_cast', can_cast)
+            """
+        )
+        return CODE_TEMPLATE
+
+    def generate_code(self, kwargs):
+        self.write_aux_code()
+        _from_dtype = kwargs["from_"][3:-3]
+        _to_dtype = kwargs["to"][3:-3]
+        code = "paddle_aux.can_cast(paddle.{}, paddle.{})".format(
+            _from_dtype, _to_dtype
+        )
+        return code
+
+
 class FloatPowerMatcher(BaseMatcher):
     def generate_code(self, kwargs):
-        return "{}.cast(paddle.float64).pow({})".format(
-            self.paddleClass, kwargs["exponent"]
+        if "input" not in kwargs:
+            return "{}.cast(paddle.float64).pow({}.cast(paddle.float64) if isinstance({}, paddle.Tensor) else {})".format(
+                self.paddleClass,
+                kwargs["exponent"],
+                kwargs["exponent"],
+                kwargs["exponent"],
+            )
+        else:
+            if "out" not in kwargs:
+                return "paddle.pow({}.cast(paddle.float64), {}.cast(paddle.float64) if isinstance({}, paddle.Tensor) else {})".format(
+                    kwargs["input"],
+                    kwargs["exponent"],
+                    kwargs["exponent"],
+                    kwargs["exponent"],
+                )
+            else:
+                return "paddle.assign(paddle.pow({}.cast(paddle.float64), {}.cast(paddle.float64) if isinstance({}, paddle.Tensor) else {}), {})".format(
+                    kwargs["input"],
+                    kwargs["exponent"],
+                    kwargs["exponent"],
+                    kwargs["exponent"],
+                    kwargs["out"],
+                )
+
+
+class PositiveMatcher(BaseMatcher):
+    def generate_code(self, kwargs):
+        API_TEMPLATE = textwrap.dedent(
+            """
+            def positive({}):
+                if {}.dtype != paddle.bool:
+                    return {}
+                else:
+                    raise RuntimeError("boolean tensors is not supported.")
+
+            positive({})
+            """
         )
+        if "input" not in kwargs:
+            code = API_TEMPLATE.format(
+                self.paddleClass, self.paddleClass, self.paddleClass, self.paddleClass
+            )
+        else:
+            code = API_TEMPLATE.format(
+                kwargs["input"], kwargs["input"], kwargs["input"], kwargs["input"]
+            )
+        return code
 
 
 class FloatPowerInplaceMatcher(BaseMatcher):

--- a/tests/test_Tensor_isneginf.py
+++ b/tests/test_Tensor_isneginf.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.isneginf")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.tensor([1, float('inf'), 2, float('-inf'), float('nan')]).isneginf()
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.tensor([1, float('inf'), 2, float('-inf'), float('nan')])
+        result = input.isneginf()
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.tensor([1, 6.9, 2])
+        result = input.isneginf()
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_Tensor_isposinf.py
+++ b/tests/test_Tensor_isposinf.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.isposinf")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.tensor([1, float('inf'), 2, float('-inf'), float('nan')]).isposinf()
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.tensor([1, float('inf'), 2, float('-inf'), float('nan')])
+        result = input.isposinf()
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.tensor([1, 6.9, 2])
+        result = input.isposinf()
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_Tensor_isreal.py
+++ b/tests/test_Tensor_isreal.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.isreal")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([1, 1+1j, 2+0j])
+        result = x.isreal()
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([-0., -2.1, 2.5])
+        result = x.isreal()
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([(-0.+1j), (-2.1+0.2j), (2.5-3.1j)])
+        result = x.isreal()
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_Tensor_positive.py
+++ b/tests/test_Tensor_positive.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.positive")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([4., 1., 1., 16.])
+        result = x.positive()
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[4., 1., 1., 16.], [5., 1., 1., 17.]])
+        result = x.positive()
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_Tensor_scatter_reduce.py
+++ b/tests/test_Tensor_scatter_reduce.py
@@ -29,12 +29,7 @@ def test_case_1():
         result = input.scatter_reduce(0, index, src, reduce="sum")
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
-    )
+    obj.run(pytorch_code, ["result"])
 
 
 def test_case_2():
@@ -47,12 +42,7 @@ def test_case_2():
         result = input.scatter_reduce(0, index, src, reduce="sum", include_self=False)
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
-    )
+    obj.run(pytorch_code, ["result"])
 
 
 def test_case_3():
@@ -65,9 +55,56 @@ def test_case_3():
         result = input.scatter_reduce(0, index, src, reduce="amax")
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        src = torch.tensor([1., 2., 3., 4., 5., 6.])
+        index = torch.tensor([0, 1, 0, 1, 2, 1])
+        input = torch.tensor([1., 2., 3., 4.])
+        result = input.scatter_reduce(0, index, src, reduce="amin")
+        """
     )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        src = torch.tensor([1., 2., 3., 4., 5., 6.])
+        index = torch.tensor([0, 1, 0, 1, 2, 1])
+        input = torch.tensor([1., 2., 3., 4.])
+        result = input.scatter_reduce(0, index, src, reduce="prod")
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_6():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        src = torch.tensor([[1., 2.],[3., 4.]])
+        index = torch.tensor([[0, 0], [0, 0]])
+        input = torch.tensor([[10., 30., 20.], [60., 40., 50.]])
+        result = input.scatter_reduce(0, index, src, reduce="sum")
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_7():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        src = torch.tensor([[1., 2.],[3., 4.]])
+        index = torch.tensor([[0, 0], [0, 0]])
+        input = torch.tensor([[10., 30., 20.], [60., 40., 50.]])
+        result = input.scatter_reduce(0, index, src, reduce="prod", include_self=False)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_block_diag.py
+++ b/tests/test_block_diag.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.block_diag")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        A = torch.tensor([[0, 1], [1, 0]])
+        B = torch.tensor([[3, 4, 5], [6, 7, 8]])
+        C = torch.tensor(7)
+        D = torch.tensor([1, 2, 3])
+        E = torch.tensor([[4], [5], [6]])
+        result = torch.block_diag(A, B, C, D, E)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        A = torch.tensor([[4], [3], [2]])
+        B = torch.tensor([7, 6, 5])
+        C = torch.tensor(1)
+        result = torch.block_diag(A, B, C)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        A = torch.tensor([[4], [3], [2]])
+        B = torch.tensor([[5, 6], [9, 1]])
+        C = torch.tensor([1, 2, 3])
+        result = torch.block_diag(A, B, C)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        A = torch.tensor([[4], [3], [2]])
+        B = torch.tensor([[5], [6]])
+        C = torch.tensor([1, 2, 3])
+        result = torch.block_diag(A, B, C)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_can_cast.py
+++ b/tests/test_can_cast.py
@@ -23,14 +23,27 @@ def test_case_1():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        x = torch.tensor([[0,1,2]])
-        y = torch.tensor([[0],[1]])
-        result = torch.can_cast(x, y)
+        result = torch.can_cast(torch.double, torch.float)
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle not support this API now",
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.can_cast(torch.float, torch.int)
+        """
     )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.can_cast(torch.complex64, torch.complex128)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_cartesian_prod.py
+++ b/tests/test_cartesian_prod.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.cartesian_prod")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([1, 2, 3])
+        b = torch.tensor([5, 6])
+        result = torch.cartesian_prod(a, b)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([1, 2, 3])
+        result = torch.cartesian_prod(a)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        tensor_a = torch.tensor([1, 2, 4, 5])
+        tensor_b = torch.tensor([5, 6])
+        result = torch.cartesian_prod(tensor_a, tensor_b)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_float_power.py
+++ b/tests/test_float_power.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.float_power")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([4, 6, 7, 1])
+        result = torch.float_power(x, 2)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([4, 6, 7, 1])
+        out = torch.zeros([4, 1], dtype=torch.double)
+        result = torch.float_power(x, 2, out=out)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([4, 6, 7, 1])
+        y = torch.tensor([2, -3, 4, -5])
+        result = torch.float_power(x, y)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([4, 6, 7, 1])
+        y = torch.tensor([2, -3, 4, -5])
+        out = torch.zeros([4, 1], dtype=torch.double)
+        result = torch.float_power(x, y, out=out)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[1, -2], [2, 5]])
+        result = torch.float_power(x, 2)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_6():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[1., -2.], [2., 5.]])
+        out = torch.zeros([2, 2], dtype=torch.double)
+        result = torch.float_power(x, 2, out=out)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_7():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[1, -2], [2, 5]])
+        y = torch.tensor([[-2, 3], [-1, 2]])
+        out = torch.zeros([2, 2], dtype=torch.double)
+        result = torch.float_power(x, y, out=out)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_isin.py
+++ b/tests/test_isin.py
@@ -27,70 +27,47 @@ def test_case_1():
         result = torch.isin(torch.tensor([[1, 2], [3, 4]]), torch.tensor([2, 3]))
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
-    )
+    obj.run(pytorch_code, ["result"])
 
 
 def test_case_2():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        result = torch.isin(elements=torch.tensor([[1, 2], [3, 4]]), test_elements=torch.tensor([2, 3]))
+        result = torch.isin(torch.tensor([[1, 2], [3, 4]]), torch.tensor([2, 3]), assume_unique=True)
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
-    )
+    obj.run(pytorch_code, ["result"])
 
 
 def test_case_3():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        result = torch.isin(test_elements=torch.tensor([2, 3]), elements=torch.tensor([[1, 2], [3, 4]]))
+        result = torch.isin(torch.tensor([[1, 2], [3, 4]]), torch.tensor([2, 3]), invert=True)
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
-    )
+    obj.run(pytorch_code, ["result"])
 
 
 def test_case_4():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        result = torch.isin(torch.tensor([[1, 2], [3, 4]]), torch.tensor([2, 3]), assume_unique=False, invert=False)
+        result = torch.isin(torch.tensor([[1, 2], [3, 4]]), torch.tensor([2, 3]), assume_unique=True, invert=True)
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
-    )
+    obj.run(pytorch_code, ["result"])
 
 
 def test_case_5():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        result = torch.isin(elements=torch.tensor([[1, 2], [3, 4]]), test_elements=torch.tensor([2, 3]),
-                            assume_unique=False, invert=False)
+        x = torch.tensor([0., 1., 2.]*20).reshape([20, 3])
+        test_x = torch.tensor([0., 1.]*20)
+        correct_result = torch.isin(x, test_x, assume_unique=False)
+        incorrect_result = torch.isin(x, test_x, assume_unique=True)
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
-    )
+    obj.run(pytorch_code, ["correct_result", "incorrect_result"])

--- a/tests/test_isneginf.py
+++ b/tests/test_isneginf.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.isneginf")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([-float('inf'), float('inf'), 1.2])
+        result = torch.isneginf(x)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        out = torch.tensor([False, False, False])
+        x = torch.tensor([-float('inf'), float('inf'), 1.2])
+        result = torch.isneginf(x, out = out)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[-float('inf'), float('inf'), 1.2, 0., 2.5],
+                        [-1.35 , -float('inf') ,  0.18, -0.33,  float('inf')],
+                        [-float('inf'), float('inf'), 1., 2., 4.]])
+        result = torch.isneginf(x)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        out = torch.zeros(3, 5, dtype=torch.bool)
+        x = torch.tensor([[-float('inf'), float('inf'), 1.2, 0., 2.5],
+                        [-1.35 , -float('inf') ,  0.18, -0.33,  float('inf')],
+                        [-float('inf'), float('inf'), 1., 2., 4.]])
+        result = torch.isneginf(x, out = out)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_isposinf.py
+++ b/tests/test_isposinf.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.isposinf")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([-float('inf'), float('inf'), 1.2])
+        result = torch.isposinf(x)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        out = torch.tensor([False, False, False])
+        x = torch.tensor([-float('inf'), float('inf'), 1.2])
+        result = torch.isposinf(x, out = out)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[-float('inf'), float('inf'), 1.2, 0., 2.5],
+                        [-1.35 , -float('inf') ,  0.18, -0.33,  float('inf')],
+                        [-float('inf'), float('inf'), 1., 2., 4.]])
+        result = torch.isposinf(x)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        out = torch.zeros(3, 5, dtype=torch.bool)
+        x = torch.tensor([[-float('inf'), float('inf'), 1.2, 0., 2.5],
+                        [-1.35 , -float('inf') ,  0.18, -0.33,  float('inf')],
+                        [-float('inf'), float('inf'), 1., 2., 4.]])
+        result = torch.isposinf(x, out = out)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_isreal.py
+++ b/tests/test_isreal.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.isreal")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.isreal(torch.tensor([1, 1+1j, 2+0j]))
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.isreal(torch.tensor([-0., -2.1, 2.5]))
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([(-0.+1j), (-2.1+0.2j), (2.5-3.1j)])
+        result = torch.isreal(x)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_positive.py
+++ b/tests/test_positive.py
@@ -24,16 +24,11 @@ def test_case_1():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        x = torch.tensor([4., 1., 1., 16.], )
+        x = torch.tensor([4., 1., 1., 16.])
         result = torch.positive(x)
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
-    )
+    obj.run(pytorch_code, ["result"])
 
 
 def test_case_2():
@@ -44,9 +39,4 @@ def test_case_2():
         result = torch.positive(t)
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
-    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_scatter_reduce.py
+++ b/tests/test_scatter_reduce.py
@@ -29,12 +29,7 @@ def test_case_1():
         result = torch.scatter_reduce(input, 0, index, src, reduce="sum")
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
-    )
+    obj.run(pytorch_code, ["result"])
 
 
 def test_case_2():
@@ -47,12 +42,7 @@ def test_case_2():
         result = torch.scatter_reduce(input, 0, index, src, reduce="sum", include_self=False)
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
-    )
+    obj.run(pytorch_code, ["result"])
 
 
 def test_case_3():
@@ -65,9 +55,56 @@ def test_case_3():
         result = torch.scatter_reduce(input, 0, index, src, reduce="amax")
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        src = torch.tensor([1., 2., 3., 4., 5., 6.])
+        index = torch.tensor([0, 1, 0, 1, 2, 1])
+        input = torch.tensor([1., 2., 3., 4.])
+        result = torch.scatter_reduce(input, 0, index, src, reduce="amin")
+        """
     )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        src = torch.tensor([1., 2., 3., 4., 5., 6.])
+        index = torch.tensor([0, 1, 0, 1, 2, 1])
+        input = torch.tensor([1., 2., 3., 4.])
+        result = torch.scatter_reduce(input, 0, index, src, reduce="prod")
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_6():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        src = torch.tensor([[1., 2.],[3., 4.]])
+        index = torch.tensor([[0, 0], [0, 0]])
+        input = torch.tensor([[10., 30., 20.], [60., 40., 50.]])
+        result = torch.scatter_reduce(input, 0, index, src, reduce="sum")
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_7():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        src = torch.tensor([[1., 2.],[3., 4.]])
+        index = torch.tensor([[0, 0], [0, 0]])
+        input = torch.tensor([[10., 30., 20.], [60., 40., 50.]])
+        result = torch.scatter_reduce(input, 0, index, src, reduce="prod", include_self=False)
+        """
+    )
+    obj.run(pytorch_code, ["result"])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->
https://github.com/PaddlePaddle/docs/pull/6885
### PR APIs
<!-- APIs what you've done -->
```bash
torch.isposinf
torch.isneginf
torch.isreal
torch.isin
torch.Tensor.isposinf
torch.Tensor.isneginf
torch.Tensor.isreal
torch.Tensor.scatter_reduce
torch.scatter_reduce
torch.positive
torch.Tensor.positive
torch.concatenate
torch.can_cast
torch.float_power
torch.block_diag
torch.cartesian_prod
```
