### PR TITLE
【Hackathon 7th No.38】为 Paddle 代码转换工具新增 API 转换规则（第5组）

### DIFF
--- a/paconvert/api_alias_mapping.json
+++ b/paconvert/api_alias_mapping.json
@@ -48,6 +48,7 @@
   "torch.bilinear": "torch.nn.functional.bilinear",
   "torch.celu_": "torch.nn.functional.celu_",
   "torch.channel_shuffle": "torch.nn.functional.channel_shuffle",
+  "torch.concatenate": "torch.cat",
   "torch.clip": "torch.clamp",
   "torch.conv1d": "torch.nn.functional.conv1d",
   "torch.conv2d": "torch.nn.functional.conv2d",

--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -1999,9 +1999,21 @@
     "paddle_api": "paddle.Tensor.isnan",
     "min_input_args": 0
   },
-  "torch.Tensor.isneginf": {},
-  "torch.Tensor.isposinf": {},
-  "torch.Tensor.isreal": {},
+  "torch.Tensor.isneginf": {
+	"Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.isneginf",
+    "min_input_args": 0
+  },
+  "torch.Tensor.isposinf": {
+	"Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.isposinf",
+    "min_input_args": 0
+  },
+  "torch.Tensor.isreal": {
+	"Matcher": "GenericMatcher",
+    "paddle_api": "paddle.Tensor.isreal",
+    "min_input_args": 0
+  },
   "torch.Tensor.istft": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.Tensor.istft",
@@ -2923,7 +2935,9 @@
       "n"
     ]
   },
-  "torch.Tensor.positive": {},
+  "torch.Tensor.positive": {
+	"Matcher": "PositiveMatcher"
+  },
   "torch.Tensor.pow": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.Tensor.pow",
@@ -3285,7 +3299,27 @@
       "reduce": "'add'"
     }
   },
-  "torch.Tensor.scatter_reduce": {},
+  "torch.Tensor.scatter_reduce": {
+	"Matcher": "ScatterReduceMatcher",
+    "paddle_api": "paddle.Tensor.put_along_axis",
+    "min_input_args": 3,
+    "args_list": [
+      "dim",
+      "index",
+      "src",
+      "reduce",
+      "*",
+      "include_self"
+    ],
+    "kwargs_change": {
+      "dim": "axis",
+      "index": "indices",
+      "src": "values"
+    },
+    "paddle_default_kwargs": {
+      "broadcast": "False"
+    }
+  },
   "torch.Tensor.scatter_reduce_": {},
   "torch.Tensor.select": {
     "Matcher": "SelectMatcher",
@@ -4885,6 +4919,17 @@
       "other": "y"
     }
   },
+  "torch.block_diag": {
+    "Matcher": "ScalableVarMatcher",
+    "paddle_api": "paddle.block_diag",
+    "min_input_args": 1,
+    "args_list": [
+      "*tensors"
+    ],
+    "kwargs_change": {
+      "tensors": "inputs"
+    }
+  },
   "torch.bmm": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.bmm",
@@ -4947,6 +4992,24 @@
     "kwargs_change": {
       "input": "x",
       "boundaries": "sorted_sequence"
+    }
+  },
+  "torch.can_cast": {
+    "Matcher": "CanCastMatcher",
+    "args_list": [
+      "from_",
+      "to"
+    ]
+  },
+  "torch.cartesian_prod": {
+    "Matcher": "CartesianProdMatcher",
+    "paddle_api": "paddle.cartesian_prod",
+    "min_input_args": 1,
+    "args_list": [
+      "*tensors"
+    ],
+    "kwargs_change": {
+      "tensors": "x"
     }
   },
   "torch.cat": {
@@ -7270,6 +7333,16 @@
       "axis": 0
     }
   },
+  "torch.float_power": {
+    "Matcher": "FloatPowerMatcher",
+    "min_input_args": 2,
+    "args_list": [
+      "input",
+      "exponent",
+      "*",
+      "out"
+    ]
+  },
   "torch.floor": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.floor",
@@ -7915,6 +7988,22 @@
       "input": "x"
     }
   },
+  "torch.isin": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.isin",
+    "min_input_args": 2,
+    "args_list": [
+      "elements",
+      "test_elements",
+      "*",
+      "assume_unique",
+      "invert"
+    ],
+    "kwargs_change": {
+      "elements": "x",
+      "test_elements": "test_x"
+    }
+  },
   "torch.isinf": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.isinf",
@@ -7929,6 +8018,43 @@
   "torch.isnan": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.isnan",
+    "min_input_args": 1,
+    "args_list": [
+      "input"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.isneginf": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.isneginf",
+    "min_input_args": 1,
+    "args_list": [
+      "input",
+      "*",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.isposinf": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.isposinf",
+    "min_input_args": 1,
+    "args_list": [
+      "input",
+      "*",
+      "out"
+    ],
+    "kwargs_change": {
+      "input": "x"
+    }
+  },
+  "torch.isreal": {
+    "Matcher": "GenericMatcher",
+    "paddle_api": "paddle.isreal",
     "min_input_args": 1,
     "args_list": [
       "input"
@@ -14002,6 +14128,12 @@
       "out"
     ]
   },
+  "torch.positive": {
+    "Matcher": "PositiveMatcher",
+    "args_list": [
+      "input"
+    ]
+  },
   "torch.pow": {
     "Matcher": "GenericMatcher",
     "paddle_api": "paddle.pow",
@@ -14519,6 +14651,29 @@
     },
     "paddle_default_kwargs": {
       "reduce": "'add'"
+    }
+  },
+  "torch.scatter_reduce": {
+    "Matcher": "ScatterReduceMatcher",
+    "paddle_api": "paddle.put_along_axis",
+    "min_input_args": 4,
+    "args_list": [
+      "input",
+      "dim",
+      "index",
+      "src",
+      "reduce",
+      "*",
+      "include_self"
+    ],
+    "kwargs_change": {
+      "input": "arr",
+      "dim": "axis",
+      "index": "indices",
+      "src": "values"
+    },
+    "paddle_default_kwargs": {
+      "broadcast": "False"
     }
   },
   "torch.searchsorted": {

--- a/tests/test_Tensor_isneginf.py
+++ b/tests/test_Tensor_isneginf.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.isneginf")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.tensor([1, float('inf'), 2, float('-inf'), float('nan')]).isneginf()
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.tensor([1, float('inf'), 2, float('-inf'), float('nan')])
+        result = input.isneginf()
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.tensor([1, 6.9, 2])
+        result = input.isneginf()
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_Tensor_isposinf.py
+++ b/tests/test_Tensor_isposinf.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.isposinf")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.tensor([1, float('inf'), 2, float('-inf'), float('nan')]).isposinf()
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.tensor([1, float('inf'), 2, float('-inf'), float('nan')])
+        result = input.isposinf()
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.tensor([1, 6.9, 2])
+        result = input.isposinf()
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_Tensor_isreal.py
+++ b/tests/test_Tensor_isreal.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.isreal")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([1, 1+1j, 2+0j])
+        result = x.isreal()
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([-0., -2.1, 2.5])
+        result = x.isreal()
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([(-0.+1j), (-2.1+0.2j), (2.5-3.1j)])
+        result = x.isreal()
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_Tensor_positive.py
+++ b/tests/test_Tensor_positive.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.Tensor.positive")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([4., 1., 1., 16.])
+        result = x.positive()
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[4., 1., 1., 16.], [5., 1., 1., 17.]])
+        result = x.positive()
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_Tensor_scatter_reduce.py
+++ b/tests/test_Tensor_scatter_reduce.py
@@ -26,7 +26,8 @@ def test_case_1():
         src = torch.tensor([1., 2., 3., 4., 5., 6.])
         index = torch.tensor([0, 1, 0, 1, 2, 1])
         input = torch.tensor([1., 2., 3., 4.])
-        result = input.scatter_reduce(0, index, src, reduce="sum")
+        type = "sum"
+        result = input.scatter_reduce(0, index, src, reduce=type)
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -39,7 +40,8 @@ def test_case_2():
         src = torch.tensor([1., 2., 3., 4., 5., 6.])
         index = torch.tensor([0, 1, 0, 1, 2, 1])
         input = torch.tensor([1., 2., 3., 4.])
-        result = input.scatter_reduce(0, index, src, reduce="sum", include_self=False)
+        re_type = "sum"
+        result = input.scatter_reduce(dim=0, index=index, src=src, reduce=re_type, include_self=False)
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -52,7 +54,7 @@ def test_case_3():
         src = torch.tensor([1., 2., 3., 4., 5., 6.])
         index = torch.tensor([0, 1, 0, 1, 2, 1])
         input = torch.tensor([1., 2., 3., 4.])
-        result = input.scatter_reduce(0, index, src, reduce="amax")
+        result = input.scatter_reduce(0, index, src, "amax")
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -91,7 +93,7 @@ def test_case_6():
         src = torch.tensor([[1., 2.],[3., 4.]])
         index = torch.tensor([[0, 0], [0, 0]])
         input = torch.tensor([[10., 30., 20.], [60., 40., 50.]])
-        result = input.scatter_reduce(0, index, src, reduce="sum")
+        result = input.scatter_reduce(index=index, src=src, reduce="sum", dim=0)
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -105,6 +107,19 @@ def test_case_7():
         index = torch.tensor([[0, 0], [0, 0]])
         input = torch.tensor([[10., 30., 20.], [60., 40., 50.]])
         result = input.scatter_reduce(0, index, src, reduce="prod", include_self=False)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+def test_case_8():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        src = torch.tensor([[1., 2.],[3., 4.]])
+        index = torch.tensor([[0, 0], [0, 0]])
+        input = torch.tensor([[10., 30., 20.], [60., 40., 50.]])
+        re_type = "prod"
+        result = input.scatter_reduce(0, index, src, re_type)
         """
     )
     obj.run(pytorch_code, ["result"])

--- a/tests/test_Tensor_scatter_reduce.py
+++ b/tests/test_Tensor_scatter_reduce.py
@@ -29,12 +29,7 @@ def test_case_1():
         result = input.scatter_reduce(0, index, src, reduce="sum")
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
-    )
+    obj.run(pytorch_code, ["result"])
 
 
 def test_case_2():
@@ -47,12 +42,7 @@ def test_case_2():
         result = input.scatter_reduce(0, index, src, reduce="sum", include_self=False)
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
-    )
+    obj.run(pytorch_code, ["result"])
 
 
 def test_case_3():
@@ -65,9 +55,56 @@ def test_case_3():
         result = input.scatter_reduce(0, index, src, reduce="amax")
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        src = torch.tensor([1., 2., 3., 4., 5., 6.])
+        index = torch.tensor([0, 1, 0, 1, 2, 1])
+        input = torch.tensor([1., 2., 3., 4.])
+        result = input.scatter_reduce(0, index, src, reduce="amin")
+        """
     )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        src = torch.tensor([1., 2., 3., 4., 5., 6.])
+        index = torch.tensor([0, 1, 0, 1, 2, 1])
+        input = torch.tensor([1., 2., 3., 4.])
+        result = input.scatter_reduce(0, index, src, reduce="prod")
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_6():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        src = torch.tensor([[1., 2.],[3., 4.]])
+        index = torch.tensor([[0, 0], [0, 0]])
+        input = torch.tensor([[10., 30., 20.], [60., 40., 50.]])
+        result = input.scatter_reduce(0, index, src, reduce="sum")
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_7():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        src = torch.tensor([[1., 2.],[3., 4.]])
+        index = torch.tensor([[0, 0], [0, 0]])
+        input = torch.tensor([[10., 30., 20.], [60., 40., 50.]])
+        result = input.scatter_reduce(0, index, src, reduce="prod", include_self=False)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_block_diag.py
+++ b/tests/test_block_diag.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.block_diag")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        A = torch.tensor([[0, 1], [1, 0]])
+        B = torch.tensor([[3, 4, 5], [6, 7, 8]])
+        C = torch.tensor(7)
+        D = torch.tensor([1, 2, 3])
+        E = torch.tensor([[4], [5], [6]])
+        result = torch.block_diag(A, B, C, D, E)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        A = torch.tensor([[4], [3], [2]])
+        B = torch.tensor([7, 6, 5])
+        C = torch.tensor(1)
+        result = torch.block_diag(A, B, C)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        A = torch.tensor([[4], [3], [2]])
+        B = torch.tensor([[5, 6], [9, 1]])
+        C = torch.tensor([1, 2, 3])
+        result = torch.block_diag(A, B, C)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        A = torch.tensor([[4], [3], [2]])
+        B = torch.tensor([[5], [6]])
+        C = torch.tensor([1, 2, 3])
+        result = torch.block_diag(A, B, C)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_block_diag.py
+++ b/tests/test_block_diag.py
@@ -41,7 +41,9 @@ def test_case_2():
         A = torch.tensor([[4], [3], [2]])
         B = torch.tensor([7, 6, 5])
         C = torch.tensor(1)
-        result = torch.block_diag(A, B, C)
+        result = torch.block_diag(torch.tensor([[4], [3], [2]]), 
+                                torch.tensor([7, 6, 5]), 
+                                torch.tensor(1))
         """
     )
     obj.run(pytorch_code, ["result"])

--- a/tests/test_can_cast.py
+++ b/tests/test_can_cast.py
@@ -23,14 +23,27 @@ def test_case_1():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        x = torch.tensor([[0,1,2]])
-        y = torch.tensor([[0],[1]])
-        result = torch.can_cast(x, y)
+        result = torch.can_cast(torch.double, torch.float)
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle not support this API now",
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.can_cast(torch.float, torch.int)
+        """
     )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.can_cast(torch.complex64, torch.complex128)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_can_cast.py
+++ b/tests/test_can_cast.py
@@ -33,7 +33,7 @@ def test_case_2():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        result = torch.can_cast(torch.float, torch.int)
+        result = torch.can_cast(from_=torch.complex64, to=torch.complex128)
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -43,7 +43,31 @@ def test_case_3():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        result = torch.can_cast(torch.complex64, torch.complex128)
+        from_type = torch.float
+        to_type = torch.int
+        result = torch.can_cast(from_type, to=to_type)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        from_type = torch.int
+        to_type = torch.bool
+        result = torch.can_cast(to=to_type, from_=from_type)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.can_cast(to=torch.bool, from_=torch.int)
         """
     )
     obj.run(pytorch_code, ["result"])

--- a/tests/test_cartesian_prod.py
+++ b/tests/test_cartesian_prod.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.cartesian_prod")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([1, 2, 3])
+        b = torch.tensor([5, 6])
+        result = torch.cartesian_prod(a, b)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([1, 2, 3])
+        result = torch.cartesian_prod(a)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        tensor_a = torch.tensor([1, 2, 4, 5])
+        tensor_b = torch.tensor([5, 6])
+        result = torch.cartesian_prod(tensor_a, tensor_b)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_cartesian_prod.py
+++ b/tests/test_cartesian_prod.py
@@ -46,9 +46,7 @@ def test_case_3():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        tensor_a = torch.tensor([1, 2, 4, 5])
-        tensor_b = torch.tensor([5, 6])
-        result = torch.cartesian_prod(tensor_a, tensor_b)
+        result = torch.cartesian_prod(torch.tensor([1, 2, 4, 5]), torch.tensor([5, 6]), torch.tensor([7]))
         """
     )
     obj.run(pytorch_code, ["result"])

--- a/tests/test_float_power.py
+++ b/tests/test_float_power.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.float_power")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([4, 6, 7, 1])
+        result = torch.float_power(x, 2)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([4, 6, 7, 1])
+        out = torch.zeros([4, 1], dtype=torch.double)
+        result = torch.float_power(x, 2, out=out)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([4, 6, 7, 1])
+        y = torch.tensor([2, -3, 4, -5])
+        result = torch.float_power(x, y)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([4, 6, 7, 1])
+        y = torch.tensor([2, -3, 4, -5])
+        out = torch.zeros([4, 1], dtype=torch.double)
+        result = torch.float_power(x, y, out=out)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[1, -2], [2, 5]])
+        result = torch.float_power(x, 2)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_6():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[1., -2.], [2., 5.]])
+        out = torch.zeros([2, 2], dtype=torch.double)
+        result = torch.float_power(x, 2, out=out)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_7():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[1, -2], [2, 5]])
+        y = torch.tensor([[-2, 3], [-1, 2]])
+        out = torch.zeros([2, 2], dtype=torch.double)
+        result = torch.float_power(x, y, out=out)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_float_power.py
+++ b/tests/test_float_power.py
@@ -35,7 +35,7 @@ def test_case_2():
         """
         import torch
         x = torch.tensor([4, 6, 7, 1])
-        out = torch.zeros([4, 1], dtype=torch.double)
+        out = torch.zeros([4], dtype=torch.double)
         result = torch.float_power(x, 2, out=out)
         """
     )
@@ -58,10 +58,8 @@ def test_case_4():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        x = torch.tensor([4, 6, 7, 1])
-        y = torch.tensor([2, -3, 4, -5])
-        out = torch.zeros([4, 1], dtype=torch.double)
-        result = torch.float_power(x, y, out=out)
+        out = torch.zeros([4], dtype=torch.double)
+        result = torch.float_power(torch.tensor([4, 6, 7, 1]), torch.tensor([2, -3, 4, -5]), out=out)
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -72,7 +70,7 @@ def test_case_5():
         """
         import torch
         x = torch.tensor([[1, -2], [2, 5]])
-        result = torch.float_power(x, 2)
+        result = torch.float_power(x, exponent=2)
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -84,7 +82,7 @@ def test_case_6():
         import torch
         x = torch.tensor([[1., -2.], [2., 5.]])
         out = torch.zeros([2, 2], dtype=torch.double)
-        result = torch.float_power(x, 2, out=out)
+        result = torch.float_power(input=x, exponent=2, out=out)
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -97,7 +95,7 @@ def test_case_7():
         x = torch.tensor([[1, -2], [2, 5]])
         y = torch.tensor([[-2, 3], [-1, 2]])
         out = torch.zeros([2, 2], dtype=torch.double)
-        result = torch.float_power(x, y, out=out)
+        result = torch.float_power(out=out, exponent=y, input=x)
         """
     )
     obj.run(pytorch_code, ["result"])

--- a/tests/test_isin.py
+++ b/tests/test_isin.py
@@ -27,70 +27,47 @@ def test_case_1():
         result = torch.isin(torch.tensor([[1, 2], [3, 4]]), torch.tensor([2, 3]))
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
-    )
+    obj.run(pytorch_code, ["result"])
 
 
 def test_case_2():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        result = torch.isin(elements=torch.tensor([[1, 2], [3, 4]]), test_elements=torch.tensor([2, 3]))
+        result = torch.isin(torch.tensor([[1, 2], [3, 4]]), torch.tensor([2, 3]), assume_unique=True)
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
-    )
+    obj.run(pytorch_code, ["result"])
 
 
 def test_case_3():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        result = torch.isin(test_elements=torch.tensor([2, 3]), elements=torch.tensor([[1, 2], [3, 4]]))
+        result = torch.isin(torch.tensor([[1, 2], [3, 4]]), torch.tensor([2, 3]), invert=True)
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
-    )
+    obj.run(pytorch_code, ["result"])
 
 
 def test_case_4():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        result = torch.isin(torch.tensor([[1, 2], [3, 4]]), torch.tensor([2, 3]), assume_unique=False, invert=False)
+        result = torch.isin(torch.tensor([[1, 2], [3, 4]]), torch.tensor([2, 3]), assume_unique=True, invert=True)
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
-    )
+    obj.run(pytorch_code, ["result"])
 
 
 def test_case_5():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        result = torch.isin(elements=torch.tensor([[1, 2], [3, 4]]), test_elements=torch.tensor([2, 3]),
-                            assume_unique=False, invert=False)
+        x = torch.tensor([0., 1., 2.]*20).reshape([20, 3])
+        test_x = torch.tensor([0., 1.]*20)
+        correct_result = torch.isin(x, test_x, assume_unique=False)
+        incorrect_result = torch.isin(x, test_x, assume_unique=True)
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
-    )
+    obj.run(pytorch_code, ["correct_result", "incorrect_result"])

--- a/tests/test_isin.py
+++ b/tests/test_isin.py
@@ -54,13 +54,25 @@ def test_case_4():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        result = torch.isin(torch.tensor([[1, 2], [3, 4]]), torch.tensor([2, 3]), assume_unique=True, invert=True)
+        result = torch.isin(elements=torch.tensor([[1, 2], [3, 4]]), test_elements=torch.tensor([2, 3]), assume_unique=True, invert=True)
         """
     )
     obj.run(pytorch_code, ["result"])
 
 
 def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        elemnts = torch.tensor([[1, 2], [3, 4]])
+        test_elemnts = torch.tensor([2, 3])
+        result = torch.isin(assume_unique=True, invert=True, test_elements=test_elemnts, elements=elemnts)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_6():
     pytorch_code = textwrap.dedent(
         """
         import torch
@@ -71,3 +83,7 @@ def test_case_5():
         """
     )
     obj.run(pytorch_code, ["correct_result", "incorrect_result"])
+
+
+if __name__ == "__main__":
+    test_case_5()

--- a/tests/test_isneginf.py
+++ b/tests/test_isneginf.py
@@ -36,7 +36,7 @@ def test_case_2():
         import torch
         out = torch.tensor([False, False, False])
         x = torch.tensor([-float('inf'), float('inf'), 1.2])
-        result = torch.isneginf(x, out = out)
+        result = torch.isneginf(input=x, out = out)
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -46,10 +46,10 @@ def test_case_3():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        x = torch.tensor([[-float('inf'), float('inf'), 1.2, 0., 2.5],
-                        [-1.35 , -float('inf') ,  0.18, -0.33,  float('inf')],
-                        [-float('inf'), float('inf'), 1., 2., 4.]])
-        result = torch.isneginf(x)
+        result = torch.isneginf(torch.tensor([[-float('inf'), float('inf'), 1.2, 0., 2.5],
+                                            [-1.35 , -float('inf') ,  0.18, -0.33,  float('inf')],
+                                            [-float('inf'), float('inf'), 1., 2., 4.]])
+                                            )
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -63,7 +63,7 @@ def test_case_4():
         x = torch.tensor([[-float('inf'), float('inf'), 1.2, 0., 2.5],
                         [-1.35 , -float('inf') ,  0.18, -0.33,  float('inf')],
                         [-float('inf'), float('inf'), 1., 2., 4.]])
-        result = torch.isneginf(x, out = out)
+        result = torch.isneginf(out = out, input=x)
         """
     )
     obj.run(pytorch_code, ["result"])

--- a/tests/test_isneginf.py
+++ b/tests/test_isneginf.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.isneginf")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([-float('inf'), float('inf'), 1.2])
+        result = torch.isneginf(x)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        out = torch.tensor([False, False, False])
+        x = torch.tensor([-float('inf'), float('inf'), 1.2])
+        result = torch.isneginf(x, out = out)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[-float('inf'), float('inf'), 1.2, 0., 2.5],
+                        [-1.35 , -float('inf') ,  0.18, -0.33,  float('inf')],
+                        [-float('inf'), float('inf'), 1., 2., 4.]])
+        result = torch.isneginf(x)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        out = torch.zeros(3, 5, dtype=torch.bool)
+        x = torch.tensor([[-float('inf'), float('inf'), 1.2, 0., 2.5],
+                        [-1.35 , -float('inf') ,  0.18, -0.33,  float('inf')],
+                        [-float('inf'), float('inf'), 1., 2., 4.]])
+        result = torch.isneginf(x, out = out)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_isposinf.py
+++ b/tests/test_isposinf.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.isposinf")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([-float('inf'), float('inf'), 1.2])
+        result = torch.isposinf(x)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        out = torch.tensor([False, False, False])
+        x = torch.tensor([-float('inf'), float('inf'), 1.2])
+        result = torch.isposinf(x, out = out)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[-float('inf'), float('inf'), 1.2, 0., 2.5],
+                        [-1.35 , -float('inf') ,  0.18, -0.33,  float('inf')],
+                        [-float('inf'), float('inf'), 1., 2., 4.]])
+        result = torch.isposinf(x)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        out = torch.zeros(3, 5, dtype=torch.bool)
+        x = torch.tensor([[-float('inf'), float('inf'), 1.2, 0., 2.5],
+                        [-1.35 , -float('inf') ,  0.18, -0.33,  float('inf')],
+                        [-float('inf'), float('inf'), 1., 2., 4.]])
+        result = torch.isposinf(x, out = out)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_isposinf.py
+++ b/tests/test_isposinf.py
@@ -36,7 +36,7 @@ def test_case_2():
         import torch
         out = torch.tensor([False, False, False])
         x = torch.tensor([-float('inf'), float('inf'), 1.2])
-        result = torch.isposinf(x, out = out)
+        result = torch.isposinf(input=x, out = out)
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -46,10 +46,10 @@ def test_case_3():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        x = torch.tensor([[-float('inf'), float('inf'), 1.2, 0., 2.5],
-                        [-1.35 , -float('inf') ,  0.18, -0.33,  float('inf')],
-                        [-float('inf'), float('inf'), 1., 2., 4.]])
-        result = torch.isposinf(x)
+        result = torch.isposinf(torch.tensor([[-float('inf'), float('inf'), 1.2, 0., 2.5],
+                                            [-1.35 , -float('inf') ,  0.18, -0.33,  float('inf')],
+                                            [-float('inf'), float('inf'), 1., 2., 4.]])
+                                            )
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -63,7 +63,7 @@ def test_case_4():
         x = torch.tensor([[-float('inf'), float('inf'), 1.2, 0., 2.5],
                         [-1.35 , -float('inf') ,  0.18, -0.33,  float('inf')],
                         [-float('inf'), float('inf'), 1., 2., 4.]])
-        result = torch.isposinf(x, out = out)
+        result = torch.isposinf(out = out, input=x)
         """
     )
     obj.run(pytorch_code, ["result"])

--- a/tests/test_isreal.py
+++ b/tests/test_isreal.py
@@ -33,7 +33,7 @@ def test_case_2():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        result = torch.isreal(torch.tensor([-0., -2.1, 2.5]))
+        result = torch.isreal(input=torch.tensor([-0., -2.1, 2.5]))
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -45,6 +45,17 @@ def test_case_3():
         import torch
         x = torch.tensor([(-0.+1j), (-2.1+0.2j), (2.5-3.1j)])
         result = torch.isreal(x)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([(-0.+1j), (-2.1+0.2j), (2.5-3.1j)])
+        result = torch.isreal(input=x)
         """
     )
     obj.run(pytorch_code, ["result"])

--- a/tests/test_isreal.py
+++ b/tests/test_isreal.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2023 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torch.isreal")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.isreal(torch.tensor([1, 1+1j, 2+0j]))
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.isreal(torch.tensor([-0., -2.1, 2.5]))
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([(-0.+1j), (-2.1+0.2j), (2.5-3.1j)])
+        result = torch.isreal(x)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_positive.py
+++ b/tests/test_positive.py
@@ -24,16 +24,11 @@ def test_case_1():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        x = torch.tensor([4., 1., 1., 16.], )
+        x = torch.tensor([4., 1., 1., 16.])
         result = torch.positive(x)
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
-    )
+    obj.run(pytorch_code, ["result"])
 
 
 def test_case_2():
@@ -44,9 +39,4 @@ def test_case_2():
         result = torch.positive(t)
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
-    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_positive.py
+++ b/tests/test_positive.py
@@ -35,8 +35,28 @@ def test_case_2():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        t = torch.tensor([[1, 2, 4, 8], [10, 20, 40, 80]])
-        result = torch.positive(t)
+        result = torch.positive(torch.tensor([[1, 2, 4, 8], [10, 20, 40, 80]]))
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[-4., 1., 1., 16.]])
+        result = torch.positive(input=x)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.positive(input=torch.tensor([[-4., 1., 1., 16.]]))
         """
     )
     obj.run(pytorch_code, ["result"])

--- a/tests/test_scatter_reduce.py
+++ b/tests/test_scatter_reduce.py
@@ -26,7 +26,8 @@ def test_case_1():
         src = torch.tensor([1., 2., 3., 4., 5., 6.])
         index = torch.tensor([0, 1, 0, 1, 2, 1])
         input = torch.tensor([1., 2., 3., 4.])
-        result = torch.scatter_reduce(input, 0, index, src, reduce="sum")
+        type = "sum"
+        result = torch.scatter_reduce(input, 0, index, src, reduce=type)
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -39,7 +40,7 @@ def test_case_2():
         src = torch.tensor([1., 2., 3., 4., 5., 6.])
         index = torch.tensor([0, 1, 0, 1, 2, 1])
         input = torch.tensor([1., 2., 3., 4.])
-        result = torch.scatter_reduce(input, 0, index, src, reduce="sum", include_self=False)
+        result = torch.scatter_reduce(input=input, dim=0, index=index, src=src, reduce="sum", include_self=False)
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -52,7 +53,7 @@ def test_case_3():
         src = torch.tensor([1., 2., 3., 4., 5., 6.])
         index = torch.tensor([0, 1, 0, 1, 2, 1])
         input = torch.tensor([1., 2., 3., 4.])
-        result = torch.scatter_reduce(input, 0, index, src, reduce="amax")
+        result = torch.scatter_reduce(input, 0, index, src, "amax")
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -78,7 +79,8 @@ def test_case_5():
         src = torch.tensor([1., 2., 3., 4., 5., 6.])
         index = torch.tensor([0, 1, 0, 1, 2, 1])
         input = torch.tensor([1., 2., 3., 4.])
-        result = torch.scatter_reduce(input, 0, index, src, reduce="prod")
+        re_type = "prod"
+        result = torch.scatter_reduce(input, 0, index, src, reduce=re_type)
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -105,6 +107,19 @@ def test_case_7():
         index = torch.tensor([[0, 0], [0, 0]])
         input = torch.tensor([[10., 30., 20.], [60., 40., 50.]])
         result = torch.scatter_reduce(input, 0, index, src, reduce="prod", include_self=False)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+def test_case_8():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        src = torch.tensor([[1., 2.],[3., 4.]])
+        index = torch.tensor([[0, 0], [0, 0]])
+        input = torch.tensor([[10., 30., 20.], [60., 40., 50.]])
+        re_type = "prod"
+        result = torch.scatter_reduce(input, 0, index, src, re_type)
         """
     )
     obj.run(pytorch_code, ["result"])

--- a/tests/test_scatter_reduce.py
+++ b/tests/test_scatter_reduce.py
@@ -29,12 +29,7 @@ def test_case_1():
         result = torch.scatter_reduce(input, 0, index, src, reduce="sum")
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
-    )
+    obj.run(pytorch_code, ["result"])
 
 
 def test_case_2():
@@ -47,12 +42,7 @@ def test_case_2():
         result = torch.scatter_reduce(input, 0, index, src, reduce="sum", include_self=False)
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
-    )
+    obj.run(pytorch_code, ["result"])
 
 
 def test_case_3():
@@ -65,9 +55,56 @@ def test_case_3():
         result = torch.scatter_reduce(input, 0, index, src, reduce="amax")
         """
     )
-    obj.run(
-        pytorch_code,
-        ["result"],
-        unsupport=True,
-        reason="paddle does not support this function temporarily",
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        src = torch.tensor([1., 2., 3., 4., 5., 6.])
+        index = torch.tensor([0, 1, 0, 1, 2, 1])
+        input = torch.tensor([1., 2., 3., 4.])
+        result = torch.scatter_reduce(input, 0, index, src, reduce="amin")
+        """
     )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        src = torch.tensor([1., 2., 3., 4., 5., 6.])
+        index = torch.tensor([0, 1, 0, 1, 2, 1])
+        input = torch.tensor([1., 2., 3., 4.])
+        result = torch.scatter_reduce(input, 0, index, src, reduce="prod")
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_6():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        src = torch.tensor([[1., 2.],[3., 4.]])
+        index = torch.tensor([[0, 0], [0, 0]])
+        input = torch.tensor([[10., 30., 20.], [60., 40., 50.]])
+        result = torch.scatter_reduce(input, 0, index, src, reduce="sum")
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_7():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        src = torch.tensor([[1., 2.],[3., 4.]])
+        index = torch.tensor([[0, 0], [0, 0]])
+        input = torch.tensor([[10., 30., 20.], [60., 40., 50.]])
+        result = torch.scatter_reduce(input, 0, index, src, reduce="prod", include_self=False)
+        """
+    )
+    obj.run(pytorch_code, ["result"])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->
https://github.com/PaddlePaddle/docs/pull/6885

### PR APIs
<!-- APIs what you've done -->
```bash
torch.isposinf
torch.isneginf
torch.isreal
torch.isin
torch.Tensor.isposinf
torch.Tensor.isneginf
torch.Tensor.isreal
torch.Tensor.scatter_reduce
torch.scatter_reduce
torch.positive
torch.Tensor.positive
torch.concatenate
torch.can_cast
torch.float_power
torch.block_diag
torch.cartesian_prod
```


ps: 如果有朋友用 ``vscode`` 修改 ``paconvert/api_mapping.json`` 和 ``paconvert/api_alias_mapping.json``，并用 ``pre-commit`` commit 时，出现 json 文件diff 全覆盖的情况，**可能** 是 pre-commit 的问题