### PR TITLE
Fix GPU CI Failures

### DIFF
--- a/tests/test_is_tensor.py
+++ b/tests/test_is_tensor.py
@@ -82,7 +82,7 @@ def test_case_6():
         """
         import torch
         a = torch.tensor([[4, 9], [23, 2]])
-        result = torch.is_tensor(obj=a)
+        result = torch.is_tensor(a)
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -97,7 +97,7 @@ def test_case_7():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        result = torch.is_tensor(obj=torch.tensor([[4, 9], [23, 2]]))
+        result = torch.is_tensor(torch.tensor([[4, 9], [23, 2]]))
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -112,7 +112,7 @@ def test_case_8():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        result = torch.is_tensor(obj=[[4, 9], [23, 2]])
+        result = torch.is_tensor([[4, 9], [23, 2]])
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -127,7 +127,7 @@ def test_case_9():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        result = torch.is_tensor(obj=(1, 0, 3, 8))
+        result = torch.is_tensor((1, 0, 3, 8))
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -142,7 +142,7 @@ def test_case_10():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        result = torch.is_tensor(obj=3)
+        result = torch.is_tensor(3)
         """
     )
     obj.run(pytorch_code, ["result"])

--- a/tests/test_set_default_dtype.py
+++ b/tests/test_set_default_dtype.py
@@ -74,7 +74,7 @@ def test_case_5():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        torch.set_default_dtype(d=torch.float64)
+        torch.set_default_dtype(torch.float64)
         result = torch.tensor([1.2, 3])
         """
     )
@@ -90,7 +90,7 @@ def test_case_6():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        torch.set_default_dtype(d=torch.float64)
+        torch.set_default_dtype(torch.float64)
         result = torch.tensor([1.2, 3j])
         """
     )
@@ -106,7 +106,7 @@ def test_case_7():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        torch.set_default_dtype(d=torch.float32)
+        torch.set_default_dtype(torch.float32)
         result = torch.tensor([1.2, 3.8])
         """
     )
@@ -122,7 +122,7 @@ def test_case_8():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        torch.set_default_dtype(d=torch.float32)
+        torch.set_default_dtype(torch.float32)
         result = torch.tensor([1.2, 3j])
         """
     )

--- a/tests/test_set_default_tensor_type.py
+++ b/tests/test_set_default_tensor_type.py
@@ -86,7 +86,7 @@ def test_case_6():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        torch.set_default_tensor_type(t="torch.FloatTensor")
+        torch.set_default_tensor_type("torch.FloatTensor")
         result = torch.tensor([1.2, 3.8])
         """
     )

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -11,3 +11,5 @@ RUN ln -sf `which pip3.10` /usr/local/bin/pip
 RUN python -m pip install astor 
 
 RUN python -m pip install -U torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+
+RUN echo "try rebuild dockerfile"

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,21 +1,21 @@
 # A image for testing PaConvert
 FROM registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda11.8-cudnn8.6-trt8.5-gcc82
 
-# RUN apt-get update && \
-    # apt-get install -y net-tools
+RUN apt-get update && \
+    apt-get install -y net-tools
 
 RUN ln -sf `which python3.10` /usr/bin/python
 
 RUN ln -sf `which pip3.10` /usr/local/bin/pip
 
-# RUN python -m pip install astor 
+RUN python -m pip install astor 
 
-# RUN python -m pip install -U torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+RUN python -m pip install -U torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
 
-# 检查Ubuntu版本
-RUN cat /etc/os-release | grep VERSION_ID
-# 获取Ubuntu版本和架构信息
-RUN export DISTRO=$(. /etc/os-release; echo $ID$VERSION_ID | sed 's/[^0-9]//g') && \
-    export ARCH=$(dpkg --print-architecture) && \
-    echo "Detected distro: $DISTRO" && \
-    echo "Detected architecture: $ARCH"
+RUN wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.1-1_all.deb && \
+    dpkg -i cuda-keyring_1.1-1_all.deb && \
+    rm cuda-keyring_1.1-1_all.deb
+
+RUN apt-get update && \
+    apt-get install -y \
+    cudnn9-cuda-11

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,16 +1,16 @@
 # A image for testing PaConvert
 FROM registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda11.8-cudnn8.6-trt8.5-gcc82
 
-RUN apt-get update && \
-    apt-get install -y net-tools
+# RUN apt-get update && \
+    # apt-get install -y net-tools
 
 RUN ln -sf `which python3.10` /usr/bin/python
 
 RUN ln -sf `which pip3.10` /usr/local/bin/pip
 
-RUN python -m pip install astor 
+# RUN python -m pip install astor 
 
-RUN python -m pip install -U torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+# RUN python -m pip install -U torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
 
 # 检查Ubuntu版本
 RUN cat /etc/os-release | grep VERSION_ID

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -12,4 +12,10 @@ RUN python -m pip install astor
 
 RUN python -m pip install -U torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
 
-RUN echo "try rebuild dockerfile"
+# 检查Ubuntu版本
+RUN cat /etc/os-release | grep VERSION_ID
+# 获取Ubuntu版本和架构信息
+RUN export DISTRO=$(. /etc/os-release; echo $ID$VERSION_ID | sed 's/[^0-9]//g') && \
+    export ARCH=$(dpkg --print-architecture) && \
+    echo "Detected distro: $DISTRO" && \
+    echo "Detected architecture: $ARCH"


### PR DESCRIPTION
### PR Docs
This pull request addresses issues in the Dockerfile by introducing cuDNN 9. 
Additionally, it modifies three test cases, `test_is_tensor.py`, `test_set_default_tensor_type.py` and `test_set_default_dtype.py` , due to API incompatibilities with Torch 2.5.

### PR APIs
The incompatibility arises because the functions `torch.is_tensor`, `torch.set_default_tensor_type` and `torch.set_default_dtype` now require positional-only arguments, meaning we cannot pass arguments using keyword syntax.
APIs:
```base
torch.is_tensor
torch.set_default_dtype
torch.set_default_tensor_type
```

Example:
```python
# Before: Using keyword arguments (not allowed in Torch 2.5)
torch.is_tensor(obj=tensor)
torch.set_default_dtype(d=torch.float32)

# After: Using positional arguments
torch.is_tensor(tensor)
torch.set_default_dtype(torch.float32)
```
