### PR TITLE
Fix `square_` not available 易用性提升

### DIFF
--- a/tests/test_Tensor_square_.py
+++ b/tests/test_Tensor_square_.py
@@ -19,8 +19,7 @@ from apibase import APIBase
 obj = APIBase("torch.Tensor.square_")
 
 
-# AttributeError: module 'paddle.base.libpaddle.eager.ops.legacy' has no attribute 'square_'
-def _test_case_1():
+def test_case_1():
     pytorch_code = textwrap.dedent(
         """
         import torch
@@ -29,3 +28,13 @@ def _test_case_1():
         """
     )
     obj.run(pytorch_code, ["x"])
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.tensor([0.2970,  1.5420, 4]).square_()
+        """
+    )
+    obj.run(pytorch_code, ["result"])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->
https://github.com/PaddlePaddle/Paddle/pull/69451
### PR APIs
<!-- APIs what you've done -->
```bash
torch.Tensor.square_
```
