### PR TITLE
fix: allow import insertion in list comprehension

### DIFF
--- a/paconvert/base.py
+++ b/paconvert/base.py
@@ -172,7 +172,7 @@ class BaseTransformer(ast.NodeTransformer):
             self.scope_insert_lines[scope_node][body] = {index: node_list}
 
     def insert_multi_node(self, node_list):
-        if len(node_list) == 0:
+        if not node_list:
             return True
 
         import_nodes = []
@@ -185,14 +185,20 @@ class BaseTransformer(ast.NodeTransformer):
             else:
                 other_nodes.append(node)
 
-        if len(import_nodes) > 0:
+        if import_nodes:
             self.record_scope((self.root, "body", 0), import_nodes)
-
-        if len(other_nodes) > 0:
-            if isinstance(self.parent_node, (ast.DictComp, ast.ListComp)):
-                return False
-            self.record_scope(self.scope_body_index(), other_nodes)
-
+            
+        if not other_nodes:
+            return True
+            
+        # allow inserting single line of code in list comprehensions
+        in_comprehension = isinstance(self.parent_node, (ast.DictComp, ast.ListComp))
+        is_single_line = len(other_nodes) == 1 and isinstance(other_nodes[0], (ast.Expr, ast.Assign))
+        
+        if in_comprehension and not is_single_line:
+            return False
+            
+        self.record_scope(self.scope_body_index(), other_nodes)
         return True
 
     def get_full_attr(self, node):

--- a/paconvert/base.py
+++ b/paconvert/base.py
@@ -187,17 +187,19 @@ class BaseTransformer(ast.NodeTransformer):
 
         if import_nodes:
             self.record_scope((self.root, "body", 0), import_nodes)
-            
+
         if not other_nodes:
             return True
-            
+
         # allow inserting single line of code in list comprehensions
         in_comprehension = isinstance(self.parent_node, (ast.DictComp, ast.ListComp))
-        is_single_line = len(other_nodes) == 1 and isinstance(other_nodes[0], (ast.Expr, ast.Assign))
-        
+        is_single_line = len(other_nodes) == 1 and isinstance(
+            other_nodes[0], (ast.Expr, ast.Assign)
+        )
+
         if in_comprehension and not is_single_line:
             return False
-            
+
         self.record_scope(self.scope_body_index(), other_nodes)
         return True
 

--- a/paconvert/base.py
+++ b/paconvert/base.py
@@ -175,9 +175,6 @@ class BaseTransformer(ast.NodeTransformer):
         if len(node_list) == 0:
             return True
 
-        if isinstance(self.parent_node, (ast.DictComp, ast.ListComp)):
-            return False
-
         import_nodes = []
         other_nodes = []
         for node in node_list:
@@ -192,6 +189,8 @@ class BaseTransformer(ast.NodeTransformer):
             self.record_scope((self.root, "body", 0), import_nodes)
 
         if len(other_nodes) > 0:
+            if isinstance(self.parent_node, (ast.DictComp, ast.ListComp)):
+                return False
             self.record_scope(self.scope_body_index(), other_nodes)
 
         return True

--- a/paconvert/base.py
+++ b/paconvert/base.py
@@ -188,12 +188,9 @@ class BaseTransformer(ast.NodeTransformer):
         if len(import_nodes) > 0:
             self.record_scope((self.root, "body", 0), import_nodes)
 
-        if len(other_nodes) > 1:
+        if len(other_nodes) > 0:
             if isinstance(self.parent_node, (ast.DictComp, ast.ListComp)):
                 return False
-            self.record_scope(self.scope_body_index(), other_nodes)
-        elif len(other_nodes) == 1:
-            # allow inserting single line of code in list comprehensions
             self.record_scope(self.scope_body_index(), other_nodes)
 
         return True


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->
Fix #521

When converting torch API calls within list/dict comprehensions, the converter failed to insert necessary auxiliary code due to scope restrictions in insert_multi_node().

This commit:
- Separates import and sys.path nodes from other nodes
- Always inserts import-related nodes at file top level
- Maintains original restrictions for non-import nodes

### PR APIs
<!-- APIs what you've done -->
```bash
insert_multi_node
```
