### PR TITLE
辅助函数最小化

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -336,7 +336,7 @@ class TransposeMatcher(BaseMatcher):
 |参数不一致|未使用不一致的用法|使用了不一致的用法|
 |其他分类||全部需要辅助代码|
 
-以 `torch.Tensor.reshape` 为例，其映射关系分类属于 **参数不一致**，是由于torch的shape即可为可变参数，也可为list/tuple，而Paddle仅支持list/tuple，因此我们只需对**可变参数**的用法 `enable_utils_code` 。
+以 `torch.Tensor.reshape` 为例，其映射关系分类属于 **参数不一致**，是由于torch的shape既可为可变参数，也可为list/tuple，而Paddle仅支持list/tuple，因此我们只需对**可变参数**的用法 `enable_utils_code` 。
 
 ```python
 class TensorReshapeMatcher(BaseMatcher):

--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -2657,7 +2657,7 @@
     ]
   },
   "torch.Tensor.max": {
-    "Matcher": "TensorMaxMinMatcher",
+    "Matcher": "TensorMaxMatcher",
     "paddle_api": "paddle.Tensor.max",
     "min_input_args": 0,
     "args_list": [
@@ -2710,7 +2710,7 @@
     ]
   },
   "torch.Tensor.min": {
-    "Matcher": "TensorMaxMinMatcher",
+    "Matcher": "TensorMinMatcher",
     "paddle_api": "paddle.Tensor.min",
     "min_input_args": 0,
     "args_list": [
@@ -9732,7 +9732,7 @@
     "min_input_args": 1
   },
   "torch.max": {
-    "Matcher": "MaxMinMatcher",
+    "Matcher": "MaxMatcher",
     "paddle_api": "paddle.max",
     "args_list": [
       "input",
@@ -9862,7 +9862,7 @@
     ]
   },
   "torch.min": {
-    "Matcher": "MaxMinMatcher",
+    "Matcher": "MinMatcher",
     "paddle_api": "paddle.min",
     "args_list": [
       "input",

--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -11236,7 +11236,7 @@
     "min_input_args": 0
   },
   "torch.nn.LogSoftmax": {
-    "Matcher": "SoftmaxMatcher",
+    "Matcher": "LogSoftmaxMatcher",
     "paddle_api": "paddle.nn.LogSoftmax",
     "min_input_args": 0,
     "args_list": [

--- a/paconvert/api_matcher.py
+++ b/paconvert/api_matcher.py
@@ -4269,6 +4269,26 @@ class SoftmaxMatcher(BaseMatcher):
                     return paddle.nn.functional.softmax(x, _get_softmax_dim(x.ndim))
                 return paddle.nn.functional.softmax(x, self._axis)
             setattr(paddle.nn.Softmax, "forward", forward)
+            """
+        )
+        return CODE_TEMPLATE
+
+    def generate_code(self, kwargs):
+        if "dim" not in kwargs or kwargs["dim"] == "None":
+            self.enable_utils_code()
+        return GenericMatcher.generate_code(self, kwargs)
+
+
+class LogSoftmaxMatcher(BaseMatcher):
+    def generate_utils_code(self):
+        CODE_TEMPLATE = textwrap.dedent(
+            """
+            def _get_softmax_dim(axis: int) -> int:
+                if axis == 0 or axis == 1 or axis == 3:
+                    ret = 0
+                else:
+                    ret = 1
+                return ret
 
             def forward(self, x):
                 if self._axis is None:

--- a/paconvert/api_matcher.py
+++ b/paconvert/api_matcher.py
@@ -536,14 +536,11 @@ class TRFMPreTrainedModelMatcher(BaseMatcher):
                     head_mask = [None] * num_hidden_layers
 
                 return head_mask
-
             setattr(paddlenlp.transformers.model_utils.PretrainedModel, "get_head_mask", get_head_mask)
 
             original_generate = paddlenlp.generation.utils.GenerationMixin.generate
-
             def generate(self, input_ids, *args, **kwargs):
                 return paddle.concat((input_ids,original_generate(self,input_ids, *args, **kwargs)[0]),axis=-1)
-
             setattr(paddlenlp.generation.utils.GenerationMixin, "generate", generate)
 
             setattr(paddlenlp.transformers.model_utils.PretrainedModel, "device", None)
@@ -553,7 +550,6 @@ class TRFMPreTrainedModelMatcher(BaseMatcher):
                     self.init_weights()
                 elif hasattr(self, "_init_weights"):
                     self._init_weights()
-
             setattr(paddlenlp.transformers.model_utils.PretrainedModel, "post_init", post_init)
             """
         )

--- a/paconvert/api_matcher.py
+++ b/paconvert/api_matcher.py
@@ -1157,46 +1157,83 @@ class PadMatcher(BaseMatcher):
         return code
 
 
-class MaxMinMatcher(BaseMatcher):
+class _MaxMinMatcherBase(BaseMatcher):
+    def get_paddle_nodes(self, args, kwargs):
+        kwargs_tmp = self.parse_kwargs(kwargs)
+        if kwargs_tmp is None:
+            return None
+
+        call_maxmin = False
+        call_maximinimum = False
+
+        if "out" in kwargs_tmp:
+            kwargs_tmp.pop("out")
+
+        if len(kwargs_tmp) > 0:
+            if "input" in kwargs_tmp and len(kwargs_tmp) == 1:
+                call_maxmin = True
+            if "dim" in kwargs_tmp or ("keepdim" in kwargs_tmp):
+                call_maxmin = True
+            if "other" in kwargs_tmp:
+                call_maximinimum = True
+        else:
+            if len(args) != 2:
+                call_maxmin = True
+            elif isinstance(args[1], ast.Constant):
+                call_maxmin = True
+
+        paddle_api = self.get_paddle_api()
+
+        if call_maximinimum:
+            return self._handle_maximinimum_case(args, kwargs, paddle_api)
+        if call_maxmin:
+            return self._handle_maxmin_case(args, kwargs, paddle_api)
+
+        self.enable_utils_code()
+        self.set_paddle_api(paddle_api.replace("paddle.", ""))
+        return UnchangeMatcher.get_paddle_nodes(self, args, kwargs)
+
+    def _handle_maximinimum_case(self, args, kwargs, paddle_api):
+        self.api_mapping["args_list"] = ["input", "other", "*", "out"]
+        new_kwargs = self.parse_args_and_kwargs(args, kwargs)
+        new_kwargs["x"] = new_kwargs.pop("input")
+        new_kwargs["y"] = new_kwargs.pop("other")
+
+        paddle_api = "paddle.minimum" if "min" in paddle_api else "paddle.maximum"
+
+        if "out" in new_kwargs:
+            out_v = new_kwargs.pop("out")
+            code = f"paddle.assign({paddle_api}({self.kwargs_to_str(new_kwargs)}), {out_v})"
+        else:
+            code = f"{paddle_api}({self.kwargs_to_str(new_kwargs)})"
+
+        self.api_mapping["args_list"] = ["input", "dim", "keepdim", "*", "out"]
+        return ast.parse(code).body
+
+    def _handle_maxmin_case(self, args, kwargs, paddle_api):
+        new_kwargs = self.parse_args_and_kwargs(args, kwargs)
+        new_kwargs["x"] = new_kwargs.pop("input")
+        if "dim" in new_kwargs:
+            new_kwargs["axis"] = new_kwargs.pop("dim")
+
+        paddle_arg_api = "paddle.argmin" if "min" in paddle_api else "paddle.argmax"
+
+        if "axis" in new_kwargs:
+            if "out" in new_kwargs:
+                out_v = new_kwargs.pop("out")
+                code = f"paddle.assign({paddle_api}({self.kwargs_to_str(new_kwargs)}), {out_v}[0]), paddle.assign({paddle_arg_api}({self.kwargs_to_str(new_kwargs)}), {out_v}[1])"
+            else:
+                code = f"{paddle_api}({self.kwargs_to_str(new_kwargs)}), {paddle_arg_api}({self.kwargs_to_str(new_kwargs)})"
+        else:
+            code = f"{paddle_api}({self.kwargs_to_str(new_kwargs)})"
+
+        return ast.parse(code).body
+
+
+class MaxMatcher(_MaxMinMatcherBase):
     def generate_utils_code(self):
-        CODE_TEMPLATE = textwrap.dedent(
+        return textwrap.dedent(
             """
-            def min(*args, **kwargs):
-                if "input" in kwargs:
-                    kwargs["x"] = kwargs.pop("input")
-
-                out_v = None
-                if "out" in kwargs:
-                    out_v = kwargs.pop("out")
-
-                if "other" in kwargs:
-                    kwargs["y"] = kwargs.pop("other")
-                    ret = paddle.minimum(*args, **kwargs)
-                elif len(args)==2 and isinstance(args[1], paddle.Tensor):
-                    ret = paddle.minimum(*args, **kwargs)
-                else:
-                    if "dim" in kwargs:
-                        kwargs["axis"] = kwargs.pop("dim")
-
-                    if "axis" in kwargs or len(args) >= 2:
-                        if out_v:
-                            ret = paddle.min(*args, **kwargs), paddle.argmin(*args, **kwargs)
-                            paddle.assign(ret[0], out_v[0])
-                            paddle.assign(ret[1], out_v[1])
-                            return out_v
-                        else:
-                            ret = paddle.min(*args, **kwargs), paddle.argmin(*args, **kwargs)
-                            return ret
-                    else:
-                        ret = paddle.min(*args, **kwargs)
-                        return ret
-
-                if out_v:
-                    paddle.assign(ret, out_v)
-                    return out_v
-                else:
-                    return ret
-
             def max(*args, **kwargs):
                 if "input" in kwargs:
                     kwargs["x"] = kwargs.pop("input")
@@ -1234,100 +1271,86 @@ class MaxMinMatcher(BaseMatcher):
                     return ret
             """
         )
+
+
+class MinMatcher(_MaxMinMatcherBase):
+    def generate_utils_code(self):
+        return textwrap.dedent(
+            """
+            def min(*args, **kwargs):
+                if "input" in kwargs:
+                    kwargs["x"] = kwargs.pop("input")
+
+                out_v = None
+                if "out" in kwargs:
+                    out_v = kwargs.pop("out")
+
+                if "other" in kwargs:
+                    kwargs["y"] = kwargs.pop("other")
+                    ret = paddle.minimum(*args, **kwargs)
+                elif len(args)==2 and isinstance(args[1], paddle.Tensor):
+                    ret = paddle.minimum(*args, **kwargs)
+                else:
+                    if "dim" in kwargs:
+                        kwargs["axis"] = kwargs.pop("dim")
+
+                    if "axis" in kwargs or len(args) >= 2:
+                        if out_v:
+                            ret = paddle.min(*args, **kwargs), paddle.argmin(*args, **kwargs)
+                            paddle.assign(ret[0], out_v[0])
+                            paddle.assign(ret[1], out_v[1])
+                            return out_v
+                        else:
+                            ret = paddle.min(*args, **kwargs), paddle.argmin(*args, **kwargs)
+                            return ret
+                    else:
+                        ret = paddle.min(*args, **kwargs)
+                        return ret
+
+                if out_v:
+                    paddle.assign(ret, out_v)
+                    return out_v
+                else:
+                    return ret
+            """
+        )
+
+
+class TensorMaxMatcher(BaseMatcher):
+    def generate_utils_code(self):
+        CODE_TEMPLATE = textwrap.dedent(
+            """
+            def max_class_func(self, *args, **kwargs):
+                if "other" in kwargs:
+                    kwargs["y"] = kwargs.pop("other")
+                    ret = paddle.maximum(self, *args, **kwargs)
+                elif len(args) == 1 and isinstance(args[0], paddle.Tensor):
+                    ret = paddle.maximum(self, *args, **kwargs)
+                else:
+                    if "dim" in kwargs:
+                        kwargs["axis"] = kwargs.pop("dim")
+
+                    if "axis" in kwargs or len(args) >= 1:
+                        ret = paddle.max(self, *args, **kwargs), paddle.argmax(self, *args, **kwargs)
+                    else:
+                        ret = paddle.max(self, *args, **kwargs)
+
+                return ret
+
+            setattr(paddle.Tensor, "max", max_class_func)
+            """
+        )
         return CODE_TEMPLATE
 
-    def get_paddle_nodes(self, args, kwargs):
-        kwargs_tmp = self.parse_kwargs(kwargs)
-        if kwargs_tmp is None:
-            return None
-
-        call_maxmin = False
-        call_maximinimum = False
-
-        if "out" in kwargs_tmp:
-            kwargs_tmp.pop("out")
-
-        if len(kwargs_tmp) > 0:
-            if "input" in kwargs_tmp and len(kwargs_tmp) == 1:
-                call_maxmin = True
-            if "dim" in kwargs_tmp or ("keepdim" in kwargs_tmp):
-                call_maxmin = True
-            if "other" in kwargs_tmp:
-                call_maximinimum = True
-        else:
-            if len(args) != 2:
-                call_maxmin = True
-            elif isinstance(args[1], ast.Constant):
-                call_maxmin = True
-
-        paddle_api = self.get_paddle_api()
-
-        # the case of two Tensor
-        if call_maximinimum:
-            self.api_mapping["args_list"] = ["input", "other", "*", "out"]
-            new_kwargs = self.parse_args_and_kwargs(args, kwargs)
-            new_kwargs["x"] = new_kwargs.pop("input")
-            new_kwargs["y"] = new_kwargs.pop("other")
-
-            if "min" in paddle_api:
-                paddle_api = "paddle.minimum"
-            else:
-                paddle_api = "paddle.maximum"
-
-            if "out" in new_kwargs:
-                out_v = new_kwargs.pop("out")
-                code = "paddle.assign({}({}), {})".format(
-                    paddle_api, self.kwargs_to_str(new_kwargs), out_v
-                )
-            else:
-                code = "{}({})".format(paddle_api, self.kwargs_to_str(new_kwargs))
-
-            self.api_mapping["args_list"] = ["input", "dim", "keepdim", "*", "out"]
-            return ast.parse(code).body
-
-        # the case of one tensor
-        if call_maxmin:
-            new_kwargs = self.parse_args_and_kwargs(args, kwargs)
-            new_kwargs["x"] = new_kwargs.pop("input")
-            if "dim" in new_kwargs:
-                new_kwargs["axis"] = new_kwargs.pop("dim")
-            if "keepdim" in new_kwargs:
-                new_kwargs["keepdim"] = new_kwargs.pop("keepdim")
-
-            if "axis" in new_kwargs:
-                if "min" in paddle_api:
-                    paddle_arg_api = "paddle.argmin"
-                else:
-                    paddle_arg_api = "paddle.argmax"
-
-                if "out" in new_kwargs:
-                    out_v = new_kwargs.pop("out")
-                    code = "paddle.assign({}({}), {}[0]), paddle.assign({}({}), {}[1])".format(
-                        paddle_api,
-                        self.kwargs_to_str(new_kwargs),
-                        out_v,
-                        paddle_arg_api,
-                        self.kwargs_to_str(new_kwargs),
-                        out_v,
-                    )
-                else:
-                    code = "{}({}), {}({})".format(
-                        paddle_api,
-                        self.kwargs_to_str(new_kwargs),
-                        paddle_arg_api,
-                        self.kwargs_to_str(new_kwargs),
-                    )
-            else:
-                code = "{}({})".format(paddle_api, self.kwargs_to_str(new_kwargs))
-
-            return ast.parse(code).body
+    def generate_code(self, kwargs):
+        if len(kwargs) > 2:
+            return "misidentify"
 
         self.enable_utils_code()
-        self.set_paddle_api(paddle_api.replace("paddle.", ""))
-        return UnchangeMatcher.get_paddle_nodes(self, args, kwargs)
+        return "unchange"
 
 
-class TensorMaxMinMatcher(BaseMatcher):
+class TensorMinMatcher(BaseMatcher):
     def generate_utils_code(self):
         CODE_TEMPLATE = textwrap.dedent(
             """
@@ -1348,25 +1371,7 @@ class TensorMaxMinMatcher(BaseMatcher):
 
                 return ret
 
-            def max_class_func(self, *args, **kwargs):
-                if "other" in kwargs:
-                    kwargs["y"] = kwargs.pop("other")
-                    ret = paddle.maximum(self, *args, **kwargs)
-                elif len(args) == 1 and isinstance(args[0], paddle.Tensor):
-                    ret = paddle.maximum(self, *args, **kwargs)
-                else:
-                    if "dim" in kwargs:
-                        kwargs["axis"] = kwargs.pop("dim")
-
-                    if "axis" in kwargs or len(args) >= 1:
-                        ret = paddle.max(self, *args, **kwargs), paddle.argmax(self, *args, **kwargs)
-                    else:
-                        ret = paddle.max(self, *args, **kwargs)
-
-                return ret
-
             setattr(paddle.Tensor, "min", min_class_func)
-            setattr(paddle.Tensor, "max", max_class_func)
             """
         )
         return CODE_TEMPLATE

--- a/tests/code_library/code_case/paddle_code/paddlenlp_Qwen.py
+++ b/tests/code_library/code_case/paddle_code/paddlenlp_Qwen.py
@@ -30,14 +30,11 @@ def get_head_mask(
         head_mask = [None] * num_hidden_layers
 
     return head_mask
-
 setattr(paddlenlp.transformers.model_utils.PretrainedModel, "get_head_mask", get_head_mask)
 
 original_generate = paddlenlp.generation.utils.GenerationMixin.generate
-
 def generate(self, input_ids, *args, **kwargs):
     return paddle.concat((input_ids,original_generate(self,input_ids, *args, **kwargs)[0]),axis=-1)
-
 setattr(paddlenlp.generation.utils.GenerationMixin, "generate", generate)
 
 setattr(paddlenlp.transformers.model_utils.PretrainedModel, "device", None)
@@ -47,7 +44,6 @@ def post_init(self):
         self.init_weights()
     elif hasattr(self, "_init_weights"):
         self._init_weights()
-
 setattr(paddlenlp.transformers.model_utils.PretrainedModel, "post_init", post_init)
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->
尽可能减少辅助函数的行数，拆分成不同matcher，避免写冗余无关的代码，例如MinMaxMatcher，需要min和max各写各的辅助函数，不要冗余多写。

### PR APIs
<!-- APIs what you've done -->
```bash
MaxMinMatcher
```
