### PR TITLE
优化torch.atleast_1d/2d/3d/foreach_erfc转换规则

### DIFF
--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -5095,7 +5095,7 @@
   "torch.atleast_1d": {
     "Matcher": "AtleastMatcher",
     "paddle_api": "paddle.atleast_1d",
-    "min_input_args": 1,
+    "min_input_args": 0,
     "args_list": [
       "*tensors"
     ]
@@ -12754,7 +12754,8 @@
       "size",
       "scale_factor",
       "mode",
-      "align_corners"
+      "align_corners",
+      "recompute_scale_factor"
     ],
     "unsupport_args": [
       "recompute_scale_factor"

--- a/paconvert/base.py
+++ b/paconvert/base.py
@@ -192,8 +192,6 @@ class BaseTransformer(ast.NodeTransformer):
         for node in node_list:
             if isinstance(node, (ast.Import, ast.ImportFrom)):
                 import_nodes.append(node)
-            # python3.9: ast.unparse, now use ast.unparse
-            # python3.8: astor.to_source
             elif "sys.path" in astor.to_source(node):
                 import_nodes.append(node)
             else:

--- a/scripts/consistency_check.sh
+++ b/scripts/consistency_check.sh
@@ -163,8 +163,8 @@ if [[ "$DOWNLOAD_DATASET_IF" == "ON" ]]; then
     git clone https://github.com/allenai/primer $TORCH_PROJECT_PATH/primer
 fi
 
-# Check the grammar mechanism of the test set and other issues
-echo '**************************start converting test case********************************'
+echo '************************************************************************************'
+echo '**************************start converting code set*********************************'
 failed_projects=()
 for project in "$TORCH_PROJECT_PATH"/*; do
     if [ -d "$project" ]; then
@@ -177,14 +177,11 @@ for project in "$TORCH_PROJECT_PATH"/*; do
     fi
 done
 
-# Check if there are failed projects
 check_error1=$(( ${#failed_projects[@]} > 0 ? 1 : 0 ))
+
 echo '************************************************************************************'
-#check whether common API transfer is successful
-
-echo '**************************start converting common API case********************************'
+echo '**************************start converting common API case**************************'
 python tools/consistency/consistency_check.py;check_error2=$?
-
 
 echo '************************************************************************************'
 echo "______      _____                          _   "
@@ -200,7 +197,7 @@ if [ ${check_error1} != 0  ]; then
     echo "The following projects failed to convert:"
     printf '%s\n' "${failed_projects[@]}"
 else
-    echo "Your PR code-test-set (more than 15W+ lines) convert check passed."
+    echo "Your PR code-test-set (more than 20W+ lines) convert check passed."
 fi
 
 if [ ${check_error2} != 0  ]; then  

--- a/tests/test_atleast_1d.py
+++ b/tests/test_atleast_1d.py
@@ -48,3 +48,121 @@ def test_case_3():
         """
     )
     obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor(1)
+        result = torch.atleast_1d(x)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor(1)
+        y = torch.tensor(2)
+        z = torch.tensor(3)
+        result = torch.atleast_1d((x, y, z))
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_6():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor(1)
+        y = torch.tensor(2)
+        z = torch.tensor(3)
+        result = torch.atleast_1d([x, y, z])
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+# TODO: fix torch.atleast bug, which not support input list/tuple
+def _test_case_7():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor(1)
+        y = torch.tensor(2)
+        z = torch.tensor(3)
+        tensors = [x, y, z]
+        result = torch.atleast_1d(tensors)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+# TODO: fix torch.atleast bug, which not support input list/tuple
+def _test_case_8():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor(1)
+        y = torch.tensor(2)
+        z = torch.tensor(3)
+        tensors = (x, y, z)
+        result = torch.atleast_1d(tensors)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_9():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor(1)
+        y = torch.tensor(2)
+        z = torch.tensor(3)
+        result = torch.atleast_1d(x, y, z)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_10():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor(1)
+        y = torch.tensor(2)
+        z = torch.tensor(3)
+        tensors = (x, y, z)
+        result = torch.atleast_1d(*tensors)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_11():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor(1)
+        y = torch.tensor(2)
+        z = torch.tensor(3)
+        tensors = [x, y, z]
+        result = torch.atleast_1d(*tensors)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_12():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.atleast_1d()
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_atleast_2d.py
+++ b/tests/test_atleast_2d.py
@@ -33,7 +33,7 @@ def test_case_2():
     pytorch_code = textwrap.dedent(
         """
         import torch
-        y = torch.tensor([1.23], dtype=torch.float32)
+        y = torch.tensor([-1, -2, 3])
         result = torch.atleast_2d((torch.tensor(123, dtype=torch.int32), y))
         """
     )
@@ -45,6 +45,124 @@ def test_case_3():
         """
         import torch
         result = torch.atleast_2d([torch.tensor([-1, -2, 3]), torch.tensor([-1, -2, 3])])
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor(1)
+        result = torch.atleast_2d(x)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor(1)
+        y = torch.tensor(2)
+        z = torch.tensor(3)
+        result = torch.atleast_2d((x, y, z))
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_6():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor(1)
+        y = torch.tensor(2)
+        z = torch.tensor(3)
+        result = torch.atleast_2d([x, y, z])
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+# TODO: fix torch.atleast bug, which not support input list/tuple
+def _test_case_7():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor(1)
+        y = torch.tensor(2)
+        z = torch.tensor(3)
+        tensors = [x, y, z]
+        result = torch.atleast_2d(tensors)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+# TODO: fix torch.atleast bug, which not support input list/tuple
+def _test_case_8():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor(1)
+        y = torch.tensor(2)
+        z = torch.tensor(3)
+        tensors = (x, y, z)
+        result = torch.atleast_2d(tensors)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_9():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor(1)
+        y = torch.tensor(2)
+        z = torch.tensor(3)
+        result = torch.atleast_2d(x, y, z)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_10():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor(1)
+        y = torch.tensor(2)
+        z = torch.tensor(3)
+        tensors = (x, y, z)
+        result = torch.atleast_2d(*tensors)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_11():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor(1)
+        y = torch.tensor(2)
+        z = torch.tensor(3)
+        tensors = [x, y, z]
+        result = torch.atleast_2d(*tensors)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_12():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.atleast_2d()
         """
     )
     obj.run(pytorch_code, ["result"])

--- a/tests/test_atleast_3d.py
+++ b/tests/test_atleast_3d.py
@@ -48,3 +48,121 @@ def test_case_3():
         """
     )
     obj.run(pytorch_code, ["result"])
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor(1)
+        result = torch.atleast_3d(x)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor(1)
+        y = torch.tensor(2)
+        z = torch.tensor(3)
+        result = torch.atleast_3d((x, y, z))
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_6():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor(1)
+        y = torch.tensor(2)
+        z = torch.tensor(3)
+        result = torch.atleast_3d([x, y, z])
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+# TODO: fix torch.atleast bug, which not support input list/tuple
+def _test_case_7():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor(1)
+        y = torch.tensor(2)
+        z = torch.tensor(3)
+        tensors = [x, y, z]
+        result = torch.atleast_3d(tensors)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+# TODO: fix torch.atleast bug, which not support input list/tuple
+def _test_case_8():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor(1)
+        y = torch.tensor(2)
+        z = torch.tensor(3)
+        tensors = (x, y, z)
+        result = torch.atleast_3d(tensors)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_9():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor(1)
+        y = torch.tensor(2)
+        z = torch.tensor(3)
+        result = torch.atleast_3d(x, y, z)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_10():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor(1)
+        y = torch.tensor(2)
+        z = torch.tensor(3)
+        tensors = (x, y, z)
+        result = torch.atleast_3d(*tensors)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_11():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor(1)
+        y = torch.tensor(2)
+        z = torch.tensor(3)
+        tensors = [x, y, z]
+        result = torch.atleast_3d(*tensors)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_12():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        result = torch.atleast_3d()
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_nn_Upsample.py
+++ b/tests/test_nn_Upsample.py
@@ -66,7 +66,7 @@ def test_case_3():
         [[ 0.1024, -0.4482,  0.4137],
          [ 0.9385,  0.4565,  0.7702],
          [ 0.4135, -0.2587,  0.0482]]]])
-        m = torch.nn.Upsample(scale_factor=2, mode='bilinear',align_corners=True)
+        m = torch.nn.Upsample(scale_factor=2, mode='bilinear', align_corners=True)
         result = m(input)
         """
     )
@@ -102,7 +102,7 @@ def test_case_5():
         [[ 0.1024, -0.4482,  0.4137],
          [ 0.9385,  0.4565,  0.7702],
          [ 0.4135, -0.2587,  0.0482]]]])
-        m = torch.nn.Upsample(scale_factor=2, mode='bilinear',align_corners=False)
+        m = torch.nn.Upsample(scale_factor=2, mode='bilinear', align_corners=False)
         result = m(input)
         """
     )
@@ -120,7 +120,7 @@ def test_case_6():
         [[ 0.1024, -0.4482,  0.4137],
          [ 0.9385,  0.4565,  0.7702],
          [ 0.4135, -0.2587,  0.0482]]]])
-        m = torch.nn.Upsample(scale_factor=2, mode='bilinear',recompute_scale_factor=True)
+        m = torch.nn.Upsample(scale_factor=2, mode='bilinear', recompute_scale_factor=True)
         result = m(input)
         """
     )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->
优化torch.atleast_1d/2d/3d的转换规则
### PR APIs
<!-- APIs what you've done -->
```bash
1. torch.atleast_1d
2. torch.atleast_2d
3. torch.atleast_3d
4. torch._foreach_erfc
5. torch._foreach_erfc_
```
