### PR TITLE
移除lr_scheduler的verbose

### DIFF
--- a/tests/test_optim_lr_scheduler_ConstantLR.py
+++ b/tests/test_optim_lr_scheduler_ConstantLR.py
@@ -20,11 +20,10 @@ from lr_scheduler_helper import generate_lr_scheduler_test_code
 obj = APIBase("torch.optim.lr_scheduler.ConstantLR")
 
 
+# verbose has been deprecated and removed in torch 2.7.0
 def test_case_1():
     pytorch_code = textwrap.dedent(
-        generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.ConstantLR(sgd, verbose=True)"
-        )
+        generate_lr_scheduler_test_code("torch.optim.lr_scheduler.ConstantLR(sgd)")
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
 
@@ -77,7 +76,7 @@ def test_case_6():
 def test_case_7():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.ConstantLR(sgd, 0.05, 3, -1, False)"
+            "torch.optim.lr_scheduler.ConstantLR(sgd, 0.05, 3, -1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -86,7 +85,7 @@ def test_case_7():
 def test_case_8():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.ConstantLR(optimizer=sgd, factor=0.05, total_iters=3, last_epoch=-1, verbose=False)"
+            "torch.optim.lr_scheduler.ConstantLR(optimizer=sgd, factor=0.05, total_iters=3, last_epoch=-1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -96,8 +95,8 @@ def test_case_9():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
             [
-                "torch.optim.lr_scheduler.ConstantLR(optimizer=sgd, factor=0.05, total_iters=3, last_epoch=-1, verbose=False)",
-                "torch.optim.lr_scheduler.ConstantLR(optimizer=sgd, factor=0.05, total_iters=3, last_epoch=scheduler_1.last_epoch, verbose=False)",
+                "torch.optim.lr_scheduler.ConstantLR(optimizer=sgd, factor=0.05, total_iters=3, last_epoch=-1)",
+                "torch.optim.lr_scheduler.ConstantLR(optimizer=sgd, factor=0.05, total_iters=3, last_epoch=scheduler_1.last_epoch)",
             ]
         )
     )
@@ -114,7 +113,7 @@ def test_case_10():
 def test_case_11():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.ConstantLR(optimizer=sgd, factor=0.05, total_iters=3, last_epoch=-1, verbose=False)"
+            "torch.optim.lr_scheduler.ConstantLR(optimizer=sgd, factor=0.05, total_iters=3, last_epoch=-1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -123,7 +122,7 @@ def test_case_11():
 def test_case_12():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.ConstantLR(optimizer=sgd, factor=0.05, total_iters=3, last_epoch=-1, verbose=False)"
+            "torch.optim.lr_scheduler.ConstantLR(optimizer=sgd, factor=0.05, total_iters=3, last_epoch=-1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)

--- a/tests/test_optim_lr_scheduler_CosineAnnealingLR.py
+++ b/tests/test_optim_lr_scheduler_CosineAnnealingLR.py
@@ -20,6 +20,7 @@ from lr_scheduler_helper import generate_lr_scheduler_test_code
 obj = APIBase("torch.optim.lr_scheduler.CosineAnnealingLR")
 
 
+# verbose has been deprecated and removed in torch 2.7.0
 def test_case_1():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
@@ -50,7 +51,7 @@ def test_case_3():
 def test_case_4():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.CosineAnnealingLR(optimizer=sgd, T_max=10, eta_min=0.0, last_epoch=-1, verbose=True)"
+            "torch.optim.lr_scheduler.CosineAnnealingLR(optimizer=sgd, T_max=10, eta_min=0.0, last_epoch=-1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -59,7 +60,7 @@ def test_case_4():
 def test_case_5():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.CosineAnnealingLR(optimizer=sgd, T_max=10, eta_min=0.05, verbose=True)"
+            "torch.optim.lr_scheduler.CosineAnnealingLR(optimizer=sgd, T_max=10, eta_min=0.05)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -68,7 +69,7 @@ def test_case_5():
 def test_case_6():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.CosineAnnealingLR(sgd, 10, 0.0, -1, False)"
+            "torch.optim.lr_scheduler.CosineAnnealingLR(sgd, 10, 0.0, -1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -81,8 +82,8 @@ def test_case_7():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
             [
-                "torch.optim.lr_scheduler.CosineAnnealingLR(optimizer=sgd, T_max=10, eta_min=0.0, last_epoch=-1, verbose=False)",
-                "torch.optim.lr_scheduler.CosineAnnealingLR(optimizer=sgd, T_max=10, eta_min=0.0, last_epoch=scheduler_1.last_epoch, verbose=False)",
+                "torch.optim.lr_scheduler.CosineAnnealingLR(optimizer=sgd, T_max=10, eta_min=0.0, last_epoch=-1)",
+                "torch.optim.lr_scheduler.CosineAnnealingLR(optimizer=sgd, T_max=10, eta_min=0.0, last_epoch=scheduler_1.last_epoch)",
             ]
         )
     )
@@ -92,7 +93,7 @@ def test_case_7():
 def test_case_8():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.CosineAnnealingLR(T_max=10, eta_min=0.0, optimizer=sgd, last_epoch=-1, verbose=True)"
+            "torch.optim.lr_scheduler.CosineAnnealingLR(T_max=10, eta_min=0.0, optimizer=sgd, last_epoch=-1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)

--- a/tests/test_optim_lr_scheduler_CosineAnnealingWarmRestarts.py
+++ b/tests/test_optim_lr_scheduler_CosineAnnealingWarmRestarts.py
@@ -20,6 +20,7 @@ from lr_scheduler_helper import generate_lr_scheduler_test_code
 obj = APIBase("torch.optim.lr_scheduler.CosineAnnealingWarmRestarts")
 
 
+# verbose has been deprecated and removed in torch 2.7.0
 def test_case_1():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
@@ -50,7 +51,7 @@ def test_case_3():
 def test_case_4():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer=sgd, T_0=10, T_mult=1, eta_min=0.0, last_epoch=-1, verbose=True)"
+            "torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer=sgd, T_0=10, T_mult=1, eta_min=0.0, last_epoch=-1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -59,7 +60,7 @@ def test_case_4():
 def test_case_5():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer=sgd, T_0=10, T_mult=1, eta_min=0.05, verbose=True)"
+            "torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer=sgd, T_0=10, T_mult=1, eta_min=0.05)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -68,7 +69,7 @@ def test_case_5():
 def test_case_6():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(sgd, 10, 1, 1.0, -1, False)"
+            "torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(sgd, 10, 1, 1.0, -1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -78,8 +79,8 @@ def test_case_7():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
             [
-                "torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer=sgd, T_0=10, T_mult=1, eta_min=0.0, last_epoch=-1, verbose=False)",
-                "torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer=sgd, T_0=10, T_mult=2, eta_min=0.0, last_epoch=scheduler_1.last_epoch, verbose=False)",
+                "torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer=sgd, T_0=10, T_mult=1, eta_min=0.0, last_epoch=-1)",
+                "torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer=sgd, T_0=10, T_mult=2, eta_min=0.0, last_epoch=scheduler_1.last_epoch)",
             ]
         )
     )

--- a/tests/test_optim_lr_scheduler_CyclicLR.py
+++ b/tests/test_optim_lr_scheduler_CyclicLR.py
@@ -20,6 +20,7 @@ from lr_scheduler_helper import generate_lr_scheduler_test_code
 obj = APIBase("torch.optim.lr_scheduler.CyclicLR")
 
 
+# verbose has been deprecated and removed in torch 2.7.0
 def test_case_1():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
@@ -50,7 +51,7 @@ def test_case_3():
 def test_case_4():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.CyclicLR(optimizer=sgd, base_lr=0.01, max_lr=0.1, step_size_up=1000, step_size_down=1000, mode='triangular', gamma=1.0, scale_fn=None, scale_mode='cycle', cycle_momentum=True, base_momentum=0.8, max_momentum=0.9, last_epoch=-1, verbose=False)"
+            "torch.optim.lr_scheduler.CyclicLR(optimizer=sgd, base_lr=0.01, max_lr=0.1, step_size_up=1000, step_size_down=1000, mode='triangular', gamma=1.0, scale_fn=None, scale_mode='cycle', cycle_momentum=True, base_momentum=0.8, max_momentum=0.9, last_epoch=-1)"
         )
     )
     obj.run(
@@ -65,7 +66,7 @@ def test_case_4():
 def test_case_5():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.CyclicLR(optimizer=sgd, base_lr=0.01, max_lr=0.1, step_size_up=1000, step_size_down=1000, mode='triangular', gamma=1.0, scale_fn=None, scale_mode='cycle', last_epoch=-1, verbose=False)"
+            "torch.optim.lr_scheduler.CyclicLR(optimizer=sgd, base_lr=0.01, max_lr=0.1, step_size_up=1000, step_size_down=1000, mode='triangular', gamma=1.0, scale_fn=None, scale_mode='cycle', last_epoch=-1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5, check_value=False)
@@ -74,7 +75,7 @@ def test_case_5():
 def test_case_6():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.CyclicLR(scale_fn=None, scale_mode='cycle', last_epoch=-1, verbose=False, base_lr=0.01, max_lr=0.1, step_size_up=1000, optimizer=sgd, mode='triangular', gamma=1.0)"
+            "torch.optim.lr_scheduler.CyclicLR(scale_fn=None, scale_mode='cycle', last_epoch=-1, base_lr=0.01, max_lr=0.1, step_size_up=1000, optimizer=sgd, mode='triangular', gamma=1.0)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5, check_value=False)
@@ -83,7 +84,7 @@ def test_case_6():
 def test_case_7():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.CyclicLR(sgd, 0.01, 0.1, 1000, 1000, 'triangular', 1.0, None, 'cycle', last_epoch=-1, verbose=False)"
+            "torch.optim.lr_scheduler.CyclicLR(sgd, 0.01, 0.1, 1000, 1000, 'triangular', 1.0, None, 'cycle', last_epoch=-1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5, check_value=False)
@@ -102,8 +103,8 @@ def test_case_9():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
             [
-                "torch.optim.lr_scheduler.CyclicLR(optimizer=sgd, base_lr=0.01, max_lr=0.1, step_size_up=1000, step_size_down=1000, mode='triangular', gamma=1.0, scale_fn=None, scale_mode='cycle', last_epoch=-1, verbose=False)",
-                "torch.optim.lr_scheduler.CyclicLR(optimizer=sgd, base_lr=0.01, max_lr=0.1, step_size_up=1000, step_size_down=1000, mode='triangular', gamma=1.0, scale_fn=None, scale_mode='cycle', last_epoch=scheduler_1.last_epoch, verbose=False)",
+                "torch.optim.lr_scheduler.CyclicLR(optimizer=sgd, base_lr=0.01, max_lr=0.1, step_size_up=1000, step_size_down=1000, mode='triangular', gamma=1.0, scale_fn=None, scale_mode='cycle', last_epoch=-1)",
+                "torch.optim.lr_scheduler.CyclicLR(optimizer=sgd, base_lr=0.01, max_lr=0.1, step_size_up=1000, step_size_down=1000, mode='triangular', gamma=1.0, scale_fn=None, scale_mode='cycle', last_epoch=scheduler_1.last_epoch)",
             ]
         )
     )
@@ -113,7 +114,7 @@ def test_case_9():
 def test_case_10():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.CyclicLR(sgd, 0.01, 0.1, 1000, 1000, 'triangular', 1.0, None, 'cycle', True, 0.8, 0.9, -1, False)"
+            "torch.optim.lr_scheduler.CyclicLR(sgd, 0.01, 0.1, 1000, 1000, 'triangular', 1.0, None, 'cycle', True, 0.8, 0.9, -1)"
         )
     )
     obj.run(
@@ -128,7 +129,7 @@ def test_case_10():
 def test_case_11():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.CyclicLR(optimizer=sgd, max_lr=0.1, mode='triangular', step_size_up=1000, base_lr=0.01, step_size_down=1000, gamma=1.0, cycle_momentum=True, scale_fn=None, scale_mode='cycle', base_momentum=0.8, max_momentum=0.9, last_epoch=-1, verbose=False)"
+            "torch.optim.lr_scheduler.CyclicLR(optimizer=sgd, max_lr=0.1, mode='triangular', step_size_up=1000, base_lr=0.01, step_size_down=1000, gamma=1.0, cycle_momentum=True, scale_fn=None, scale_mode='cycle', base_momentum=0.8, max_momentum=0.9, last_epoch=-1)"
         )
     )
     obj.run(

--- a/tests/test_optim_lr_scheduler_ExponentialLR.py
+++ b/tests/test_optim_lr_scheduler_ExponentialLR.py
@@ -20,6 +20,7 @@ from lr_scheduler_helper import generate_lr_scheduler_test_code
 obj = APIBase("torch.optim.lr_scheduler.ExponentialLR")
 
 
+# verbose has been deprecated and removed in torch 2.7.0
 def test_case_1():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
@@ -50,7 +51,7 @@ def test_case_3():
 def test_case_4():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.ExponentialLR(optimizer=sgd, gamma=0.5, last_epoch=-1, verbose=True)"
+            "torch.optim.lr_scheduler.ExponentialLR(optimizer=sgd, gamma=0.5, last_epoch=-1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -59,7 +60,7 @@ def test_case_4():
 def test_case_5():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.ExponentialLR(optimizer=sgd, gamma=0.5, verbose=True)"
+            "torch.optim.lr_scheduler.ExponentialLR(optimizer=sgd, gamma=0.5)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -68,7 +69,7 @@ def test_case_5():
 def test_case_6():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.ExponentialLR(sgd, 0.5, -1, False)"
+            "torch.optim.lr_scheduler.ExponentialLR(sgd, 0.5, -1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -80,8 +81,8 @@ def test_case_7():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
             [
-                "torch.optim.lr_scheduler.ExponentialLR(optimizer=sgd, gamma=0.5, last_epoch=-1, verbose=False)",
-                "torch.optim.lr_scheduler.ExponentialLR(optimizer=sgd, gamma=0.5, last_epoch=scheduler_1.last_epoch, verbose=True)",
+                "torch.optim.lr_scheduler.ExponentialLR(optimizer=sgd, gamma=0.5, last_epoch=-1)",
+                "torch.optim.lr_scheduler.ExponentialLR(optimizer=sgd, gamma=0.5, last_epoch=scheduler_1.last_epoch)",
             ]
         )
     )
@@ -91,7 +92,7 @@ def test_case_7():
 def test_case_8():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.ExponentialLR(gamma=0.5, last_epoch=-1, optimizer=sgd, verbose=True)"
+            "torch.optim.lr_scheduler.ExponentialLR(gamma=0.5, last_epoch=-1, optimizer=sgd)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)

--- a/tests/test_optim_lr_scheduler_LambdaLR.py
+++ b/tests/test_optim_lr_scheduler_LambdaLR.py
@@ -20,6 +20,7 @@ from lr_scheduler_helper import generate_lr_scheduler_test_code
 obj = APIBase("torch.optim.lr_scheduler.LambdaLR")
 
 
+# verbose has been deprecated and removed in torch 2.7.0
 def test_case_1():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
@@ -50,7 +51,7 @@ def test_case_3():
 def test_case_4():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.LambdaLR(optimizer=sgd, lr_lambda=lambda x:0.95**x, last_epoch=-1, verbose=True)"
+            "torch.optim.lr_scheduler.LambdaLR(optimizer=sgd, lr_lambda=lambda x:0.95**x, last_epoch=-1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -59,7 +60,7 @@ def test_case_4():
 def test_case_5():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.LambdaLR(optimizer=sgd, lr_lambda=lambda x:0.95**x, verbose=True)"
+            "torch.optim.lr_scheduler.LambdaLR(optimizer=sgd, lr_lambda=lambda x:0.95**x)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -68,7 +69,7 @@ def test_case_5():
 def test_case_6():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.LambdaLR(sgd, lambda x:0.95**x, -1, False)"
+            "torch.optim.lr_scheduler.LambdaLR(sgd, lambda x:0.95**x, -1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -80,8 +81,8 @@ def test_case_7():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
             [
-                "torch.optim.lr_scheduler.LambdaLR(optimizer=sgd, lr_lambda=lambda x:0.95**x, verbose=False)",
-                "torch.optim.lr_scheduler.LambdaLR(optimizer=sgd, lr_lambda=lambda x:0.95**x, last_epoch=scheduler_1.last_epoch, verbose=True)",
+                "torch.optim.lr_scheduler.LambdaLR(optimizer=sgd, lr_lambda=lambda x:0.95**x)",
+                "torch.optim.lr_scheduler.LambdaLR(optimizer=sgd, lr_lambda=lambda x:0.95**x, last_epoch=scheduler_1.last_epoch)",
             ]
         )
     )
@@ -91,7 +92,7 @@ def test_case_7():
 def test_case_8():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.LambdaLR(lr_lambda=lambda x:0.95**x, optimizer=sgd, last_epoch=-1, verbose=True)"
+            "torch.optim.lr_scheduler.LambdaLR(lr_lambda=lambda x:0.95**x, optimizer=sgd, last_epoch=-1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)

--- a/tests/test_optim_lr_scheduler_LinearLR.py
+++ b/tests/test_optim_lr_scheduler_LinearLR.py
@@ -20,11 +20,10 @@ from lr_scheduler_helper import generate_lr_scheduler_test_code
 obj = APIBase("torch.optim.lr_scheduler.LinearLR")
 
 
+# verbose has been deprecated and removed in torch 2.7.0
 def test_case_1():
     pytorch_code = textwrap.dedent(
-        generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.LinearLR(sgd, verbose=True)"
-        )
+        generate_lr_scheduler_test_code("torch.optim.lr_scheduler.LinearLR(sgd)")
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
 
@@ -77,7 +76,7 @@ def test_case_6():
 def test_case_7():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.LinearLR(sgd, 0.05, 1.0, 3, -1, False)"
+            "torch.optim.lr_scheduler.LinearLR(sgd, 0.05, 1.0, 3, -1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -86,7 +85,7 @@ def test_case_7():
 def test_case_8():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.LinearLR(optimizer=sgd, start_factor=0.05, end_factor=1.0, total_iters=3, last_epoch=-1, verbose=False)"
+            "torch.optim.lr_scheduler.LinearLR(optimizer=sgd, start_factor=0.05, end_factor=1.0, total_iters=3, last_epoch=-1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -96,8 +95,8 @@ def test_case_9():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
             [
-                "torch.optim.lr_scheduler.LinearLR(optimizer=sgd, start_factor=0.05, end_factor=1.0, total_iters=3, last_epoch=-1, verbose=False)",
-                "torch.optim.lr_scheduler.LinearLR(optimizer=sgd, start_factor=0.05, end_factor=1.0, total_iters=3, last_epoch=scheduler_1.last_epoch, verbose=False)",
+                "torch.optim.lr_scheduler.LinearLR(optimizer=sgd, start_factor=0.05, end_factor=1.0, total_iters=3, last_epoch=-1)",
+                "torch.optim.lr_scheduler.LinearLR(optimizer=sgd, start_factor=0.05, end_factor=1.0, total_iters=3, last_epoch=scheduler_1.last_epoch)",
             ]
         )
     )

--- a/tests/test_optim_lr_scheduler_MultiStepLR.py
+++ b/tests/test_optim_lr_scheduler_MultiStepLR.py
@@ -20,6 +20,7 @@ from lr_scheduler_helper import generate_lr_scheduler_test_code
 obj = APIBase("torch.optim.lr_scheduler.MultiStepLR")
 
 
+# verbose has been deprecated and removed in torch 2.7.0
 def test_case_1():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
@@ -50,7 +51,7 @@ def test_case_3():
 def test_case_4():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.MultiStepLR(optimizer=sgd, milestones=[2,4,6], gamma=0.5, last_epoch=-1, verbose=True)"
+            "torch.optim.lr_scheduler.MultiStepLR(optimizer=sgd, milestones=[2,4,6], gamma=0.5, last_epoch=-1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -59,7 +60,7 @@ def test_case_4():
 def test_case_5():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.MultiStepLR(optimizer=sgd, milestones=[2,4,6], verbose=True)"
+            "torch.optim.lr_scheduler.MultiStepLR(optimizer=sgd, milestones=[2,4,6])"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -68,7 +69,7 @@ def test_case_5():
 def test_case_6():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.MultiStepLR(sgd, [2,4,6], 0.5, -1, False)"
+            "torch.optim.lr_scheduler.MultiStepLR(sgd, [2,4,6], 0.5, -1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -77,7 +78,7 @@ def test_case_6():
 def test_case_7():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.MultiStepLR(optimizer=sgd, milestones=[2,4,6,12,24], gamma=0.5, last_epoch=-1, verbose=True)"
+            "torch.optim.lr_scheduler.MultiStepLR(optimizer=sgd, milestones=[2,4,6,12,24], gamma=0.5, last_epoch=-1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -89,8 +90,8 @@ def test_case_8():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
             [
-                "torch.optim.lr_scheduler.MultiStepLR(optimizer=sgd, milestones=[2,4,6,12,24], gamma=0.5, last_epoch=-1, verbose=False)",
-                "torch.optim.lr_scheduler.MultiStepLR(optimizer=sgd, milestones=[2,4,6,12,24], gamma=0.5, last_epoch=scheduler_1.last_epoch, verbose=True)",
+                "torch.optim.lr_scheduler.MultiStepLR(optimizer=sgd, milestones=[2,4,6,12,24], gamma=0.5, last_epoch=-1)",
+                "torch.optim.lr_scheduler.MultiStepLR(optimizer=sgd, milestones=[2,4,6,12,24], gamma=0.5, last_epoch=scheduler_1.last_epoch)",
             ]
         )
     )
@@ -100,7 +101,7 @@ def test_case_8():
 def test_case_9():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.MultiStepLR(milestones=[2,4,6], gamma=0.5, last_epoch=-1, optimizer=sgd, verbose=False)"
+            "torch.optim.lr_scheduler.MultiStepLR(milestones=[2,4,6], gamma=0.5, last_epoch=-1, optimizer=sgd)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)

--- a/tests/test_optim_lr_scheduler_MultiplicativeLR.py
+++ b/tests/test_optim_lr_scheduler_MultiplicativeLR.py
@@ -20,6 +20,7 @@ from lr_scheduler_helper import generate_lr_scheduler_test_code
 obj = APIBase("torch.optim.lr_scheduler.MultiplicativeLR")
 
 
+# verbose has been deprecated and removed in torch 2.7.0
 def test_case_1():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
@@ -50,7 +51,7 @@ def test_case_3():
 def test_case_4():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.MultiplicativeLR(optimizer=sgd, lr_lambda=lambda x:0.95**x, last_epoch=-1, verbose=True)"
+            "torch.optim.lr_scheduler.MultiplicativeLR(optimizer=sgd, lr_lambda=lambda x:0.95**x, last_epoch=-1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -59,7 +60,7 @@ def test_case_4():
 def test_case_5():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.MultiplicativeLR(optimizer=sgd, lr_lambda=lambda x:0.95**x, verbose=True)"
+            "torch.optim.lr_scheduler.MultiplicativeLR(optimizer=sgd, lr_lambda=lambda x:0.95**x)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -68,7 +69,7 @@ def test_case_5():
 def test_case_6():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.MultiplicativeLR(sgd, lambda x:0.95**x, -1, False)"
+            "torch.optim.lr_scheduler.MultiplicativeLR(sgd, lambda x:0.95**x, -1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -80,8 +81,8 @@ def test_case_7():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
             [
-                "torch.optim.lr_scheduler.MultiplicativeLR(optimizer=sgd, lr_lambda=lambda x:0.95**x, last_epoch=-1, verbose=False)",
-                "torch.optim.lr_scheduler.MultiplicativeLR(optimizer=sgd, lr_lambda=lambda x:0.95**x, last_epoch=scheduler_1.last_epoch, verbose=True)",
+                "torch.optim.lr_scheduler.MultiplicativeLR(optimizer=sgd, lr_lambda=lambda x:0.95**x, last_epoch=-1)",
+                "torch.optim.lr_scheduler.MultiplicativeLR(optimizer=sgd, lr_lambda=lambda x:0.95**x, last_epoch=scheduler_1.last_epoch)",
             ]
         )
     )
@@ -91,7 +92,7 @@ def test_case_7():
 def test_case_8():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.MultiplicativeLR(lr_lambda=lambda x:0.95**x, last_epoch=-1, optimizer=sgd, verbose=True)"
+            "torch.optim.lr_scheduler.MultiplicativeLR(lr_lambda=lambda x:0.95**x, last_epoch=-1, optimizer=sgd)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)

--- a/tests/test_optim_lr_scheduler_OneCycleLR.py
+++ b/tests/test_optim_lr_scheduler_OneCycleLR.py
@@ -20,6 +20,7 @@ from lr_scheduler_helper import generate_lr_scheduler_test_code
 obj = APIBase("torch.optim.lr_scheduler.OneCycleLR")
 
 
+# verbose has been deprecated and removed in torch 2.7.0
 def test_case_1():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
@@ -50,7 +51,7 @@ def test_case_3():
 def test_case_4():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.OneCycleLR(optimizer=sgd, max_lr=0.01, steps_per_epoch=20, epochs=10, last_epoch=-1, verbose=True)"
+            "torch.optim.lr_scheduler.OneCycleLR(optimizer=sgd, max_lr=0.01, steps_per_epoch=20, epochs=10, last_epoch=-1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5, check_value=False)
@@ -59,7 +60,7 @@ def test_case_4():
 def test_case_5():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.OneCycleLR(optimizer=sgd, max_lr=0.01, steps_per_epoch=20, epochs=10, verbose=True)"
+            "torch.optim.lr_scheduler.OneCycleLR(optimizer=sgd, max_lr=0.01, steps_per_epoch=20, epochs=10)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5, check_value=False)
@@ -68,7 +69,7 @@ def test_case_5():
 def test_case_6():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.OneCycleLR(optimizer=sgd, max_lr=0.01, total_steps=None, steps_per_epoch=20, epochs=10, pct_start=0.3, anneal_strategy='cos', div_factor=25.0, final_div_factor=10000.0, three_phase=False, last_epoch=-1, verbose=True)"
+            "torch.optim.lr_scheduler.OneCycleLR(optimizer=sgd, max_lr=0.01, total_steps=None, steps_per_epoch=20, epochs=10, pct_start=0.3, anneal_strategy='cos', div_factor=25.0, final_div_factor=10000.0, three_phase=False, last_epoch=-1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5, check_value=False)
@@ -77,7 +78,7 @@ def test_case_6():
 def test_case_7():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.OneCycleLR(optimizer=sgd, max_lr=0.01, total_steps=None, steps_per_epoch=20, epochs=10, pct_start=0.3, anneal_strategy='cos', cycle_momentum=True, base_momentum=0.85, max_momentum=0.95, div_factor=25.0, final_div_factor=10000.0, three_phase=False, last_epoch=-1, verbose=True)"
+            "torch.optim.lr_scheduler.OneCycleLR(optimizer=sgd, max_lr=0.01, total_steps=None, steps_per_epoch=20, epochs=10, pct_start=0.3, anneal_strategy='cos', cycle_momentum=True, base_momentum=0.85, max_momentum=0.95, div_factor=25.0, final_div_factor=10000.0, three_phase=False, last_epoch=-1)"
         )
     )
     obj.run(
@@ -92,7 +93,7 @@ def test_case_7():
 def test_case_8():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.OneCycleLR(optimizer=sgd, max_lr=0.01, steps_per_epoch=20, epochs=10, pct_start=0.3, anneal_strategy='linear', div_factor=2.5, final_div_factor=2000.0, three_phase=False, last_epoch=-1, verbose=True)"
+            "torch.optim.lr_scheduler.OneCycleLR(optimizer=sgd, max_lr=0.01, steps_per_epoch=20, epochs=10, pct_start=0.3, anneal_strategy='linear', div_factor=2.5, final_div_factor=2000.0, three_phase=False, last_epoch=-1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5, check_value=False)
@@ -101,7 +102,7 @@ def test_case_8():
 def test_case_9():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.OneCycleLR(sgd, 0.01, None, 20, 10, 0.3, 'linear', div_factor=2.5, final_div_factor=2000.0, three_phase=False, last_epoch=-1, verbose=False)"
+            "torch.optim.lr_scheduler.OneCycleLR(sgd, 0.01, None, 20, 10, 0.3, 'linear', div_factor=2.5, final_div_factor=2000.0, three_phase=False, last_epoch=-1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5, check_value=False)
@@ -120,8 +121,8 @@ def test_case_11():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
             [
-                "torch.optim.lr_scheduler.OneCycleLR(sgd, 0.01, None, 20, 10, 0.3, 'linear', div_factor=2.5, final_div_factor=2000.0, three_phase=False, last_epoch=-1, verbose=False)",
-                "torch.optim.lr_scheduler.OneCycleLR(sgd, 0.01, None, 20, 10, 0.3, 'linear', div_factor=2.5, final_div_factor=2000.0, three_phase=False, last_epoch=scheduler_1.last_epoch, verbose=True)",
+                "torch.optim.lr_scheduler.OneCycleLR(sgd, 0.01, None, 20, 10, 0.3, 'linear', div_factor=2.5, final_div_factor=2000.0, three_phase=False, last_epoch=-1)",
+                "torch.optim.lr_scheduler.OneCycleLR(sgd, 0.01, None, 20, 10, 0.3, 'linear', div_factor=2.5, final_div_factor=2000.0, three_phase=False, last_epoch=scheduler_1.last_epoch)",
             ]
         )
     )
@@ -131,7 +132,7 @@ def test_case_11():
 def test_case_12():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.OneCycleLR(optimizer=sgd, max_lr=0.01, total_steps=None, epochs=10, steps_per_epoch=20, pct_start=0.3, anneal_strategy='linear', div_factor=2.5, final_div_factor=2000.0, three_phase=False, last_epoch=-1, verbose=True)"
+            "torch.optim.lr_scheduler.OneCycleLR(optimizer=sgd, max_lr=0.01, total_steps=None, epochs=10, steps_per_epoch=20, pct_start=0.3, anneal_strategy='linear', div_factor=2.5, final_div_factor=2000.0, three_phase=False, last_epoch=-1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5, check_value=False)
@@ -140,7 +141,7 @@ def test_case_12():
 def test_case_13():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.OneCycleLR(sgd, 0.01, None, 20, 10, 0.3, 'cos', True, 0.85, 0.95, 25.0, 10000.0, False, -1, True)"
+            "torch.optim.lr_scheduler.OneCycleLR(sgd, 0.01, None, 20, 10, 0.3, 'cos', True, 0.85, 0.95, 25.0, 10000.0, False, -1)"
         )
     )
     obj.run(
@@ -155,7 +156,7 @@ def test_case_13():
 def test_case_14():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.OneCycleLR(optimizer=sgd, total_steps=None, anneal_strategy='cos', steps_per_epoch=20, max_lr=0.01, epochs=10, base_momentum=0.85, pct_start=0.3, cycle_momentum=True, final_div_factor=10000.0, max_momentum=0.95, div_factor=25.0, three_phase=False, last_epoch=-1, verbose=True)"
+            "torch.optim.lr_scheduler.OneCycleLR(optimizer=sgd, total_steps=None, anneal_strategy='cos', steps_per_epoch=20, max_lr=0.01, epochs=10, base_momentum=0.85, pct_start=0.3, cycle_momentum=True, final_div_factor=10000.0, max_momentum=0.95, div_factor=25.0, three_phase=False, last_epoch=-1)"
         )
     )
     obj.run(

--- a/tests/test_optim_lr_scheduler_ReduceLROnPlateau.py
+++ b/tests/test_optim_lr_scheduler_ReduceLROnPlateau.py
@@ -20,6 +20,7 @@ from lr_scheduler_helper import generate_lr_scheduler_test_code
 obj = APIBase("torch.optim.lr_scheduler.ReduceLROnPlateau")
 
 
+# verbose has been deprecated and removed in torch 2.7.0
 def test_case_1():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
@@ -52,7 +53,7 @@ def test_case_3():
 def test_case_4():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer=sgd, mode='min',verbose=True)",
+            "torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer=sgd, mode='min')",
             step_with_loss=True,
         )
     )
@@ -62,7 +63,7 @@ def test_case_4():
 def test_case_5():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer=sgd, mode='min', factor=0.1, patience=10, threshold=1e-4, threshold_mode='rel', cooldown=0, min_lr=0, eps=1e-8, verbose=False)",
+            "torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer=sgd, mode='min', factor=0.1, patience=10, threshold=1e-4, threshold_mode='rel', cooldown=0, min_lr=0, eps=1e-8)",
             step_with_loss=True,
         )
     )
@@ -72,7 +73,7 @@ def test_case_5():
 def test_case_6():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer=sgd, mode='max', factor=0.1, patience=10, threshold=1e-4, threshold_mode='rel', cooldown=0, min_lr=0, eps=1e-8, verbose=False)",
+            "torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer=sgd, mode='max', factor=0.1, patience=10, threshold=1e-4, threshold_mode='rel', cooldown=0, min_lr=0, eps=1e-8)",
             step_with_loss=True,
         )
     )
@@ -82,7 +83,7 @@ def test_case_6():
 def test_case_7():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.ReduceLROnPlateau(sgd, 'max', 0.1, 10, 1e-4, 'rel', 0, 0, 1e-8, False)",
+            "torch.optim.lr_scheduler.ReduceLROnPlateau(sgd, 'max', 0.1, 10, 1e-4, 'rel', 0, 0, 1e-8)",
             step_with_loss=True,
         )
     )
@@ -94,8 +95,8 @@ def test_case_8():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
             [
-                "torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer=sgd, mode='min',verbose=False)",
-                "torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer=sgd, mode='min',verbose=True)",
+                "torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer=sgd, mode='min')",
+                "torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer=sgd, mode='min')",
             ],
             step_with_loss=True,
         )
@@ -106,7 +107,7 @@ def test_case_8():
 def test_case_9():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.ReduceLROnPlateau(mode='min', verbose=False, factor=0.1, patience=10, threshold=1e-4, threshold_mode='rel', cooldown=0, optimizer=sgd, min_lr=0, eps=1e-8)",
+            "torch.optim.lr_scheduler.ReduceLROnPlateau(mode='min', factor=0.1, patience=10, threshold=1e-4, threshold_mode='rel', cooldown=0, optimizer=sgd, min_lr=0, eps=1e-8)",
             step_with_loss=True,
         )
     )

--- a/tests/test_optim_lr_scheduler_StepLR.py
+++ b/tests/test_optim_lr_scheduler_StepLR.py
@@ -20,10 +20,11 @@ from lr_scheduler_helper import generate_lr_scheduler_test_code
 obj = APIBase("torch.optim.lr_scheduler.StepLR")
 
 
+# verbose has been deprecated and removed in torch 2.7.0
 def test_case_1():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.StepLR(sgd, step_size=2, verbose=True)"
+            "torch.optim.lr_scheduler.StepLR(sgd, step_size=2)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -57,7 +58,7 @@ def test_case_4():
 def test_case_5():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.StepLR(sgd, 10, 0.2, -1, False)"
+            "torch.optim.lr_scheduler.StepLR(sgd, 10, 0.2, -1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -75,7 +76,7 @@ def test_case_6():
 def test_case_7():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
-            "torch.optim.lr_scheduler.StepLR(optimizer=sgd, step_size=3, gamma=0.2, last_epoch=-1, verbose=False)"
+            "torch.optim.lr_scheduler.StepLR(optimizer=sgd, step_size=3, gamma=0.2, last_epoch=-1)"
         )
     )
     obj.run(pytorch_code, ["result1", "result2"], rtol=1.0e-5)
@@ -96,8 +97,8 @@ def test_case_9():
     pytorch_code = textwrap.dedent(
         generate_lr_scheduler_test_code(
             [
-                "torch.optim.lr_scheduler.StepLR(optimizer=sgd, step_size=3, gamma=0.2, last_epoch=-1, verbose=False)",
-                "torch.optim.lr_scheduler.StepLR(optimizer=sgd, step_size=3, gamma=0.2, last_epoch=scheduler_1.last_epoch, verbose=False)",
+                "torch.optim.lr_scheduler.StepLR(optimizer=sgd, step_size=3, gamma=0.2, last_epoch=-1)",
+                "torch.optim.lr_scheduler.StepLR(optimizer=sgd, step_size=3, gamma=0.2, last_epoch=scheduler_1.last_epoch)",
             ]
         )
     )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->
lr_scheduler verbose has been deprecated and removed in torch 2.7.0

### PR APIs
<!-- APIs what you've done -->
```bash
lr_scheduler verbose has been deprecated and removed in torch 2.7.0
```
