### PR TITLE
Fix `torch._assert` conversion with `f-string` message

### DIFF
--- a/paconvert/api_matcher.py
+++ b/paconvert/api_matcher.py
@@ -865,7 +865,7 @@ class AssertMatcher(BaseMatcher):
     def generate_code(self, kwargs):
         API_TEMPLATE = textwrap.dedent(
             """
-            assert {}, '{}'
+            assert {}, {}
             """
         )
         code = API_TEMPLATE.format(

--- a/tests/test__assert.py
+++ b/tests/test__assert.py
@@ -56,3 +56,18 @@ def test_case_4():
         """
     )
     obj.run(pytorch_code)
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        _, _, H, W = [1, 2, 3, 4]
+        img_size = [3, 4]
+        torch._assert(
+            H == img_size[0],
+            f"Input image height ({H}) doesn't match model ({img_size[0]}).",
+        )
+        """
+    )
+    obj.run(pytorch_code)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->

no docs update

### PR APIs
<!-- APIs what you've done -->

Fix errors when convert `torch._assert`

message 本身就是字符串，不需要额外包裹 `''`，而且在 message 是 f-string 时，会出现 SyntaxError

```
source = '\nassert (H == self.img_size[0]), \'f"""Input image height ({H}) doesn\'t match model ({img_size[0]})."""\'\n', filename = '<unknown>', mode = 'exec'

    def parse(source, filename='<unknown>', mode='exec', *,
              type_comments=False, feature_version=None):
        """
        Parse the source into an AST node.
        Equivalent to compile(source, filename, mode, PyCF_ONLY_AST).
        Pass type_comments=True to get back type comments where the syntax allows.
        """
        flags = PyCF_ONLY_AST
        if type_comments:
            flags |= PyCF_TYPE_COMMENTS
        if isinstance(feature_version, tuple):
            major, minor = feature_version  # Should be a 2-tuple.
            assert major == 3
            feature_version = minor
        elif feature_version is None:
            feature_version = -1
        # Else it should be an int giving the minor version for 3.x.
>       return compile(source, filename, mode, flags,
                       _feature_version=feature_version)
E         File "<unknown>", line 2
E           assert (H == self.img_size[0]), 'f"""Input image height ({H}) doesn't match model ({img_size[0]})."""'
E                                                                                                             ^
E       SyntaxError: unterminated triple-quoted string literal (detected at line 2)

/home/nyakku/mambaforge/envs/paddle-py310/lib/python3.10/ast.py:50: SyntaxError
```