### PR TITLE
在SmoothL1Loss中使用is_huber参数

### DIFF
--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -12677,7 +12677,7 @@
     "min_input_args": 0
   },
   "torch.nn.SmoothL1Loss": {
-    "Matcher": "SizeAverageMatcher",
+    "Matcher": "SmoothL1LossMatcher",
     "paddle_api": "paddle.nn.SmoothL1Loss",
     "min_input_args": 0,
     "args_list": [

--- a/paconvert/api_matcher.py
+++ b/paconvert/api_matcher.py
@@ -4274,6 +4274,15 @@ class SizeAverageMatcher(BaseMatcher):
         return GenericMatcher.generate_code(self, kwargs)
 
 
+class SmoothL1LossMatcher(BaseMatcher):
+    def generate_code(self, kwargs):
+        process_reduce_and_size_average(kwargs)
+        if "beta" in kwargs:
+            kwargs["delta"] = kwargs.pop("beta")
+            kwargs["is_huber"] = False
+        return GenericMatcher.generate_code(self, kwargs)
+
+
 class CudaNvtxRangePushMatcher(BaseMatcher):
     def generate_code(self, kwargs):
         code = "{}({})".format(self.get_paddle_api(), kwargs["msg"])

--- a/paconvert/api_matcher.py
+++ b/paconvert/api_matcher.py
@@ -3658,9 +3658,9 @@ class FunctionalSmoothL1LossMatcher(BaseMatcher):
 
         if "beta" in kwargs:
             kwargs["delta"] = kwargs.pop("beta")
-            API_TEMPLATE = "paddle.nn.functional.smooth_l1_loss({})/" + kwargs["delta"]
-        else:
-            API_TEMPLATE = "paddle.nn.functional.smooth_l1_loss({})"
+            kwargs["is_huber"] = False
+
+        API_TEMPLATE = "paddle.nn.functional.smooth_l1_loss({})"
 
         code = API_TEMPLATE.format(self.kwargs_to_str(kwargs))
         return code

--- a/tests/test_nn_SmoothL1Loss.py
+++ b/tests/test_nn_SmoothL1Loss.py
@@ -87,7 +87,7 @@ def test_case_5():
 
 
 # paddle result has diff with pytorch result
-def _test_case_6():
+def test_case_6():
     pytorch_code = textwrap.dedent(
         """
         import torch
@@ -101,7 +101,7 @@ def _test_case_6():
 
 
 # paddle result has diff with pytorch result
-def _test_case_7():
+def test_case_7():
     pytorch_code = textwrap.dedent(
         """
         import torch


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->

在SmoothL1Loss中使用is_huber参数，这样SmoothL1Loss会在底层函数计算中就除以delta，而不需要在得到结果后再除以delta  
https://github.com/PaddlePaddle/Paddle/pull/73325
### PR APIs
<!-- APIs what you've done -->
```bash
paddle.nn.loss.SmoothL1Loss
```
