### PR TITLE
Dont remove `name` in `CppExtension`/`CUDAExtension`

### DIFF
--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -18088,9 +18088,6 @@
       "optional",
       "py_limited_api"
     ],
-    "kwargs_change": {
-      "name": ""
-    },
     "min_input_args": 2
   },
   "torch.utils.cpp_extension.CppExtension": {
@@ -18116,9 +18113,6 @@
       "optional",
       "py_limited_api"
     ],
-    "kwargs_change": {
-      "name": ""
-    },
     "min_input_args": 2
   },
   "torch.utils.cpp_extension.load": {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->

PaddlePaddle/docs#7372

### PR APIs
<!-- APIs what you've done -->
```bash
torch.utils.cpp_extension.CUDAExtension
torch.utils.cpp_extension.CppExtension
```

`CppExtension`/`CUDAExtension` 避免删掉 `name` 参数，删掉后完全依赖自动推导时无法保证生成的 `.so` 名字和 torch 对齐，这会影响加载（import）