### PR TITLE
[API Compatibility] Add view_as_real, view_as_complex, autograd.Function, argwhere

### DIFF
--- a/paconvert/global_var.py
+++ b/paconvert/global_var.py
@@ -94,4 +94,8 @@ class GlobalManager:
         "torch.Tensor.short",
         "torch.Tensor.cfloat",
         "torch.Tensor.cdouble",
+        "torch.view_as_real",
+        "torch.view_as_complex",
+        "torch.autograd.Function",
+        "torch.argwhere",
     ]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->

### PR APIs
将 https://github.com/PaddlePaddle/Paddle/pull/74466 和 https://github.com/PaddlePaddle/Paddle/pull/74493 中已完成兼容性改造的 4 个 API 添加到 NO_NEED_CONVERT_LIST。具体包括：
- view_as_real
- view_as_complex
- autograd.Function
- argwhere

剩余一个 Tensor.mul\_ 需等待 multiply 升级后一并合入。