### PR TITLE
[API-Compat] Add compat.min/max/sort

### DIFF
--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -10484,19 +10484,8 @@
     "min_input_args": 1
   },
   "torch.max": {
-    "Matcher": "MaxMatcher",
-    "paddle_api": "paddle.max",
-    "args_list": [
-      "input",
-      "dim",
-      "keepdim",
-      "*",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
+    "Matcher": "UnchangeMatcher",
+    "paddle_api": "paddle.compat.max"
   },
   "torch.max_pool1d": {
     "Matcher": "GenericMatcher",
@@ -10614,19 +10603,8 @@
     ]
   },
   "torch.min": {
-    "Matcher": "MinMatcher",
-    "paddle_api": "paddle.min",
-    "args_list": [
-      "input",
-      "dim",
-      "keepdim",
-      "*",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
+    "Matcher": "UnchangeMatcher",
+    "paddle_api": "paddle.compat.min"
   },
   "torch.minimum": {
     "Matcher": "GenericMatcher",
@@ -17091,23 +17069,8 @@
     "min_input_args": 2
   },
   "torch.sort": {
-    "Matcher": "SortMatcher",
-    "paddle_api": "paddle.sort",
-    "min_input_args": 1,
-    "args_list": [
-      "input",
-      "dim",
-      "descending",
-      "*",
-      "stable",
-      "dim",
-      "descending",
-      "out"
-    ],
-    "kwargs_change": {
-      "input": "x",
-      "dim": "axis"
-    }
+    "Matcher": "UnchangeMatcher",
+    "paddle_api": "paddle.compat.sort"
   },
   "torch.sparse.FloatTensor": {
     "Matcher": "GenericMatcher",

--- a/tests/test_max.py
+++ b/tests/test_max.py
@@ -186,3 +186,70 @@ def test_case_15():
         """
     )
     obj.run(pytorch_code, ["result", "out"])
+
+
+def test_case_16():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[1, 2, 1], [3, 4, 6]], dtype=torch.float32)
+        x.requires_grad = True
+        y = x * x + x
+        values, indices = torch.max(keepdim=False, dim=1, input=y)
+        values.backward(torch.ones_like(values))
+        grad_tensor = x.grad
+        grad_tensor.requires_grad = False
+        """
+    )
+    obj.run(pytorch_code, ["indices", "grad_tensor"])
+
+
+def test_case_17():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[1, 2, 1], [3, 4, 6]], dtype=torch.float32)
+        x.requires_grad = True
+        y = x * 2
+        values = torch.max(input=y)
+        values.backward()
+        grad_tensor = x.grad
+        grad_tensor.requires_grad = False
+        """
+    )
+    obj.run(pytorch_code, ["values", "grad_tensor"])
+
+
+def test_case_18():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[1, 1, 2, 2], [3, 3, 4, 4], [1, 3, 2, 4]], dtype=torch.float32)
+        x.requires_grad = True
+        y = x * 2 + 1
+        results = torch.max(input=y, dim = 0)
+        results.values.backward(torch.ones_like(results.values))
+        grad_tensor = x.grad
+        grad_tensor.requires_grad = False
+        """
+    )
+    obj.run(pytorch_code, ["results", "grad_tensor"])
+
+
+def test_case_19():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[1, 1, 2, 2], [3, 3, 4, 4], [1, 3, 2, 4]], dtype=torch.float32)
+        y = torch.tensor([[2, 1, 1, 2], [4, 3, 4, 3], [3, 1, 4, 2]], dtype=torch.float32)
+        x.requires_grad = True
+        y.requires_grad = True
+        result = torch.max(x, y)
+        result.backward(torch.ones_like(result))
+        x.grad.requires_grad = False
+        y.grad.requires_grad = False
+        x_grad = x.grad
+        y_grad = y.grad
+        """
+    )
+    obj.run(pytorch_code, ["result", "x_grad", "y_grad"])

--- a/tests/test_min.py
+++ b/tests/test_min.py
@@ -174,3 +174,70 @@ def test_case_14():
         """
     )
     obj.run(pytorch_code, ["result", "out"])
+
+
+def test_case_15():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[1, 2, 1], [3, 4, 6]], dtype=torch.float32)
+        x.requires_grad = True
+        y = x * x + x
+        values, indices = torch.min(keepdim=False, dim=1, input=y)
+        values.backward(torch.ones_like(values))
+        grad_tensor = x.grad
+        grad_tensor.requires_grad = False
+        """
+    )
+    obj.run(pytorch_code, ["indices", "grad_tensor"])
+
+
+def test_case_16():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[1, 2, 1], [3, 4, 6]], dtype=torch.float32)
+        x.requires_grad = True
+        y = x * 2
+        values = torch.min(input=y)
+        values.backward()
+        grad_tensor = x.grad
+        grad_tensor.requires_grad = False
+        """
+    )
+    obj.run(pytorch_code, ["values", "grad_tensor"])
+
+
+def test_case_17():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[1, 1, 2, 2], [3, 3, 4, 4], [1, 3, 2, 4]], dtype=torch.float32)
+        x.requires_grad = True
+        y = x * 2 + 1
+        results = torch.min(input=y, dim = 0)
+        results.values.backward(torch.ones_like(results.values))
+        grad_tensor = x.grad
+        grad_tensor.requires_grad = False
+        """
+    )
+    obj.run(pytorch_code, ["results", "grad_tensor"])
+
+
+def test_case_18():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        x = torch.tensor([[1, 1, 2, 2], [3, 3, 4, 4], [1, 3, 2, 4]], dtype=torch.float32)
+        y = torch.tensor([[2, 1, 1, 2], [4, 3, 4, 3], [3, 1, 4, 2]], dtype=torch.float32)
+        x.requires_grad = True
+        y.requires_grad = True
+        result = torch.min(x, y)
+        result.backward(torch.ones_like(result))
+        x.grad.requires_grad = False
+        y.grad.requires_grad = False
+        x_grad = x.grad
+        y_grad = y.grad
+        """
+    )
+    obj.run(pytorch_code, ["result", "x_grad", "y_grad"])

--- a/tests/test_sort.py
+++ b/tests/test_sort.py
@@ -96,3 +96,43 @@ def test_case_7():
         """
     )
     obj.run(pytorch_code, ["result", "out"])
+
+
+def test_case_8():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([ 90, 124, 101,  20,  67,  88,  22,  82, 116, 121,  8,  69, 32,
+            100,  97,  25, 126, 114,  21,  90, 101,  34, 127, 105,  81,  72,
+            28, 127, 127, 122,  33,  86])
+        out = (torch.tensor(a), torch.tensor(a))
+        result = torch.sort(descending=True, out=out, dim=0, input=a, stable=True)
+        """
+    )
+    obj.run(pytorch_code, ["result", "out"])
+
+
+def test_case_9():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        a = torch.tensor([[ 80,  23,  57],
+            [ 69, 122,  39],
+            [ 15,  36,  50],
+            [121,   6,  65],
+            [ 36,  35,  72],
+            [ 18,  13,  15],
+            [ 79,  86,  98],
+            [107, 113,  30],
+            [ 41,  53,  59],
+            [ 23,  93, 116],
+            [ 28,  32,  87],
+            [ 89,  21,  20],
+            [ 83,  24,  99],
+            [  5,  15,  19],
+            [ 92,  28,  48],
+            [ 82, 117,  46]]).to(torch.int16)
+        vals, inds = torch.sort(dim=-1, stable=False, input=a)
+        """
+    )
+    obj.run(pytorch_code, ["vals", "inds"])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
- compat.Unfold/split/sort/min/max CN docs: https://github.com/PaddlePaddle/docs/pull/7396

### PR APIs
<!-- APIs what you've done -->
```bash
torch.max
torch.min
torch.sort
```
均转为了 UnchangedMatcher，增加了对应的单测。
