### PR TITLE
[API-Compat] Recover GPU Unittests for `scatter`/`gather`

### DIFF
--- a/tests/test_Tensor_scatter.py
+++ b/tests/test_Tensor_scatter.py
@@ -304,8 +304,7 @@ def test_case_20_complex():
     obj.run(pytorch_code, ["result", "input_grad", "src_grad"])
 
 
-# RuntimeError: scatter(): Expected dtype int64 for index
-def _test_case_21_complex():
+def test_case_21_complex():
     pytorch_code = textwrap.dedent(
         """
         import torch

--- a/tests/test_Tensor_scatter_.py
+++ b/tests/test_Tensor_scatter_.py
@@ -312,8 +312,7 @@ def test_case_21_complex():
     obj.run(pytorch_code, ["result", "input_grad", "src_grad"])
 
 
-#  RuntimeError: scatter(): Expected dtype int64 for index
-def _test_case_22_complex():
+def test_case_22_complex():
     pytorch_code = textwrap.dedent(
         """
         import torch

--- a/tests/test_gather.py
+++ b/tests/test_gather.py
@@ -205,8 +205,7 @@ def test_case_16():
     obj.run(pytorch_code, ["result", "out"])
 
 
-#  RuntimeError: gather(): Expected dtype int64 for index
-def _test_case_17_complex():
+def test_case_17_complex():
     pytorch_code = textwrap.dedent(
         """
         import torch

--- a/tests/test_scatter.py
+++ b/tests/test_scatter.py
@@ -365,8 +365,7 @@ def test_case_25_complex():
     obj.run(pytorch_code, ["result", "input_grad", "src_grad"])
 
 
-# RuntimeError: scatter(): Expected dtype int64 for index
-def _test_case_26_complex():
+def test_case_26_complex():
     # Test int32 reduce = add with shape mismatch
     pytorch_code = textwrap.dedent(
         """


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->

### PR APIs
<!-- APIs what you've done -->
本 PR 测试 GPU 下某些单测是否能正确运行。本地环境为 `A100` + `CUDA 11.8` 无问题。
torch 版本：`torch2.8.0+cu128`

```bash
torch.gather
toch.scatter
torch.Tensor.gather
torch.Tensor.scatter
torch.Tensor.scatter_
```
