### PR TITLE
[API Compatibility] Add `paddle.nn.functional.gelu`, `paddle.layer_norm` into `NO_NEED_CONVERT_LIST`

### DIFF
--- a/paconvert/global_var.py
+++ b/paconvert/global_var.py
@@ -564,6 +564,8 @@ class GlobalManager:
         "torch.Tensor.all",
         "torch.Tensor.any",
         "torch.tensor_split",
+        "torch.nn.functional.gelu",
+        "torch.layer_norm",
 
         # haoyang
         "torch.logical_not",


### PR DESCRIPTION
### PR Docs
| API | PR |
| :------- | :------: | 
| torch.nn.functional.gelu  | https://github.com/PaddlePaddle/Paddle/pull/75210 | 
| torch.layer_norm  | https://github.com/PaddlePaddle/Paddle/pull/75257 | 

### PR APIs
<!-- APIs what you've done -->
```bash
"torch.nn.functional.gelu",
"torch.layer_norm"
```

Execution Log
```
$ pytest tests/test_nn_functional_gelu.py
========================================================================================== test session starts ==========================================================================================
platform linux -- Python 3.9.16, pytest-8.4.1, pluggy-1.6.0 -- /bin/python
cachedir: .pytest_cache
rootdir: *****
configfile: pytest.ini
plugins: cov-6.2.1, anyio-4.9.0
collected 4 items                                                                                                                                                                                       

tests/test_nn_functional_gelu.py::test_case_1 W0916 16:18:51.015588 161746 gpu_resources.cc:114] Please NOTE: device: 0, GPU Compute Capability: 8.0, Driver API Version: 12.0, Runtime API Version: 11.8
PASSED
tests/test_nn_functional_gelu.py::test_case_2 PASSED
tests/test_nn_functional_gelu.py::test_case_3 PASSED
tests/test_nn_functional_gelu.py::test_case_4 PASSED

=========================================================================================== 4 passed in 8.22s ===========================================================================================
$ pytest tests/test_layer_norm.py 
========================================================================================== test session starts ==========================================================================================
platform linux -- Python 3.9.16, pytest-8.4.1, pluggy-1.6.0 -- /bin/python
cachedir: .pytest_cache
rootdir: *****
configfile: pytest.ini
plugins: cov-6.2.1, anyio-4.9.0
collected 6 items                                                                                                                                                                                       

tests/test_layer_norm.py::test_case_1 W0916 16:19:56.609458 162440 gpu_resources.cc:114] Please NOTE: device: 0, GPU Compute Capability: 8.0, Driver API Version: 12.0, Runtime API Version: 11.8
PASSED
tests/test_layer_norm.py::test_case_2 PASSED
tests/test_layer_norm.py::test_case_3 PASSED
tests/test_layer_norm.py::test_case_4 PASSED
tests/test_layer_norm.py::test_case_5 PASSED
tests/test_layer_norm.py::test_case_6 PASSED

=========================================================================================== 6 passed in 7.77s ===========================================================================================
```

