### PR TITLE
Reorder import statements in model_apibase.py

### DIFF
--- a/tests/torchvision_tests/model_apibase.py
+++ b/tests/torchvision_tests/model_apibase.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import numpy as np
-import paddle
 import torch
+import paddle
 from apibase import APIBase
 
 


### PR DESCRIPTION
tests/torchvision_tests/model_apibase.py 第16行先导入了 paddle，第17行才导入 torch，这会在 Windows 上触发两者 DLL 冲突，进而报 shm.dll 依赖错误。

<!-- Demo: https://github.com/PaddlePaddle/PaConvert/pull/80 -->
### PR Docs
<!-- Describe the docs PR corresponding the APIs -->

### PR APIs
<!-- APIs what you've done -->
```bash

```
