### PR TITLE
[API Compatibility No.191] Remove kwargs_change for poisson_nll_loss since Paddle now accepts target/eps aliases -part

### DIFF
--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -9109,10 +9109,6 @@
       "reduce",
       "reduction"
     ],
-    "kwargs_change": {
-      "target": "label",
-      "eps": "epsilon"
-    },
     "min_input_args": 2
   },
   "torch.nn.functional.prelu": {


### PR DESCRIPTION
## Summary
- Remove `kwargs_change` (`target` → `label`, `eps` → `epsilon`) from `torch.nn.functional.poisson_nll_loss` mapping in `api_mapping.json`
- Paddle PR [#77919](https://github.com/PaddlePaddle/Paddle/pull/77919) adds `@param_two_alias(["label", "target"], ["epsilon", "eps"])` decorator, so Paddle now natively accepts `target` and `eps` as parameter aliases
- Keep `SizeAverageMatcher` to continue handling deprecated `size_average` and `reduce` parameters

## Related PRs
- Paddle: https://github.com/PaddlePaddle/Paddle/pull/77919

## PR Category
User Experience

## PR Types
New features