### PR TITLE
[API Compatibility No.188] Remove kwargs_change for nll_loss since Paddle now accepts target alias -part

### DIFF
--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -9511,9 +9511,6 @@
       "reduce",
       "reduction"
     ],
-    "kwargs_change": {
-      "target": "label"
-    },
     "min_input_args": 2
   },
   "torch.nn.functional.normalize": {


### PR DESCRIPTION
## Summary
- Remove `kwargs_change` (`target` -> `label`) from `torch.nn.functional.nll_loss` mapping in `api_mapping.json`.
- Paddle PR [#78133](https://github.com/PaddlePaddle/Paddle/pull/78133) adds `@param_one_alias([label, target])`, so Paddle now natively accepts `target` as an alias.
- Keep `SizeAverageMatcher` unchanged for deprecated `size_average` / `reduce` handling.

## Related PRs
- Paddle: https://github.com/PaddlePaddle/Paddle/pull/78133

## PR Category
User Experience

## PR Types
New features