### PR TITLE
[API Compatibility] Switch BCE/MSE/multi_margin/nll_loss to ChangePrefixMatcher

### DIFF
--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -8390,20 +8390,7 @@
     }
   },
   "torch.nn.functional.binary_cross_entropy": {
-    "Matcher": "SizeAverageMatcher",
-    "paddle_api": "paddle.nn.functional.binary_cross_entropy",
-    "args_list": [
-      "input",
-      "target",
-      "weight",
-      "size_average",
-      "reduce",
-      "reduction"
-    ],
-    "kwargs_change": {
-      "target": "label"
-    },
-    "min_input_args": 2
+    "Matcher": "ChangePrefixMatcher"
   },
   "torch.nn.functional.binary_cross_entropy_with_logits": {
     "Matcher": "SizeAverageMatcher",
@@ -8985,37 +8972,10 @@
     "Matcher": "ChangePrefixMatcher"
   },
   "torch.nn.functional.mse_loss": {
-    "Matcher": "SizeAverageMatcher",
-    "paddle_api": "paddle.nn.functional.mse_loss",
-    "args_list": [
-      "input",
-      "target",
-      "size_average",
-      "reduce",
-      "reduction"
-    ],
-    "kwargs_change": {
-      "target": "label"
-    },
-    "min_input_args": 2
+    "Matcher": "ChangePrefixMatcher"
   },
   "torch.nn.functional.multi_margin_loss": {
-    "Matcher": "SizeAverageMatcher",
-    "paddle_api": "paddle.nn.functional.multi_margin_loss",
-    "args_list": [
-      "input",
-      "target",
-      "p",
-      "margin",
-      "weight",
-      "size_average",
-      "reduce",
-      "reduction"
-    ],
-    "kwargs_change": {
-      "target": "label"
-    },
-    "min_input_args": 2
+    "Matcher": "ChangePrefixMatcher"
   },
   "torch.nn.functional.multilabel_margin_loss": {
     "Matcher": "SizeAverageMatcher",
@@ -9049,21 +9009,7 @@
     "min_input_args": 2
   },
   "torch.nn.functional.nll_loss": {
-    "Matcher": "SizeAverageMatcher",
-    "paddle_api": "paddle.nn.functional.nll_loss",
-    "args_list": [
-      "input",
-      "target",
-      "weight",
-      "size_average",
-      "ignore_index",
-      "reduce",
-      "reduction"
-    ],
-    "kwargs_change": {
-      "target": "label"
-    },
-    "min_input_args": 2
+    "Matcher": "ChangePrefixMatcher"
   },
   "torch.nn.functional.normalize": {
     "Matcher": "ChangePrefixMatcher"

--- a/tests/test_nn_functional_binary_cross_entropy.py
+++ b/tests/test_nn_functional_binary_cross_entropy.py
@@ -200,3 +200,35 @@ def test_case_12():
         """
     )
     obj.run(pytorch_code, ["result"])
+
+
+def test_case_13():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.tensor([[0.12, 0.73, 0.41],
+            [0.88, 0.26, 0.64]], dtype=torch.float32)
+        target = torch.tensor([[0., 1., 0.],
+            [1., 0., 1.]], dtype=torch.float32)
+        weight = torch.tensor([[0.5, 0.2, 0.7],
+            [0.3, 0.9, 0.4]], dtype=torch.float32)
+        result = torch.nn.functional.binary_cross_entropy(input=input, target=target, weight=weight, reduction='sum')
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_14():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.tensor([[0.18, 0.67, 0.39],
+            [0.81, 0.34, 0.58]], dtype=torch.float32)
+        target = torch.tensor([[0., 1., 0.],
+            [1., 0., 1.]], dtype=torch.float32)
+        weight = torch.tensor([[0.4, 0.8, 0.6],
+            [0.7, 0.3, 0.5]], dtype=torch.float32)
+        result = torch.nn.functional.binary_cross_entropy(input, target=target, weight=weight, size_average=False, reduce=True)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_nn_functional_mse_loss.py
+++ b/tests/test_nn_functional_mse_loss.py
@@ -189,3 +189,31 @@ def test_case_12():
         """
     )
     obj.run(pytorch_code, ["result"])
+
+
+def test_case_13():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.tensor([[1.25, -0.75, 0.33],
+            [0.48, 1.12, -1.42]], dtype=torch.float32)
+        target = torch.tensor([[0.75, -0.25, 0.10],
+            [1.50, 0.80, -0.90]], dtype=torch.float32)
+        result = torch.nn.functional.mse_loss(input=input, target=target, reduction='sum')
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_14():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.tensor([[1.10, -0.60, 0.45],
+            [0.52, 1.35, -1.10]], dtype=torch.float32)
+        target = torch.tensor([[0.65, -0.15, 0.25],
+            [1.20, 0.95, -0.70]], dtype=torch.float32)
+        result = torch.nn.functional.mse_loss(input, target=target, size_average=False, reduce=True)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_nn_functional_multi_margin_loss.py
+++ b/tests/test_nn_functional_multi_margin_loss.py
@@ -177,3 +177,31 @@ def test_case_12():
         """
     )
     obj.run(pytorch_code, ["result"])
+
+
+def test_case_13():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.tensor([[0.42, -1.15, 1.37],
+            [1.08, 0.25, -0.74]], dtype=torch.float32)
+        target = torch.tensor([2, 0], dtype=torch.long)
+        weight = torch.tensor([0.4, 0.8, 0.6], dtype=torch.float32)
+        result = torch.nn.functional.multi_margin_loss(input=input, target=target, p=2, margin=0.7, weight=weight, reduction='sum')
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_14():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        input = torch.tensor([[0.31, -0.84, 1.22],
+            [1.45, 0.18, -0.52]], dtype=torch.float32)
+        target = torch.tensor([2, 0], dtype=torch.long)
+        weight = torch.tensor([0.5, 0.7, 0.3], dtype=torch.float32)
+        result = torch.nn.functional.multi_margin_loss(input, target=target, p=1, margin=1.2, weight=weight, size_average=False, reduce=True)
+        """
+    )
+    obj.run(pytorch_code, ["result"])

--- a/tests/test_nn_functional_nll_loss.py
+++ b/tests/test_nn_functional_nll_loss.py
@@ -24,9 +24,10 @@ def test_case_1():
         """
         import torch
         import torch.nn as nn
-        input = torch.tensor([[-1.2837, -0.0297,  0.0355],
-            [ 0.9112, -1.7526, -0.4061]])
-        target = torch.tensor([1, 2])
+        logits = torch.tensor([[1.2837, -0.0297, 0.0355],
+            [0.9112, -1.7526, -0.4061]])
+        input = torch.nn.functional.log_softmax(logits, dim=1)
+        target = torch.tensor([1, 2], dtype=torch.long)
         result = torch.nn.functional.nll_loss(input, target, size_average=True)
         """
     )
@@ -38,9 +39,10 @@ def test_case_2():
         """
         import torch
         import torch.nn as nn
-        input = torch.tensor([[-1.2837, -0.0297,  0.0355],
-            [ 0.9112, -1.7526, -0.4061]])
-        target = torch.tensor([1, 2])
+        logits = torch.tensor([[1.2837, -0.0297, 0.0355],
+            [0.9112, -1.7526, -0.4061]])
+        input = torch.nn.functional.log_softmax(logits, dim=1)
+        target = torch.tensor([1, 2], dtype=torch.long)
         result = torch.nn.functional.nll_loss(input, target, size_average=False)
         """
     )
@@ -52,9 +54,10 @@ def test_case_3():
         """
         import torch
         import torch.nn as nn
-        input = torch.tensor([[-1.2837, -0.0297,  0.0355],
-            [ 0.9112, -1.7526, -0.4061]])
-        target = torch.tensor([1, 2])
+        logits = torch.tensor([[1.2837, -0.0297, 0.0355],
+            [0.9112, -1.7526, -0.4061]])
+        input = torch.nn.functional.log_softmax(logits, dim=1)
+        target = torch.tensor([1, 2], dtype=torch.long)
         result = torch.nn.functional.nll_loss(input, target, reduction='none')
         """
     )
@@ -66,9 +69,10 @@ def test_case_4():
         """
         import torch
         import torch.nn as nn
-        input = torch.tensor([[-1.2837, -0.0297,  0.0355],
-            [ 0.9112, -1.7526, -0.4061]])
-        target = torch.tensor([1, 2])
+        logits = torch.tensor([[1.2837, -0.0297, 0.0355],
+            [0.9112, -1.7526, -0.4061]])
+        input = torch.nn.functional.log_softmax(logits, dim=1)
+        target = torch.tensor([1, 2], dtype=torch.long)
         result = torch.nn.functional.nll_loss(input, target, reduction='mean')
         """
     )
@@ -80,9 +84,10 @@ def test_case_5():
         """
         import torch
         import torch.nn as nn
-        input = torch.tensor([[-1.2837, -0.0297,  0.0355],
-            [ 0.9112, -1.7526, -0.4061]])
-        target = torch.tensor([1, 2])
+        logits = torch.tensor([[1.2837, -0.0297, 0.0355],
+            [0.9112, -1.7526, -0.4061]])
+        input = torch.nn.functional.log_softmax(logits, dim=1)
+        target = torch.tensor([1, 2], dtype=torch.long)
         result = torch.nn.functional.nll_loss(input, target, reduction='sum')
         """
     )
@@ -94,9 +99,10 @@ def test_case_6():
         """
         import torch
         import torch.nn as nn
-        input = torch.tensor([[-1.2837, -0.0297,  0.0355],
-            [ 0.9112, -1.7526, -0.4061]])
-        target = torch.tensor([1, 2])
+        logits = torch.tensor([[1.2837, -0.0297, 0.0355],
+            [0.9112, -1.7526, -0.4061]])
+        input = torch.nn.functional.log_softmax(logits, dim=1)
+        target = torch.tensor([1, 2], dtype=torch.long)
         result = torch.nn.functional.nll_loss(input, target, reduce=True)
         """
     )
@@ -108,9 +114,10 @@ def test_case_7():
         """
         import torch
         import torch.nn as nn
-        input = torch.tensor([[-1.2837, -0.0297,  0.0355],
-            [ 0.9112, -1.7526, -0.4061]])
-        target = torch.tensor([1, 2])
+        logits = torch.tensor([[1.2837, -0.0297, 0.0355],
+            [0.9112, -1.7526, -0.4061]])
+        input = torch.nn.functional.log_softmax(logits, dim=1)
+        target = torch.tensor([1, 2], dtype=torch.long)
         result = torch.nn.functional.nll_loss(input, target, reduce=False)
         """
     )
@@ -122,9 +129,10 @@ def test_case_8():
         """
         import torch
         import torch.nn as nn
-        input = torch.tensor([[-1.2837, -0.0297,  0.0355],
-            [ 0.9112, -1.7526, -0.4061]])
-        target = torch.tensor([1, 2])
+        logits = torch.tensor([[1.2837, -0.0297, 0.0355],
+            [0.9112, -1.7526, -0.4061]])
+        input = torch.nn.functional.log_softmax(logits, dim=1)
+        target = torch.tensor([1, 2], dtype=torch.long)
         result = torch.nn.functional.nll_loss(input, target, weight=None, size_average=None, ignore_index=-100, reduce=True, reduction='mean')
         """
     )
@@ -137,9 +145,10 @@ def test_case_9():
         """
         import torch
         import torch.nn as nn
-        input = torch.tensor([[-1.2837, -0.0297,  0.0355],
-            [ 0.9112, -1.7526, -0.4061]])
-        target = torch.tensor([1, 2])
+        logits = torch.tensor([[1.2837, -0.0297, 0.0355],
+            [0.9112, -1.7526, -0.4061]])
+        input = torch.nn.functional.log_softmax(logits, dim=1)
+        target = torch.tensor([1, 2], dtype=torch.long)
         result = torch.nn.functional.nll_loss(input, target, None, None, -100, True, 'mean')
         """
     )
@@ -152,9 +161,10 @@ def test_case_10():
         """
         import torch
         import torch.nn as nn
-        input = torch.tensor([[-1.2837, -0.0297,  0.0355],
-            [ 0.9112, -1.7526, -0.4061]])
-        target = torch.tensor([1, 2])
+        logits = torch.tensor([[1.2837, -0.0297, 0.0355],
+            [0.9112, -1.7526, -0.4061]])
+        input = torch.nn.functional.log_softmax(logits, dim=1)
+        target = torch.tensor([1, 2], dtype=torch.long)
         result = torch.nn.functional.nll_loss(input=input, target=target, weight=None, size_average=None, ignore_index=-100, reduce=True, reduction='mean')
         """
     )
@@ -167,9 +177,10 @@ def test_case_11():
         """
         import torch
         import torch.nn as nn
-        input = torch.tensor([[-1.2837, -0.0297,  0.0355],
-            [ 0.9112, -1.7526, -0.4061]])
-        target = torch.tensor([1, 2])
+        logits = torch.tensor([[1.2837, -0.0297, 0.0355],
+            [0.9112, -1.7526, -0.4061]])
+        input = torch.nn.functional.log_softmax(logits, dim=1)
+        target = torch.tensor([1, 2], dtype=torch.long)
         result = torch.nn.functional.nll_loss(reduction='mean', reduce=True, ignore_index=-100, size_average=None, weight=None, target=target, input=input)
         """
     )
@@ -182,10 +193,41 @@ def test_case_12():
         """
         import torch
         import torch.nn as nn
-        input = torch.tensor([[-1.2837, -0.0297,  0.0355],
-            [ 0.9112, -1.7526, -0.4061]])
-        target = torch.tensor([1, 2])
+        logits = torch.tensor([[1.2837, -0.0297, 0.0355],
+            [0.9112, -1.7526, -0.4061]])
+        input = torch.nn.functional.log_softmax(logits, dim=1)
+        target = torch.tensor([1, 2], dtype=torch.long)
         result = torch.nn.functional.nll_loss(input, target)
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_13():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        logits = torch.tensor([[1.30, -0.20, 0.70],
+            [-0.45, 1.10, 0.25]], dtype=torch.float32)
+        input = torch.nn.functional.log_softmax(logits, dim=1)
+        target = torch.tensor([0, 1], dtype=torch.long)
+        weight = torch.tensor([0.4, 0.8, 0.6], dtype=torch.float32)
+        result = torch.nn.functional.nll_loss(input=input, target=target, weight=weight, ignore_index=-100, reduction='sum')
+        """
+    )
+    obj.run(pytorch_code, ["result"])
+
+
+def test_case_14():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        logits = torch.tensor([[0.80, -0.35, 1.15],
+            [-0.20, 0.95, 0.40]], dtype=torch.float32)
+        input = torch.nn.functional.log_softmax(logits, dim=1)
+        target = torch.tensor([2, 1], dtype=torch.long)
+        weight = torch.tensor([0.6, 0.5, 0.9], dtype=torch.float32)
+        result = torch.nn.functional.nll_loss(input, target=target, weight=weight, size_average=False, ignore_index=-100, reduce=True)
         """
     )
     obj.run(pytorch_code, ["result"])


### PR DESCRIPTION
### PR Category
User Experience

### PR Types
New features

### Description
After the Paddle-side alignment for legacy reduction args and `target` alias handling, switch these functional loss mappings to prefix-only conversion:
- `torch.nn.functional.binary_cross_entropy`
- `torch.nn.functional.mse_loss`
- `torch.nn.functional.multi_margin_loss`
- `torch.nn.functional.nll_loss`

This PR:
- changes the four mappings to `ChangePrefixMatcher`
- removes the extra `target -> label` rewrite / `SizeAverageMatcher` config for these APIs
- relies on runnable PaConvert tests to verify the converted Paddle code executes successfully

Related Paddle PR:
- https://github.com/PaddlePaddle/Paddle/pull/78574
