### PR TITLE
优化 UnitTest CI 稳定性：固定 GPU 工作目录、收敛 pytest 路径并隔离 stateful tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 ; print user output; clear warning
 addopts = -v -s -p no:warnings
 timeout = 100
+testpaths = tests
+pythonpath = tests

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,9 @@
 ; print user output; clear warning
 addopts = -v -s -p no:warnings
 timeout = 100
+; 固定默认测试收集根目录，减少从不同入口目录启动 pytest 时的收集差异。
+; 这样即使脚本或开发者没有显式传 tests/，默认发现行为也会落在仓库的测试目录下。
 testpaths = tests
+; 显式把 tests 加入导入路径，稳定 `from apibase import APIBase` 这类测试工具导入。
+; 这一步主要用于收敛“全量执行、单文件执行、python -m pytest”之间的导入差异。
 pythonpath = tests

--- a/scripts/unittest_check.sh
+++ b/scripts/unittest_check.sh
@@ -14,7 +14,34 @@
 
 set +x
 
-cd /workspace/$1/PaConvert/
+cd /workspace/$1/PaConvert/ || {
+    echo "[unittest-cpu] Failed to enter repo root: /workspace/$1/PaConvert/"
+    exit 1
+}
+
+test -f requirements.txt || {
+    echo "[unittest-cpu] requirements.txt not found under repo root"
+    exit 1
+}
+
+test -d tests || {
+    echo "[unittest-cpu] tests directory not found under repo root"
+    exit 1
+}
+
+# These files mutate process-level defaults and are more stable when run in
+# their own pytest process after the main suite.
+ISOLATED_TEST_FILES=(
+  ./tests/test_set_default_device.py
+  ./tests/test_set_default_dtype.py
+  ./tests/test_set_num_threads.py
+  ./tests/test_set_printoptions.py
+)
+
+IGNORE_ARGS=()
+for test_file in "${ISOLATED_TEST_FILES[@]}"; do
+    IGNORE_ARGS+=("--ignore=${test_file}")
+done
 
 echo '************************************************************************************************************'
 echo "Insalling latest release cpu version torch"
@@ -47,10 +74,32 @@ python -m pip install -r requirements.txt
 echo '************************************************************************************************************'
 echo "Checking code cpu unit test by pytest ..."
 python -m pip install pytest-timeout
-python -m pytest -v -s -p no:warnings ./tests;check_error=$?
-if [ ${check_error} != 0 ];then
-    echo "Rerun cpu unit test check." 
-    python -m pytest -v -s -p no:warnings --lf ./tests; check_error=$?
+PYTHONPATH=.:tests python -m pytest -v -s -p no:warnings "${IGNORE_ARGS[@]}" ./tests
+first_run_error=$?
+
+if [ ${first_run_error} != 0 ]; then
+    echo "[unittest-cpu] Diagnostic rerun of failed tests. This does not change the final result."
+    PYTHONPATH=.:tests python -m pytest -v -s -p no:warnings "${IGNORE_ARGS[@]}" --lf ./tests || true
+fi
+
+check_error=${first_run_error}
+
+if [ ${first_run_error} = 0 ]; then
+    isolated_error=0
+    for test_file in "${ISOLATED_TEST_FILES[@]}"; do
+        echo "[unittest-cpu] Running isolated test file: ${test_file}"
+        PYTHONPATH=.:tests python -m pytest -v -s -p no:warnings "${test_file}"
+        file_error=$?
+
+        if [ ${file_error} != 0 ]; then
+            echo "[unittest-cpu] Diagnostic rerun for isolated file: ${test_file}. This does not change the final result."
+            PYTHONPATH=.:tests python -m pytest -v -s -p no:warnings "${test_file}" || true
+            isolated_error=${file_error}
+            break
+        fi
+    done
+
+    check_error=${isolated_error}
 fi
 
 echo '************************************************************************************************************'

--- a/scripts/unittest_check.sh
+++ b/scripts/unittest_check.sh
@@ -14,11 +14,22 @@
 
 set +x
 
+# 先显式进入 repo root，而不是继续依赖外部调用方的当前目录。
+# 这样后续所有相对路径都会稳定落在同一个工作区下，包括：
+# 1. requirements.txt 的安装路径
+# 2. pytest ./tests 的收集根目录
+# 3. tests/apibase.py 中基于 os.getcwd() 生成的临时文件目录
+# 如果这里进入失败，就直接中断，避免后面出现更难读的连锁报错。
 cd /workspace/$1/PaConvert/ || {
     echo "[unittest-cpu] Failed to enter repo root: /workspace/$1/PaConvert/"
     exit 1
 }
 
+# 这两个检查属于 fail-fast：
+# 1. requirements.txt 用于后续安装测试依赖
+# 2. tests 是 unittest 主入口
+# 如果这两个路径在当前目录下都不可见，说明 workspace 本身或 cwd 已经不对，
+# 继续跑只会把真正的问题伪装成 pip/pytest 的噪声错误。
 test -f requirements.txt || {
     echo "[unittest-cpu] requirements.txt not found under repo root"
     exit 1
@@ -31,6 +42,12 @@ test -d tests || {
 
 # These files mutate process-level defaults and are more stable when run in
 # their own pytest process after the main suite.
+# 这些文件会修改默认 device / dtype / tensor type / 线程数 / printoptions 等进程级状态。
+# 本次改法分两步：
+# 1. 主套件先通过 --ignore 跳过它们，只验证普通测试
+# 2. 再为每个文件单独启动一个 pytest 进程执行
+# 目的不是跳过这些测试，而是通过进程边界隔离副作用，降低 first-run 全量执行时
+# 因状态污染导致的“第一次失败、rerun 又通过”的概率。
 ISOLATED_TEST_FILES=(
   ./tests/test_set_default_device.py
   ./tests/test_set_default_dtype.py
@@ -39,6 +56,8 @@ ISOLATED_TEST_FILES=(
   ./tests/test_set_printoptions.py
 )
 
+# 把上面的列表转换成 pytest 所需的 --ignore 参数。
+# 这样做可以避免手写重复命令，同时确保 CPU/GPU 两个脚本使用完全一致的隔离集合。
 IGNORE_ARGS=()
 for test_file in "${ISOLATED_TEST_FILES[@]}"; do
     IGNORE_ARGS+=("--ignore=${test_file}")
@@ -75,14 +94,25 @@ python -m pip install -r requirements.txt
 echo '************************************************************************************************************'
 echo "Checking code cpu unit test by pytest ..."
 python -m pip install pytest-timeout
+# 这里显式设置 PYTHONPATH=.:tests，有两个目的：
+# 1. 让脚本直接调用 python -m pytest 时，也能稳定导入 tests/apibase.py
+# 2. 与 pytest.ini 中 pythonpath = tests 的配置形成显式兜底
+# 主套件先忽略掉 stateful 文件，把“普通测试是否稳定”单独跑出来看。
 PYTHONPATH=.:tests python -m pytest -v -s -p no:warnings "${IGNORE_ARGS[@]}" ./tests
 first_run_error=$?
 
+# 首轮结果决定最终 success / fail。
+# 如果首轮失败，保留一次 --lf rerun 仅用于诊断日志，帮助判断失败是否具有顺序相关性；
+# 但 rerun 结果不会再覆盖首轮退出码，避免把真实问题“洗绿”。
 if [ ${first_run_error} != 0 ]; then
     echo "[unittest-cpu] Diagnostic rerun of failed tests. This does not change the final result."
     PYTHONPATH=.:tests python -m pytest -v -s -p no:warnings "${IGNORE_ARGS[@]}" --lf ./tests || true
 fi
 
+# 接下来逐个执行隔离文件。每个文件都会启动新的 pytest 进程：
+# 1. 前一个文件留下的全局状态不会泄漏到下一个文件
+# 2. 一旦某个隔离文件失败，再追加一次诊断性 rerun 方便看日志
+# 3. isolated_error 只记录“是否存在任一隔离文件失败”，最后与主套件统一汇总
 isolated_error=0
 for test_file in "${ISOLATED_TEST_FILES[@]}"; do
     echo "[unittest-cpu] Running isolated test file: ${test_file}"
@@ -96,6 +126,9 @@ for test_file in "${ISOLATED_TEST_FILES[@]}"; do
     fi
 done
 
+# 最终退出码采用主套件和隔离套件的并集语义：
+# - 任意一边失败，整个 unittest job 都失败
+# - 不因为诊断 rerun 通过而掩盖 first-run 的真实结果
 check_error=0
 if [ ${first_run_error} != 0 ] || [ ${isolated_error} != 0 ]; then
     check_error=1

--- a/scripts/unittest_check.sh
+++ b/scripts/unittest_check.sh
@@ -34,6 +34,7 @@ test -d tests || {
 ISOLATED_TEST_FILES=(
   ./tests/test_set_default_device.py
   ./tests/test_set_default_dtype.py
+  ./tests/test_set_default_tensor_type.py
   ./tests/test_set_num_threads.py
   ./tests/test_set_printoptions.py
 )
@@ -82,24 +83,22 @@ if [ ${first_run_error} != 0 ]; then
     PYTHONPATH=.:tests python -m pytest -v -s -p no:warnings "${IGNORE_ARGS[@]}" --lf ./tests || true
 fi
 
-check_error=${first_run_error}
+isolated_error=0
+for test_file in "${ISOLATED_TEST_FILES[@]}"; do
+    echo "[unittest-cpu] Running isolated test file: ${test_file}"
+    PYTHONPATH=.:tests python -m pytest -v -s -p no:warnings "${test_file}"
+    file_error=$?
 
-if [ ${first_run_error} = 0 ]; then
-    isolated_error=0
-    for test_file in "${ISOLATED_TEST_FILES[@]}"; do
-        echo "[unittest-cpu] Running isolated test file: ${test_file}"
-        PYTHONPATH=.:tests python -m pytest -v -s -p no:warnings "${test_file}"
-        file_error=$?
+    if [ ${file_error} != 0 ]; then
+        echo "[unittest-cpu] Diagnostic rerun for isolated file: ${test_file}. This does not change the final result."
+        PYTHONPATH=.:tests python -m pytest -v -s -p no:warnings "${test_file}" || true
+        isolated_error=1
+    fi
+done
 
-        if [ ${file_error} != 0 ]; then
-            echo "[unittest-cpu] Diagnostic rerun for isolated file: ${test_file}. This does not change the final result."
-            PYTHONPATH=.:tests python -m pytest -v -s -p no:warnings "${test_file}" || true
-            isolated_error=${file_error}
-            break
-        fi
-    done
-
-    check_error=${isolated_error}
+check_error=0
+if [ ${first_run_error} != 0 ] || [ ${isolated_error} != 0 ]; then
+    check_error=1
 fi
 
 echo '************************************************************************************************************'

--- a/scripts/unittest_check_gpu.sh
+++ b/scripts/unittest_check_gpu.sh
@@ -19,6 +19,8 @@ cd /workspace/$1/PaConvert/ || {
     exit 1
 }
 
+echo "Current working directory: $(pwd)"
+
 test -f requirements.txt || {
     echo "[unittest-gpu] requirements.txt not found under repo root"
     exit 1
@@ -34,6 +36,7 @@ test -d tests || {
 ISOLATED_TEST_FILES=(
   ./tests/test_set_default_device.py
   ./tests/test_set_default_dtype.py
+  ./tests/test_set_default_tensor_type.py
   ./tests/test_set_num_threads.py
   ./tests/test_set_printoptions.py
 )
@@ -84,24 +87,22 @@ if [ ${first_run_error} != 0 ]; then
     PYTHONPATH=.:tests python -m pytest -v -s -p no:warnings -n 1 "${IGNORE_ARGS[@]}" --lf ./tests || true
 fi
 
-check_error=${first_run_error}
+isolated_error=0
+for test_file in "${ISOLATED_TEST_FILES[@]}"; do
+    echo "[unittest-gpu] Running isolated test file: ${test_file}"
+    PYTHONPATH=.:tests python -m pytest -v -s -p no:warnings -n 1 "${test_file}"
+    file_error=$?
 
-if [ ${first_run_error} = 0 ]; then
-    isolated_error=0
-    for test_file in "${ISOLATED_TEST_FILES[@]}"; do
-        echo "[unittest-gpu] Running isolated test file: ${test_file}"
-        PYTHONPATH=.:tests python -m pytest -v -s -p no:warnings -n 1 "${test_file}"
-        file_error=$?
+    if [ ${file_error} != 0 ]; then
+        echo "[unittest-gpu] Diagnostic rerun for isolated file: ${test_file}. This does not change the final result."
+        PYTHONPATH=.:tests python -m pytest -v -s -p no:warnings -n 1 "${test_file}" || true
+        isolated_error=1
+    fi
+done
 
-        if [ ${file_error} != 0 ]; then
-            echo "[unittest-gpu] Diagnostic rerun for isolated file: ${test_file}. This does not change the final result."
-            PYTHONPATH=.:tests python -m pytest -v -s -p no:warnings -n 1 "${test_file}" || true
-            isolated_error=${file_error}
-            break
-        fi
-    done
-
-    check_error=${isolated_error}
+check_error=0
+if [ ${first_run_error} != 0 ] || [ ${isolated_error} != 0 ]; then
+    check_error=1
 fi
 
 echo '************************************************************************************************************'

--- a/scripts/unittest_check_gpu.sh
+++ b/scripts/unittest_check_gpu.sh
@@ -14,6 +14,35 @@
 
 set +x
 
+cd /workspace/$1/PaConvert/ || {
+    echo "[unittest-gpu] Failed to enter repo root: /workspace/$1/PaConvert/"
+    exit 1
+}
+
+test -f requirements.txt || {
+    echo "[unittest-gpu] requirements.txt not found under repo root"
+    exit 1
+}
+
+test -d tests || {
+    echo "[unittest-gpu] tests directory not found under repo root"
+    exit 1
+}
+
+# These files mutate process-level defaults and are more stable when run in
+# their own pytest process after the main suite.
+ISOLATED_TEST_FILES=(
+  ./tests/test_set_default_device.py
+  ./tests/test_set_default_dtype.py
+  ./tests/test_set_num_threads.py
+  ./tests/test_set_printoptions.py
+)
+
+IGNORE_ARGS=()
+for test_file in "${ISOLATED_TEST_FILES[@]}"; do
+    IGNORE_ARGS+=("--ignore=${test_file}")
+done
+
 echo '************************************************************************************************************'
 echo "Insalling latest release gpu version torch"
 python -m pip uninstall -y torchaudio
@@ -46,11 +75,33 @@ python -m pip install -r requirements.txt
 
 echo '************************************************************************************************************'
 echo "Checking code gpu unit test by pytest ..."
-python -m pip install pytest-timeout pytest-xdist pytest-rerunfailures
-python -m pytest -v -s -p no:warnings -n 1 --reruns=3 ./tests; check_error=$?
-if [ ${check_error} != 0 ];then
-    echo "Rerun gpu unit test check." 
-    python -m pytest -v -s -p no:warnings -n 1 --lf ./tests; check_error=$?
+python -m pip install pytest-timeout pytest-xdist
+PYTHONPATH=.:tests python -m pytest -v -s -p no:warnings -n 1 "${IGNORE_ARGS[@]}" ./tests
+first_run_error=$?
+
+if [ ${first_run_error} != 0 ]; then
+    echo "[unittest-gpu] Diagnostic rerun of failed tests. This does not change the final result."
+    PYTHONPATH=.:tests python -m pytest -v -s -p no:warnings -n 1 "${IGNORE_ARGS[@]}" --lf ./tests || true
+fi
+
+check_error=${first_run_error}
+
+if [ ${first_run_error} = 0 ]; then
+    isolated_error=0
+    for test_file in "${ISOLATED_TEST_FILES[@]}"; do
+        echo "[unittest-gpu] Running isolated test file: ${test_file}"
+        PYTHONPATH=.:tests python -m pytest -v -s -p no:warnings -n 1 "${test_file}"
+        file_error=$?
+
+        if [ ${file_error} != 0 ]; then
+            echo "[unittest-gpu] Diagnostic rerun for isolated file: ${test_file}. This does not change the final result."
+            PYTHONPATH=.:tests python -m pytest -v -s -p no:warnings -n 1 "${test_file}" || true
+            isolated_error=${file_error}
+            break
+        fi
+    done
+
+    check_error=${isolated_error}
 fi
 
 echo '************************************************************************************************************'

--- a/scripts/unittest_check_gpu.sh
+++ b/scripts/unittest_check_gpu.sh
@@ -14,13 +14,22 @@
 
 set +x
 
+# GPU 脚本之前没有像 CPU 脚本一样固定 cwd，导致它更依赖外部调用方从哪里触发。
+# 这里统一切到 repo root，是为了让 requirements.txt、./tests 以及 apibase 的临时文件路径
+# 都基于同一个仓库目录；如果 workspace 或 $1 不对，就立刻失败并给出明确日志。
 cd /workspace/$1/PaConvert/ || {
     echo "[unittest-gpu] Failed to enter repo root: /workspace/$1/PaConvert/"
     exit 1
 }
 
+# 这行日志用于在 CI 首屏确认 GPU job 是否真的进入了预期目录，
+# 排查“同一脚本在不同入口目录下行为不一致”的问题时会更直观。
 echo "Current working directory: $(pwd)"
 
+# 与 CPU 脚本相同，先做最小环境自检：
+# - requirements.txt 决定依赖安装是否可执行
+# - tests 目录决定 pytest 收集是否能落在正确位置
+# 如果这两个路径不可见，就说明当前工作区本身已经不满足执行前提。
 test -f requirements.txt || {
     echo "[unittest-gpu] requirements.txt not found under repo root"
     exit 1
@@ -33,6 +42,11 @@ test -d tests || {
 
 # These files mutate process-level defaults and are more stable when run in
 # their own pytest process after the main suite.
+# 这些文件会修改进程级默认状态，是引发全量执行顺序污染的高风险集合。
+# 处理方式与 CPU 一致：
+# 1. 主套件先忽略它们
+# 2. 再逐个单文件、单独进程执行
+# 这样既不丢掉覆盖率，也能把“普通测试”和“全局状态测试”的影响面拆开观察。
 ISOLATED_TEST_FILES=(
   ./tests/test_set_default_device.py
   ./tests/test_set_default_dtype.py
@@ -41,6 +55,7 @@ ISOLATED_TEST_FILES=(
   ./tests/test_set_printoptions.py
 )
 
+# 统一生成 pytest --ignore 参数，避免人工维护两套重复命令。
 IGNORE_ARGS=()
 for test_file in "${ISOLATED_TEST_FILES[@]}"; do
     IGNORE_ARGS+=("--ignore=${test_file}")
@@ -78,15 +93,23 @@ python -m pip install -r requirements.txt
 
 echo '************************************************************************************************************'
 echo "Checking code gpu unit test by pytest ..."
+# GPU 这边保留 pytest-xdist，因为脚本原本就在使用 -n 1 的执行方式；
+# 但去掉 pytest-rerunfailures/--reruns=3，避免 first-run 失败被自动重试掩盖。
 python -m pip install pytest-timeout pytest-xdist
+# 这里同样显式设置 PYTHONPATH=.:tests，确保 GPU CI 在脚本直接调用 python -m pytest 时，
+# 对 tests/apibase.py 的导入与 pytest.ini 中的配置保持一致。
 PYTHONPATH=.:tests python -m pytest -v -s -p no:warnings -n 1 "${IGNORE_ARGS[@]}" ./tests
 first_run_error=$?
 
+# 首轮结果决定最终成败；失败后保留一次 --lf rerun 仅用于诊断，
+# 方便观察失败是否与执行顺序或环境状态相关，但不会再改变最终 exit code。
 if [ ${first_run_error} != 0 ]; then
     echo "[unittest-gpu] Diagnostic rerun of failed tests. This does not change the final result."
     PYTHONPATH=.:tests python -m pytest -v -s -p no:warnings -n 1 "${IGNORE_ARGS[@]}" --lf ./tests || true
 fi
 
+# 逐个执行隔离文件，让每个 stateful 文件都跑在新的 pytest 进程里。
+# 这样即使某个文件会修改默认 device / dtype，也不会把副作用泄漏到其他测试文件。
 isolated_error=0
 for test_file in "${ISOLATED_TEST_FILES[@]}"; do
     echo "[unittest-gpu] Running isolated test file: ${test_file}"
@@ -100,6 +123,8 @@ for test_file in "${ISOLATED_TEST_FILES[@]}"; do
     fi
 done
 
+# 最终退出码仍然只看“主套件 + 隔离套件”的 first-run 结果。
+# 任何一边失败都应该让 job fail，这样 CI 才能真实暴露不稳定问题。
 check_error=0
 if [ ${first_run_error} != 0 ] || [ ${isolated_error} != 0 ]; then
     check_error=1


### PR DESCRIPTION
### 背景

当前 UnitTest CI 存在一类典型的不稳定现象：

- 首次执行 `pytest ./tests` 时出现批量失败
- 随后执行 rerun 或 `--lf` 时又通过

结合现有日志和脚本行为，这类问题主要有 4 个风险来源：

- GPU CI 脚本没有像 CPU CI 一样显式切到仓库根目录，执行行为依赖外部调用方的 cwd
- `pytest.ini` 没有固定 `testpaths` / `pythonpath`，全量执行和单文件执行的收集、导入语义不够稳定
- rerun 目前承担了“放行”作用，容易把 first-run flaky 洗成绿色
- 一些会修改全局状态的测试文件和普通测试混跑，容易造成进程级污染

### 本次改动

本 PR 只改了 3 个文件：

- `pytest.ini`
- `scripts/unittest_check.sh`
- `scripts/unittest_check_gpu.sh`

主要调整如下：

#### 1. 固定 GPU CI 的工作目录

在 `scripts/unittest_check_gpu.sh` 开头补齐：

- `cd /workspace/$1/PaConvert/`
- `echo "Current working directory: $(pwd)"`
- `requirements.txt` / `tests` 存在性检查

目标是让 GPU CI 和 CPU CI 一样，始终从 repo root 执行，避免路径漂移影响：

- `requirements.txt` 安装
- `pytest ./tests`
- `tests/apibase.py` 中基于 `os.getcwd()` 的临时文件路径

#### 2. 固定 pytest 的收集和导入路径

在 `pytest.ini` 中新增：

- `testpaths = tests`
- `pythonpath = tests`

目标是让以下行为更稳定一致：

- `pytest tests/`
- `pytest 某个单文件.py`
- `python -m pytest`

同时稳定诸如 `from apibase import APIBase` 这类测试工具模块导入。

#### 3. 把 rerun 从“放行机制”改成“诊断信息”

在 `scripts/unittest_check.sh` 和 `scripts/unittest_check_gpu.sh` 中统一调整为：

- 首轮 pytest 的退出码决定 job 成败
- 失败后仍可执行诊断性 `--lf` rerun
- rerun 结果不再覆盖首轮失败
- GPU 侧移除 `pytest-rerunfailures` 和 `--reruns=3`

这样做的目的不是让 CI 更容易绿，而是让 CI 说真话，避免把 flaky 问题洗成“稳定通过”。

#### 4. 隔离会修改全局状态的测试文件

在 CPU/GPU 两个 unittest 脚本中，都把以下 5 个 stateful 文件从主套件中排除，并在主套件之外按文件单独执行：

- `tests/test_set_default_device.py`
- `tests/test_set_default_dtype.py`
- `tests/test_set_default_tensor_type.py`
- `tests/test_set_num_threads.py`
- `tests/test_set_printoptions.py`

原因是这些测试会修改进程级默认状态，不适合和普通测试混在同一个 pytest 进程里跑。

当前执行策略是：

- 主套件先跑，并 `--ignore` 上述 5 个文件
- 然后这 5 个文件逐个单独起 pytest 进程执行
- 主套件和隔离套件统一汇总退出码

### 预期收益

- GPU CI 不再依赖外部入口目录，路径行为更稳定
- pytest 全量/单文件执行的收集与导入语义更一致
- first-run 失败不会再被 rerun 掩盖
- 会修改全局状态的测试文件与普通测试解耦，降低互相污染概率
- 后续如果仍有 flaky，日志会更容易定位到真实失败点

### 兼容性与影响

这次改动主要是 CI 行为收敛和稳定性优化，可能带来这些影响：

- CI 可能会比以前更容易显式失败
- 原因是以前有一部分失败会被 rerun 掩盖，现在不再掩盖
- CI 总时长可能会略有增加
- 原因是 5 个 stateful 文件会在主套件之外单独跑
- 这次改动优先解决“CI 反馈真实性”和“执行稳定性”，不等同于已经完全修复底层根因

### 验证

已完成以下直接相关验证：

- `bash -n scripts/unittest_check.sh`
- `bash -n scripts/unittest_check_gpu.sh`
- 检查 `pytest.ini` 中 `testpaths = tests` 与 `pythonpath = tests` 已生效
- 检查 CPU/GPU 脚本中：
  - GPU cwd 日志已加入
  - `test_set_default_tensor_type.py` 已纳入隔离列表
  - rerun 已改为诊断用途
  - GPU 已移除 `--reruns=3`

当前这条 PR 分支相对 `origin/master` 仅包含这 3 个文件变更，没有混入其他无关改动。

### 后续关注

如果这版合入后仍能复现 “first-run fail / rerun pass”，下一步更值得继续排查的方向是：

- `tests/apibase.py` 中动态执行与临时文件路径逻辑
- 是否还有其他未识别出的 stateful 测试文件
- 是否需要进一步做 per-case 临时目录或更强的执行隔离