### PR TITLE
Fix same-process default-device leak in test_set_default_device CUDA cases

### DIFF
--- a/tests/test_set_default_device.py
+++ b/tests/test_set_default_device.py
@@ -46,6 +46,9 @@ def test_case_2():
         import torch
         torch.set_default_device("cuda")
         result = torch.get_default_device()
+
+        # if not set None, will cause test_vander error
+        torch.set_default_device(None)
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -89,6 +92,9 @@ def test_case_5():
         import torch
         torch.set_default_device(device=torch.device("cuda"))
         result = torch.get_default_device()
+
+        # if not set None, will cause test_vander error
+        torch.set_default_device(None)
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -120,6 +126,9 @@ def test_case_7():
         device = torch.device("cuda")
         torch.set_default_device(device)
         result = torch.get_default_device()
+
+        # if not set None, will cause test_vander error
+        torch.set_default_device(None)
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -151,6 +160,9 @@ def test_case_9():
         device = "cuda:0"
         torch.set_default_device(device=device)
         result = torch.get_default_device()
+
+        # if not set None, will cause test_vander error
+        torch.set_default_device(None)
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -182,6 +194,9 @@ def test_case_11():
         cond = True
         torch.set_default_device(device='cuda' if cond else 'cpu')
         result = torch.get_default_device()
+
+        # if not set None, will cause test_vander error
+        torch.set_default_device(None)
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -198,6 +213,9 @@ def test_case_12():
         cond = True
         torch.set_default_device(device='cuda:0' if cond else 'cuda:1')
         result = torch.get_default_device()
+
+        # if not set None, will cause test_vander error
+        torch.set_default_device(None)
         """
     )
     obj.run(pytorch_code, ["result"])
@@ -250,6 +268,9 @@ def test_case_15():
         import torch
         torch.set_default_device(0)
         result = torch.get_default_device()
+
+        # if not set None, will cause test_vander error
+        torch.set_default_device(None)
         """
     )
     obj.run(pytorch_code, ["result"])


### PR DESCRIPTION
## What changed

This PR adds missing `torch.set_default_device(None)` cleanup to the remaining legal CUDA cases in `tests/test_set_default_device.py`:
- `test_case_2`
- `test_case_5`
- `test_case_7`
- `test_case_9`
- `test_case_11`
- `test_case_12`
- `test_case_15`

## Why

These cases modify the process-wide default device and could leak that state into later tests running in the same pytest process.
In practice, this could pollute a following `tests/test_vander.py` run and produce a mixed-run failure that disappears on rerun.

## Validation

Validated on a real CUDA runner:
- `tests/test_vander.py` passes by itself
- before this patch, running any of the legal uncleaned CUDA cases above before `tests/test_vander.py` could make `tests/test_vander.py::test_case_1` fail
- after this patch, the same `polluter + victim` sequences pass cleanly

This PR only addresses that confirmed same-process default-device leak in `test_set_default_device.py`.
