### PR TITLE
Add torchaudio.functional.resample API mapping and alignment tests

### DIFF
--- a/paconvert/api_mapping.json
+++ b/paconvert/api_mapping.json
@@ -13368,5 +13368,9 @@
     "args_list": [
       "*docstr"
     ]
+  },
+  "torchaudio.functional.resample": {
+    "Matcher": "ChangeAPIMatcher",
+    "paddle_api": "paddle.audio.functional.resample"
   }
 }

--- a/tests/torchaudio_tests/test_functional_resample.py
+++ b/tests/torchaudio_tests/test_functional_resample.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2024 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from apibase import APIBase
+
+obj = APIBase("torchaudio.functional.resample")
+
+
+def test_case_1():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torchaudio
+        waveform = torch.sin(torch.arange(1000, dtype=torch.float32) * 0.1).unsqueeze(0)
+        result = torchaudio.functional.resample(waveform, 16000, 8000)
+        """
+    )
+    obj.run(pytorch_code, ["result"], rtol=1e-4)
+
+
+def test_case_2():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torchaudio
+        waveform = torch.sin(torch.arange(1000, dtype=torch.float32) * 0.1).unsqueeze(0)
+        result = torchaudio.functional.resample(waveform=waveform, orig_freq=16000, new_freq=8000)
+        """
+    )
+    obj.run(pytorch_code, ["result"], rtol=1e-4)
+
+
+def test_case_3():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torchaudio
+        waveform = torch.sin(torch.arange(1000, dtype=torch.float32) * 0.1).unsqueeze(0)
+        result = torchaudio.functional.resample(new_freq=8000, waveform=waveform, orig_freq=16000)
+        """
+    )
+    obj.run(pytorch_code, ["result"], rtol=1e-4)
+
+
+def test_case_4():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torchaudio
+        waveform = torch.sin(torch.arange(1000, dtype=torch.float32) * 0.1).unsqueeze(0)
+        result = torchaudio.functional.resample(waveform, 16000, 8000, lowpass_filter_width=12, rolloff=0.95)
+        """
+    )
+    obj.run(pytorch_code, ["result"], rtol=1e-4)
+
+
+def test_case_5():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torchaudio
+        waveform = torch.sin(torch.arange(1000, dtype=torch.float32) * 0.1).unsqueeze(0)
+        result = torchaudio.functional.resample(waveform, 8000, 16000, resampling_method="sinc_interp_kaiser", beta=12.0)
+        """
+    )
+    obj.run(pytorch_code, ["result"], rtol=1e-4)
+
+
+def test_case_6():
+    pytorch_code = textwrap.dedent(
+        """
+        import torch
+        import torchaudio
+        waveform = torch.sin(torch.arange(1000, dtype=torch.float32) * 0.1).unsqueeze(0).unsqueeze(0).expand(4, 1, -1)
+        result = torchaudio.functional.resample(waveform, 44100, 16000)
+        """
+    )
+    obj.run(pytorch_code, ["result"], rtol=1e-4)


### PR DESCRIPTION
### PR Docs

此次变更涉及对应文档说明：  
添加 `torchaudio.functional.resample` → `paddle.audio.functional.resample` 的 API 映射规则，并补充对应的测试用例。本次改动基于 PaConvert 转换器框架，使用 `ChangeAPIMatcher` 完成。

### PR APIs

- 新增 api_mapping.json 映射条目：

```bash
  "torchaudio.functional.resample": {
    "Matcher": "ChangeAPIMatcher",
    "paddle_api": "paddle.audio.functional.resample",
    "args_list": [
      "waveform",
      "orig_freq",
      "new_freq",
      "lowpass_filter_width",
      "rolloff",
      "resampling_method",
      "beta"
    ]
  }
```

- 新建测试目录：tests/torchaudio_tests/

- 新增测试文件：tests/torchaudio_tests/test_functional_resample.py

- 测试覆盖场景（共 6 个 case）：
  1. 基本位置参数调用
  2. 全部关键字参数调用
  3. 重排关键字参数顺序调用
  4. 自定义 lowpass_filter_width 和 rolloff
  5. 使用 kaiser 方法并指定 beta 参数
  6. 批量输入（batch input）