### PR TITLE
ci: route GPU jobs to gpu runner, CPU jobs to cpu runner via labels

### DIFF
--- a/.github/workflows/Modeltest_check.yml
+++ b/.github/workflows/Modeltest_check.yml
@@ -35,6 +35,7 @@ jobs:
         name: Modeltest Check
         runs-on:
             group: PaConvert
+            labels: [cpu]
         timeout-minutes: 120
         env:
             TORCH_PROJECT_PATH: /workspace/torch_project

--- a/.github/workflows/Unittest_check.yml
+++ b/.github/workflows/Unittest_check.yml
@@ -34,6 +34,7 @@ jobs:
         name: CI Unittest
         runs-on:
             group: PaConvert
+            labels: [cpu]
         timeout-minutes: 60
 
         steps:

--- a/.github/workflows/Unittest_check_distribute.yml
+++ b/.github/workflows/Unittest_check_distribute.yml
@@ -34,6 +34,7 @@ jobs:
         name: Distributed Unittest Check
         runs-on:
             group: PaConvert
+            labels: [gpu]
         timeout-minutes: 120
 
         steps:

--- a/.github/workflows/Unittest_check_gpu.yml
+++ b/.github/workflows/Unittest_check_gpu.yml
@@ -34,6 +34,7 @@ jobs:
         name: GPU Unittest Check
         runs-on:
             group: PaConvert
+            labels: [gpu]
         timeout-minutes: 120
 
         steps:


### PR DESCRIPTION
### PR Docs
two workflows can run in parallel

### PR APIs
```bash
\
```
